### PR TITLE
Add per-application profile limits, auto-create, and session attachment (#11)

### DIFF
--- a/jetty-ws-test/src/main/java/dev/getelements/elements/rest/test/EmbeddedRestApiIntegrationTestModule.java
+++ b/jetty-ws-test/src/main/java/dev/getelements/elements/rest/test/EmbeddedRestApiIntegrationTestModule.java
@@ -55,6 +55,11 @@ public class EmbeddedRestApiIntegrationTestModule extends AbstractModule {
             final var application = new Application();
             application.setName("CXTTAPP");
             application.setDescription("Context Test Application");
+            // This is a shared fixture reused across the whole test suite, including tests that
+            // intentionally create multiple profiles for the same user (e.g. header-convention
+            // matrices). Give it a generous limit so it doesn't inherit the production-safety
+            // default of 1.
+            application.setMaxProfiles(1000);
             final var applicationDao = applicationDaoProvider.get();
             return applicationDao.createOrUpdateInactiveApplication(application);
         }).asEagerSingleton();

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoProfileDao.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoProfileDao.java
@@ -7,10 +7,13 @@ import dev.getelements.elements.dao.mongo.model.MongoProfile;
 import dev.getelements.elements.dao.mongo.model.MongoUser;
 import dev.getelements.elements.dao.mongo.model.application.MongoApplication;
 import dev.getelements.elements.dao.mongo.model.largeobject.MongoLargeObject;
+import dev.getelements.elements.dao.mongo.model.profile.MongoProfileSlot;
+import dev.getelements.elements.dao.mongo.model.profile.MongoProfileSlotId;
 import dev.getelements.elements.dao.mongo.query.BooleanQueryParser;
 import dev.getelements.elements.sdk.model.exception.BadQueryException;
 import dev.getelements.elements.sdk.model.exception.InvalidDataException;
 import dev.getelements.elements.sdk.model.exception.NotFoundException;
+import dev.getelements.elements.sdk.model.exception.profile.ProfileLimitExceededException;
 import dev.getelements.elements.sdk.model.exception.profile.ProfileNotFoundException;
 import dev.getelements.elements.sdk.model.Pagination;
 import dev.getelements.elements.sdk.model.ValidationGroups.Insert;
@@ -110,6 +113,30 @@ public class MongoProfileDao implements ProfileDao {
 
         final MongoProfile mongoProfile = query.first();
         return mongoProfile == null ? Optional.empty() : Optional.of(transform(mongoProfile));
+
+    }
+
+    @Override
+    public Optional<Profile> findPrimaryProfile(final String userId, final String applicationNameOrId) {
+
+        if (userId == null || !ObjectId.isValid(userId)) return Optional.empty();
+
+        final var mongoApplication = getMongoApplicationDao()
+                .findMongoApplicationOptional(applicationNameOrId)
+                .orElse(null);
+
+        if (mongoApplication == null) return Optional.empty();
+
+        final var slotId = new MongoProfileSlotId(new ObjectId(userId), mongoApplication.getObjectId(), 0);
+
+        final var mongoProfileSlot = getDatastore()
+                .find(MongoProfileSlot.class)
+                .filter(eq("_id", slotId))
+                .first();
+
+        if (mongoProfileSlot == null) return Optional.empty();
+
+        return findActiveMongoProfile(mongoProfileSlot.getProfileId()).map(this::transform);
 
     }
 
@@ -449,6 +476,56 @@ public class MongoProfileDao implements ProfileDao {
                 setOnInsert(insertMap)
             ).execute(query, new ModifyOptions().upsert(true).returnDocument(AFTER))
         );
+
+        return transform(mongoProfile);
+
+    }
+
+    @Override
+    public Profile createSlottedProfile(final Profile profile, final Map<String, Object> metadata) {
+
+        getValidationHelper().validateModel(profile, Insert.class);
+
+        final var user = getMongoUserFromProfile(profile);
+        final var application = getMongoApplicationFromProfile(profile);
+        final var imageObject = getMongoLargeObjectFromProfile(profile);
+
+        final var slotCountQuery = getDatastore().find(MongoProfileSlot.class);
+
+        slotCountQuery.filter(and(
+                eq("_id.userId", user.getObjectId()),
+                eq("_id.applicationId", application.getObjectId())
+        ));
+
+        final var nextSlot = slotCountQuery.count();
+
+        // Mirrors the null-coalesced default applied by MongoApplicationDao#transform for legacy applications
+        // that predate this field.
+        final var maxProfiles = application.getMaxProfiles() == null ? 1 : application.getMaxProfiles();
+
+        if (nextSlot >= maxProfiles) {
+            throw new ProfileLimitExceededException(
+                    "User " + user.getObjectId() + " already has the maximum number of profiles (" +
+                    maxProfiles + ") for application " + application.getObjectId());
+        }
+
+        final var mongoProfile = new MongoProfile();
+        mongoProfile.setActive(true);
+        mongoProfile.setUser(user);
+        mongoProfile.setApplication(application);
+        mongoProfile.setImageUrl(nullToEmpty(profile.getImageUrl()).trim());
+        mongoProfile.setDisplayName(nullToEmpty(profile.getDisplayName()).trim());
+        mongoProfile.setImageObject(imageObject);
+        mongoProfile.setMetadata(metadata);
+
+        getDatastore().insert(mongoProfile);
+
+        final var slotId = new MongoProfileSlotId(user.getObjectId(), application.getObjectId(), (int) nextSlot);
+        final var mongoProfileSlot = new MongoProfileSlot();
+        mongoProfileSlot.setObjectId(slotId);
+        mongoProfileSlot.setProfileId(mongoProfile.getObjectId());
+
+        getDatastore().insert(mongoProfileSlot);
 
         return transform(mongoProfile);
 

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/application/MongoApplicationDao.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/application/MongoApplicationDao.java
@@ -39,6 +39,8 @@ public class MongoApplicationDao implements ApplicationDao {
 
     private static final boolean DEFAULT_AUTO_CREATE_PROFILE = true;
 
+    private static final boolean DEFAULT_AUTHORITATIVE_PROFILE_PICTURE = false;
+
     private ValidationHelper validationHelper;
 
     private MongoDBUtils mongoDBUtils;
@@ -61,6 +63,10 @@ public class MongoApplicationDao implements ApplicationDao {
         mongoApplication.setAutoCreateProfile(application.getAutoCreateProfile() == null
                 ? DEFAULT_AUTO_CREATE_PROFILE
                 : application.getAutoCreateProfile());
+
+        mongoApplication.setAuthoritativeProfilePicture(application.getAuthoritativeProfilePicture() == null
+                ? DEFAULT_AUTHORITATIVE_PROFILE_PICTURE
+                : application.getAuthoritativeProfilePicture());
 
         getDatastore().insert(mongoApplication);
 
@@ -162,7 +168,11 @@ public class MongoApplicationDao implements ApplicationDao {
                         : application.getMaxProfiles()),
                 set("autoCreateProfile", application.getAutoCreateProfile() == null
                         ? DEFAULT_AUTO_CREATE_PROFILE
-                        : application.getAutoCreateProfile())
+                        : application.getAutoCreateProfile()),
+                set("authoritativeProfilePicture", application.getAuthoritativeProfilePicture() == null
+                        ? DEFAULT_AUTHORITATIVE_PROFILE_PICTURE
+                        : application.getAuthoritativeProfilePicture()),
+                set("displayNameRegex", nullToEmpty(application.getDisplayNameRegex()).trim())
         ).execute(query, new ModifyOptions().upsert(false).returnDocument(AFTER)));
 
         if (mongoApplication == null) {
@@ -254,6 +264,10 @@ public class MongoApplicationDao implements ApplicationDao {
         application.setAutoCreateProfile(mongoApplication.getAutoCreateProfile() == null
                 ? DEFAULT_AUTO_CREATE_PROFILE
                 : mongoApplication.getAutoCreateProfile());
+
+        application.setAuthoritativeProfilePicture(mongoApplication.getAuthoritativeProfilePicture() == null
+                ? DEFAULT_AUTHORITATIVE_PROFILE_PICTURE
+                : mongoApplication.getAuthoritativeProfilePicture());
 
         return application;
 

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/application/MongoApplicationDao.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/application/MongoApplicationDao.java
@@ -35,6 +35,10 @@ import static java.util.Collections.emptyMap;
  */
 public class MongoApplicationDao implements ApplicationDao {
 
+    private static final int DEFAULT_MAX_PROFILES = 1;
+
+    private static final boolean DEFAULT_AUTO_CREATE_PROFILE = true;
+
     private ValidationHelper validationHelper;
 
     private MongoDBUtils mongoDBUtils;
@@ -49,6 +53,15 @@ public class MongoApplicationDao implements ApplicationDao {
         validate(application, ValidationGroups.Insert.class);
 
         final var mongoApplication = getMapperRegistry().map(application, MongoApplication.class);
+
+        mongoApplication.setMaxProfiles(application.getMaxProfiles() == null
+                ? DEFAULT_MAX_PROFILES
+                : application.getMaxProfiles());
+
+        mongoApplication.setAutoCreateProfile(application.getAutoCreateProfile() == null
+                ? DEFAULT_AUTO_CREATE_PROFILE
+                : application.getAutoCreateProfile());
+
         getDatastore().insert(mongoApplication);
 
         return transform(mongoApplication);
@@ -143,7 +156,13 @@ public class MongoApplicationDao implements ApplicationDao {
         final var mongoApplication = mongoDBUtils.perform(ds -> new UpdateBuilder().with(
                 set("name", application.getName().trim()),
                 set("description", nullToEmpty(application.getDescription()).trim()),
-                set("attributes", application.getAttributes())
+                set("attributes", application.getAttributes()),
+                set("maxProfiles", application.getMaxProfiles() == null
+                        ? DEFAULT_MAX_PROFILES
+                        : application.getMaxProfiles()),
+                set("autoCreateProfile", application.getAutoCreateProfile() == null
+                        ? DEFAULT_AUTO_CREATE_PROFILE
+                        : application.getAutoCreateProfile())
         ).execute(query, new ModifyOptions().upsert(false).returnDocument(AFTER)));
 
         if (mongoApplication == null) {
@@ -225,7 +244,19 @@ public class MongoApplicationDao implements ApplicationDao {
     }
 
     private Application transform(final MongoApplication mongoApplication) {
-        return getMapperRegistry().map(mongoApplication, Application.class);
+
+        final var application = getMapperRegistry().map(mongoApplication, Application.class);
+
+        application.setMaxProfiles(mongoApplication.getMaxProfiles() == null
+                ? DEFAULT_MAX_PROFILES
+                : mongoApplication.getMaxProfiles());
+
+        application.setAutoCreateProfile(mongoApplication.getAutoCreateProfile() == null
+                ? DEFAULT_AUTO_CREATE_PROFILE
+                : mongoApplication.getAutoCreateProfile());
+
+        return application;
+
     }
 
     private void validate(final Application application, final Class<?> group) {

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/application/MongoApplication.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/application/MongoApplication.java
@@ -27,6 +27,12 @@ public class MongoApplication {
     @Property
     private Map<String, Object> attributes;
 
+    @Property
+    private Integer maxProfiles;
+
+    @Property
+    private Boolean autoCreateProfile;
+
     public ObjectId getObjectId() {
         return objectId;
     }
@@ -57,6 +63,22 @@ public class MongoApplication {
 
     public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
+    }
+
+    public Integer getMaxProfiles() {
+        return maxProfiles;
+    }
+
+    public void setMaxProfiles(Integer maxProfiles) {
+        this.maxProfiles = maxProfiles;
+    }
+
+    public Boolean getAutoCreateProfile() {
+        return autoCreateProfile;
+    }
+
+    public void setAutoCreateProfile(Boolean autoCreateProfile) {
+        this.autoCreateProfile = autoCreateProfile;
     }
 
 }

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/application/MongoApplication.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/application/MongoApplication.java
@@ -33,6 +33,12 @@ public class MongoApplication {
     @Property
     private Boolean autoCreateProfile;
 
+    @Property
+    private Boolean authoritativeProfilePicture;
+
+    @Property
+    private String displayNameRegex;
+
     public ObjectId getObjectId() {
         return objectId;
     }
@@ -79,6 +85,22 @@ public class MongoApplication {
 
     public void setAutoCreateProfile(Boolean autoCreateProfile) {
         this.autoCreateProfile = autoCreateProfile;
+    }
+
+    public Boolean getAuthoritativeProfilePicture() {
+        return authoritativeProfilePicture;
+    }
+
+    public void setAuthoritativeProfilePicture(Boolean authoritativeProfilePicture) {
+        this.authoritativeProfilePicture = authoritativeProfilePicture;
+    }
+
+    public String getDisplayNameRegex() {
+        return displayNameRegex;
+    }
+
+    public void setDisplayNameRegex(String displayNameRegex) {
+        this.displayNameRegex = displayNameRegex;
     }
 
 }

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/profile/MongoProfileSlot.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/profile/MongoProfileSlot.java
@@ -1,0 +1,52 @@
+package dev.getelements.elements.dao.mongo.model.profile;
+
+import dev.morphia.annotations.*;
+import org.bson.types.ObjectId;
+
+/**
+ * Records that a slot has been allocated for a given user and application. Slot {@code 0} is defined as the
+ * user's primary profile for that application. This document is never exposed via the SDK model -- it exists
+ * purely to make slot assignment and the {@code maxProfiles} check race-safe under concurrent profile creation.
+ */
+@Indexes({
+        @Index(fields = { @Field("_id.userId"), @Field("_id.applicationId") })
+})
+@Entity(value = "profile_slot", useDiscriminator = false)
+public class MongoProfileSlot {
+
+    @Id
+    private MongoProfileSlotId objectId;
+
+    @Property
+    private ObjectId profileId;
+
+    public MongoProfileSlotId getObjectId() {
+        return objectId;
+    }
+
+    public void setObjectId(MongoProfileSlotId objectId) {
+        this.objectId = objectId;
+    }
+
+    public ObjectId getProfileId() {
+        return profileId;
+    }
+
+    public void setProfileId(ObjectId profileId) {
+        this.profileId = profileId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MongoProfileSlot)) return false;
+        MongoProfileSlot that = (MongoProfileSlot) o;
+        return getObjectId() != null ? getObjectId().equals(that.getObjectId()) : that.getObjectId() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return getObjectId() != null ? getObjectId().hashCode() : 0;
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/profile/MongoProfileSlotId.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/profile/MongoProfileSlotId.java
@@ -1,0 +1,118 @@
+package dev.getelements.elements.dao.mongo.model.profile;
+
+import dev.getelements.elements.dao.mongo.HexableId;
+import dev.getelements.elements.rt.util.Hex;
+import dev.morphia.annotations.Embedded;
+import dev.morphia.annotations.Property;
+import org.bson.types.ObjectId;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * A compound ID for a {@link MongoProfileSlot}, encoding the owning user, the application, and the 0-based slot
+ * number in fixed positions. Unlike {@link dev.getelements.elements.dao.mongo.model.MongoFriendshipId}, this is
+ * <strong>not</strong> order-independent -- user, application, and slot each occupy a fixed, distinct position, so
+ * there is no symmetry to normalize away.
+ */
+@Embedded
+public class MongoProfileSlotId implements HexableId {
+
+    public static int SIZE = new ObjectId().toByteArray().length * 2 + Integer.BYTES;
+
+    @Property
+    private ObjectId userId;
+
+    @Property
+    private ObjectId applicationId;
+
+    @Property
+    private int slot;
+
+    public MongoProfileSlotId() {}
+
+    public MongoProfileSlotId(final String hex) {
+        this(Hex.decode(hex));
+    }
+
+    public MongoProfileSlotId(final byte[] bytes) {
+        this(ByteBuffer.wrap(bytes));
+    }
+
+    public MongoProfileSlotId(final ByteBuffer byteBuffer) {
+        try {
+            userId = new ObjectId(byteBuffer);
+            applicationId = new ObjectId(byteBuffer);
+            slot = byteBuffer.getInt();
+        } catch (BufferUnderflowException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
+
+    public MongoProfileSlotId(final ObjectId userId, final ObjectId applicationId, final int slot) {
+        this.userId = userId;
+        this.applicationId = applicationId;
+        this.slot = slot;
+    }
+
+    public ObjectId getUserId() {
+        return userId;
+    }
+
+    public void setUserId(ObjectId userId) {
+        this.userId = userId;
+    }
+
+    public ObjectId getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(ObjectId applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public int getSlot() {
+        return slot;
+    }
+
+    public void setSlot(int slot) {
+        this.slot = slot;
+    }
+
+    @Override
+    public String toHexString() {
+        final var buffer = ByteBuffer.allocate(SIZE);
+        userId.putToByteBuffer(buffer);
+        applicationId.putToByteBuffer(buffer);
+        buffer.putInt(slot);
+        return Hex.encode(buffer.flip());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MongoProfileSlotId that = (MongoProfileSlotId) o;
+        return getSlot() == that.getSlot()
+                && Objects.equals(getUserId(), that.getUserId())
+                && Objects.equals(getApplicationId(), that.getApplicationId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUserId(), getApplicationId(), getSlot());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("MongoProfileSlotId{");
+        sb.append("userId=").append(userId);
+        sb.append(", applicationId=").append(applicationId);
+        sb.append(", slot=").append(slot);
+        sb.append(", (").append(toHexString()).append(")");
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MongoProfileSlotDaoTest.java
+++ b/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MongoProfileSlotDaoTest.java
@@ -1,0 +1,229 @@
+package dev.getelements.elements.dao.mongo.test;
+
+import dev.getelements.elements.sdk.dao.ApplicationDao;
+import dev.getelements.elements.sdk.dao.ProfileDao;
+import dev.getelements.elements.sdk.dao.Transaction;
+import dev.getelements.elements.sdk.model.application.Application;
+import dev.getelements.elements.sdk.model.exception.profile.ProfileLimitExceededException;
+import dev.getelements.elements.sdk.model.exception.profile.ProfileNotFoundException;
+import dev.getelements.elements.sdk.model.profile.Profile;
+import dev.getelements.elements.sdk.model.user.User;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+@Guice(modules = IntegrationTestModule.class)
+public class MongoProfileSlotDaoTest {
+
+    private static final int MAX_PROFILES = 2;
+
+    private ApplicationDao applicationDao;
+
+    private ProfileDao profileDao;
+
+    private UserTestFactory userTestFactory;
+
+    private ApplicationTestFactory applicationTestFactory;
+
+    private Provider<Transaction> transactionProvider;
+
+    private Application limitedApplication;
+
+    private User user;
+
+    @BeforeClass
+    public void setup() {
+
+        final var application = getApplicationTestFactory()
+                .createAtomicApplication("Application for MongoProfileSlotDaoTest");
+        application.setMaxProfiles(MAX_PROFILES);
+        application.setAutoCreateProfile(true);
+
+        limitedApplication = getApplicationDao().createApplication(application);
+        user = getUserTestFactory().createTestUser();
+
+    }
+
+    @Test
+    public void testCreateSlottedProfileAssignsSlotsUpToLimit() {
+
+        final var first = getProfileDao().createSlottedProfile(newProfile(user, limitedApplication, "Primary"), null);
+        assertNotNull(first.getId());
+
+        final var primary = getProfileDao().getPrimaryProfile(user.getId(), limitedApplication.getId());
+        assertEquals(primary.getId(), first.getId());
+
+        final var second = getProfileDao().createSlottedProfile(newProfile(user, limitedApplication, "Secondary"), null);
+        assertNotNull(second.getId());
+        assertNotEquals(second.getId(), first.getId());
+
+        // The primary profile (slot 0) is unaffected by additional slots being assigned.
+        final var primaryAgain = getProfileDao().getPrimaryProfile(user.getId(), limitedApplication.getId());
+        assertEquals(primaryAgain.getId(), first.getId());
+
+    }
+
+    @Test(dependsOnMethods = "testCreateSlottedProfileAssignsSlotsUpToLimit")
+    public void testCreateSlottedProfileOverLimitThrows() {
+        expectThrows(ProfileLimitExceededException.class,
+                () -> getProfileDao().createSlottedProfile(newProfile(user, limitedApplication, "Overflow"), null));
+    }
+
+    @Test(dependsOnMethods = "testCreateSlottedProfileOverLimitThrows")
+    public void testLoweringMaxProfilesDoesNotAffectExistingProfiles() {
+
+        limitedApplication.setMaxProfiles(1);
+        getApplicationDao().updateApplication(limitedApplication);
+
+        // Existing profiles created before the limit was lowered are left alone -- both remain findable.
+        final var primary = getProfileDao().getPrimaryProfile(user.getId(), limitedApplication.getId());
+        assertNotNull(primary.getId());
+
+        // Restore the limit so later tests in this class see the originally configured value.
+        limitedApplication.setMaxProfiles(MAX_PROFILES);
+        getApplicationDao().updateApplication(limitedApplication);
+
+    }
+
+    @Test
+    public void testFindPrimaryProfileEmptyWhenNoneExists() {
+
+        final var otherUser = getUserTestFactory().createTestUser();
+
+        final var found = getProfileDao().findPrimaryProfile(otherUser.getId(), limitedApplication.getId());
+        assertFalse(found.isPresent());
+
+        expectThrows(ProfileNotFoundException.class,
+                () -> getProfileDao().getPrimaryProfile(otherUser.getId(), limitedApplication.getId()));
+
+    }
+
+    @Test
+    public void testConcurrentCreateSlottedProfileRespectsLimit() throws InterruptedException {
+
+        final var application = getApplicationTestFactory()
+                .createAtomicApplication("Concurrent application for MongoProfileSlotDaoTest");
+        application.setMaxProfiles(MAX_PROFILES);
+        application.setAutoCreateProfile(true);
+
+        final var concurrentApplication = getApplicationDao().createApplication(application);
+        final var concurrentUser = getUserTestFactory().createTestUser();
+
+        final var attempts = MAX_PROFILES * 4;
+        final var succeeded = new CopyOnWriteArrayList<Profile>();
+        final var rejected = new CopyOnWriteArrayList<ProfileLimitExceededException>();
+
+        final ExecutorService executorService = Executors.newFixedThreadPool(attempts);
+
+        try {
+
+            final var futures = IntStream.range(0, attempts)
+                    .mapToObj(i -> executorService.submit(() -> {
+                        try {
+                            final var profile = getTransactionProvider().get().performAndClose(tx ->
+                                    tx.getDao(ProfileDao.class).createSlottedProfile(
+                                            newProfile(concurrentUser, concurrentApplication, "Slot-" + i),
+                                            null));
+                            succeeded.add(profile);
+                        } catch (ProfileLimitExceededException ex) {
+                            rejected.add(ex);
+                        }
+                    }))
+                    .toList();
+
+            for (final var future : futures) {
+                try {
+                    future.get();
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+
+        } finally {
+            executorService.shutdown();
+            executorService.awaitTermination(30, TimeUnit.SECONDS);
+        }
+
+        assertEquals(succeeded.size(), MAX_PROFILES);
+        assertEquals(rejected.size(), attempts - MAX_PROFILES);
+
+        final List<String> distinctProfileIds = succeeded.stream().map(Profile::getId).distinct().toList();
+        assertEquals(distinctProfileIds.size(), MAX_PROFILES);
+
+        assertTrue(getProfileDao()
+                .findPrimaryProfile(concurrentUser.getId(), concurrentApplication.getId())
+                .isPresent());
+
+    }
+
+    private Profile newProfile(final User user, final Application application, final String displayName) {
+        final var profile = new Profile();
+        profile.setUser(user);
+        profile.setApplication(application);
+        profile.setDisplayName(displayName);
+        return profile;
+    }
+
+    public ApplicationDao getApplicationDao() {
+        return applicationDao;
+    }
+
+    @Inject
+    public void setApplicationDao(ApplicationDao applicationDao) {
+        this.applicationDao = applicationDao;
+    }
+
+    public ProfileDao getProfileDao() {
+        return profileDao;
+    }
+
+    @Inject
+    public void setProfileDao(ProfileDao profileDao) {
+        this.profileDao = profileDao;
+    }
+
+    public UserTestFactory getUserTestFactory() {
+        return userTestFactory;
+    }
+
+    @Inject
+    public void setUserTestFactory(UserTestFactory userTestFactory) {
+        this.userTestFactory = userTestFactory;
+    }
+
+    public ApplicationTestFactory getApplicationTestFactory() {
+        return applicationTestFactory;
+    }
+
+    @Inject
+    public void setApplicationTestFactory(ApplicationTestFactory applicationTestFactory) {
+        this.applicationTestFactory = applicationTestFactory;
+    }
+
+    public Provider<Transaction> getTransactionProvider() {
+        return transactionProvider;
+    }
+
+    @Inject
+    public void setTransactionProvider(Provider<Transaction> transactionProvider) {
+        this.transactionProvider = transactionProvider;
+    }
+
+}

--- a/sdk-dao/src/main/java/dev/getelements/elements/sdk/dao/ProfileDao.java
+++ b/sdk-dao/src/main/java/dev/getelements/elements/sdk/dao/ProfileDao.java
@@ -4,6 +4,8 @@ import dev.getelements.elements.sdk.model.exception.DuplicateException;
 import dev.getelements.elements.sdk.model.exception.NotFoundException;
 import dev.getelements.elements.sdk.model.Pagination;
 import dev.getelements.elements.sdk.model.application.Application;
+import dev.getelements.elements.sdk.model.exception.profile.ProfileLimitExceededException;
+import dev.getelements.elements.sdk.model.exception.profile.ProfileNotFoundException;
 import dev.getelements.elements.sdk.model.profile.Profile;
 import dev.getelements.elements.sdk.model.user.User;
 import dev.getelements.elements.sdk.annotation.ElementServiceExport;
@@ -117,7 +119,13 @@ public interface ProfileDao {
      * and updates will be keyed using the {@link User} and {@link Application}.
      *
      * @return the {@link Profile} as it was written into the database
+     *
+     * @deprecated This creates/reactivates a profile without assigning a profile slot or enforcing
+     * {@link Application#getMaxProfiles()}. It is retained only for reactivating a previously soft-deleted profile,
+     * where slot/limit accounting must not be re-run. New code creating a profile should use
+     * {@link #createSlottedProfile(Profile, Map)} instead.
      */
+    @Deprecated
     default Profile createOrReactivateProfile(Profile profile) {
         return createOrReactivateProfile(profile, profile.getMetadata());
     }
@@ -130,7 +138,13 @@ public interface ProfileDao {
      *
      * @param metadata the profile metadata
      * @return the {@link Profile} as it was written into the database
+     *
+     * @deprecated This creates/reactivates a profile without assigning a profile slot or enforcing
+     * {@link Application#getMaxProfiles()}. It is retained only for reactivating a previously soft-deleted profile,
+     * where slot/limit accounting must not be re-run. New code creating a profile should use
+     * {@link #createSlottedProfile(Profile, Map)} instead.
      */
+    @Deprecated
     Profile createOrReactivateProfile(Profile profile, Map<String, Object> metadata);
 
     /**
@@ -143,8 +157,49 @@ public interface ProfileDao {
      *
      * @param profile the user
      * @return the {@link Profile}, as written to the database
+     *
+     * @deprecated This upserts a profile without assigning a profile slot or enforcing
+     * {@link Application#getMaxProfiles()}. It is retained for the OIDC login get-or-create path, where slot/limit
+     * accounting is deliberately not applied. New code should prefer {@link #findPrimaryProfile(String, String)}
+     * together with {@link #createSlottedProfile(Profile, Map)}.
      */
+    @Deprecated
     Profile createOrRefreshProfile(final Profile profile);
+
+    /**
+     * Finds the user's primary (slot {@code 0}) profile for the given application, if one exists.
+     *
+     * @param userId the user ID
+     * @param applicationNameOrId the application name or ID
+     * @return an {@link Optional} containing the primary {@link Profile}, or empty if none exists
+     */
+    Optional<Profile> findPrimaryProfile(String userId, String applicationNameOrId);
+
+    /**
+     * Gets the user's primary (slot {@code 0}) profile for the given application, or throws a
+     * {@link ProfileNotFoundException} if none exists.
+     *
+     * @param userId the user ID
+     * @param applicationNameOrId the application name or ID
+     * @return the primary {@link Profile}, never null
+     */
+    default Profile getPrimaryProfile(String userId, String applicationNameOrId) {
+        return findPrimaryProfile(userId, applicationNameOrId)
+                .orElseThrow(() -> new ProfileNotFoundException(
+                        "No primary profile for user " + userId + " and application " + applicationNameOrId));
+    }
+
+    /**
+     * Creates a new profile, atomically assigning it the next available profile slot for the profile's
+     * {@link User} and {@link Application}. Slot {@code 0} is the primary profile. Throws
+     * {@link ProfileLimitExceededException} if the user already has {@link Application#getMaxProfiles()} profiles
+     * for that application.
+     *
+     * @param profile the profile to create
+     * @param metadata the profile metadata
+     * @return the {@link Profile} as it was written into the database
+     */
+    Profile createSlottedProfile(Profile profile, Map<String, Object> metadata);
 
     /**
      * Deletes a profile by marking it as inactive.  Data is otherwise retained in the database.

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/application/Application.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/application/Application.java
@@ -4,6 +4,7 @@ import dev.getelements.elements.sdk.model.Constants;
 import dev.getelements.elements.sdk.model.ValidationGroups.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Pattern;
@@ -55,6 +56,15 @@ public class Application implements Serializable {
 
     @Null(groups = {Create.class})
     private ApplicationConfiguration applicationConfiguration;
+
+    @Min(0)
+    @Schema(description = "The maximum number of profiles a user may create for this application. " +
+            "If unspecified, defaults to 1.")
+    private Integer maxProfiles;
+
+    @Schema(description = "Whether a user's primary profile for this application should be created " +
+            "automatically when the user is created. If unspecified, defaults to true.")
+    private Boolean autoCreateProfile;
 
     /**
      * The globally-unique identifier.
@@ -218,17 +228,56 @@ public class Application implements Serializable {
         this.applicationConfiguration = applicationConfiguration;
     }
 
+    /**
+     * Gets the maximum number of profiles a user may create for this application. If null (unspecified), the
+     * server treats this as {@code 1}.
+     *
+     * @return the maximum number of profiles per user, or null if unspecified
+     */
+    public Integer getMaxProfiles() {
+        return maxProfiles;
+    }
+
+    /**
+     * Sets the maximum number of profiles a user may create for this application.
+     *
+     * @param maxProfiles the maximum number of profiles per user
+     */
+    public void setMaxProfiles(Integer maxProfiles) {
+        this.maxProfiles = maxProfiles;
+    }
+
+    /**
+     * Gets whether a user's primary profile for this application should be created automatically when the user
+     * is created. If null (unspecified), the server treats this as {@code true}.
+     *
+     * @return whether to automatically create a primary profile, or null if unspecified
+     */
+    public Boolean getAutoCreateProfile() {
+        return autoCreateProfile;
+    }
+
+    /**
+     * Sets whether a user's primary profile for this application should be created automatically when the user
+     * is created.
+     *
+     * @param autoCreateProfile whether to automatically create a primary profile
+     */
+    public void setAutoCreateProfile(Boolean autoCreateProfile) {
+        this.autoCreateProfile = autoCreateProfile;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Application that = (Application) o;
-        return Objects.equals(getId(), that.getId()) && Objects.equals(getName(), that.getName()) && Objects.equals(getDescription(), that.getDescription()) && Objects.equals(getGitBranch(), that.getGitBranch()) && Objects.equals(getScriptRepoUrl(), that.getScriptRepoUrl()) && Objects.equals(getHttpDocumentationUrl(), that.getHttpDocumentationUrl()) && Objects.equals(getHttpDocumentationUiUrl(), that.getHttpDocumentationUiUrl()) && Objects.equals(getHttpTunnelEndpointUrl(), that.getHttpTunnelEndpointUrl()) && Objects.equals(getAttributes(), that.getAttributes()) && Objects.equals(getApplicationConfiguration(), that.getApplicationConfiguration());
+        return Objects.equals(getId(), that.getId()) && Objects.equals(getName(), that.getName()) && Objects.equals(getDescription(), that.getDescription()) && Objects.equals(getGitBranch(), that.getGitBranch()) && Objects.equals(getScriptRepoUrl(), that.getScriptRepoUrl()) && Objects.equals(getHttpDocumentationUrl(), that.getHttpDocumentationUrl()) && Objects.equals(getHttpDocumentationUiUrl(), that.getHttpDocumentationUiUrl()) && Objects.equals(getHttpTunnelEndpointUrl(), that.getHttpTunnelEndpointUrl()) && Objects.equals(getAttributes(), that.getAttributes()) && Objects.equals(getApplicationConfiguration(), that.getApplicationConfiguration()) && Objects.equals(getMaxProfiles(), that.getMaxProfiles()) && Objects.equals(getAutoCreateProfile(), that.getAutoCreateProfile());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getName(), getDescription(), getGitBranch(), getScriptRepoUrl(), getHttpDocumentationUrl(), getHttpDocumentationUiUrl(), getHttpTunnelEndpointUrl(), getAttributes(), getApplicationConfiguration());
+        return Objects.hash(getId(), getName(), getDescription(), getGitBranch(), getScriptRepoUrl(), getHttpDocumentationUrl(), getHttpDocumentationUiUrl(), getHttpTunnelEndpointUrl(), getAttributes(), getApplicationConfiguration(), getMaxProfiles(), getAutoCreateProfile());
     }
 
     /**

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/application/Application.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/application/Application.java
@@ -66,6 +66,16 @@ public class Application implements Serializable {
             "automatically when the user is created. If unspecified, defaults to true.")
     private Boolean autoCreateProfile;
 
+    @Schema(description = "If true, a user cannot edit their own profile picture for this application via the " +
+            "REST API -- it must be set by backend/Element code instead. If false (the default), users may edit " +
+            "their own profile picture via the REST API.")
+    private Boolean authoritativeProfilePicture;
+
+    @Schema(description = "A Java regular expression that a profile's display name must match for this " +
+            "application, or the profile create/update is rejected. If blank or unspecified, no additional " +
+            "check is performed.")
+    private String displayNameRegex;
+
     /**
      * The globally-unique identifier.
      *
@@ -267,17 +277,55 @@ public class Application implements Serializable {
         this.autoCreateProfile = autoCreateProfile;
     }
 
+    /**
+     * Gets whether a user can edit their own profile picture for this application via the REST API. If null
+     * (unspecified), the server treats this as {@code false}.
+     *
+     * @return whether the profile picture is authoritative (backend-only), or null if unspecified
+     */
+    public Boolean getAuthoritativeProfilePicture() {
+        return authoritativeProfilePicture;
+    }
+
+    /**
+     * Sets whether a user can edit their own profile picture for this application via the REST API.
+     *
+     * @param authoritativeProfilePicture whether the profile picture is authoritative (backend-only)
+     */
+    public void setAuthoritativeProfilePicture(Boolean authoritativeProfilePicture) {
+        this.authoritativeProfilePicture = authoritativeProfilePicture;
+    }
+
+    /**
+     * Gets the Java regular expression a profile's display name must match for this application. If null or
+     * blank, no additional check is performed.
+     *
+     * @return the display name regular expression, or null if unspecified
+     */
+    public String getDisplayNameRegex() {
+        return displayNameRegex;
+    }
+
+    /**
+     * Sets the Java regular expression a profile's display name must match for this application.
+     *
+     * @param displayNameRegex the display name regular expression
+     */
+    public void setDisplayNameRegex(String displayNameRegex) {
+        this.displayNameRegex = displayNameRegex;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Application that = (Application) o;
-        return Objects.equals(getId(), that.getId()) && Objects.equals(getName(), that.getName()) && Objects.equals(getDescription(), that.getDescription()) && Objects.equals(getGitBranch(), that.getGitBranch()) && Objects.equals(getScriptRepoUrl(), that.getScriptRepoUrl()) && Objects.equals(getHttpDocumentationUrl(), that.getHttpDocumentationUrl()) && Objects.equals(getHttpDocumentationUiUrl(), that.getHttpDocumentationUiUrl()) && Objects.equals(getHttpTunnelEndpointUrl(), that.getHttpTunnelEndpointUrl()) && Objects.equals(getAttributes(), that.getAttributes()) && Objects.equals(getApplicationConfiguration(), that.getApplicationConfiguration()) && Objects.equals(getMaxProfiles(), that.getMaxProfiles()) && Objects.equals(getAutoCreateProfile(), that.getAutoCreateProfile());
+        return Objects.equals(getId(), that.getId()) && Objects.equals(getName(), that.getName()) && Objects.equals(getDescription(), that.getDescription()) && Objects.equals(getGitBranch(), that.getGitBranch()) && Objects.equals(getScriptRepoUrl(), that.getScriptRepoUrl()) && Objects.equals(getHttpDocumentationUrl(), that.getHttpDocumentationUrl()) && Objects.equals(getHttpDocumentationUiUrl(), that.getHttpDocumentationUiUrl()) && Objects.equals(getHttpTunnelEndpointUrl(), that.getHttpTunnelEndpointUrl()) && Objects.equals(getAttributes(), that.getAttributes()) && Objects.equals(getApplicationConfiguration(), that.getApplicationConfiguration()) && Objects.equals(getMaxProfiles(), that.getMaxProfiles()) && Objects.equals(getAutoCreateProfile(), that.getAutoCreateProfile()) && Objects.equals(getAuthoritativeProfilePicture(), that.getAuthoritativeProfilePicture()) && Objects.equals(getDisplayNameRegex(), that.getDisplayNameRegex());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getName(), getDescription(), getGitBranch(), getScriptRepoUrl(), getHttpDocumentationUrl(), getHttpDocumentationUiUrl(), getHttpTunnelEndpointUrl(), getAttributes(), getApplicationConfiguration(), getMaxProfiles(), getAutoCreateProfile());
+        return Objects.hash(getId(), getName(), getDescription(), getGitBranch(), getScriptRepoUrl(), getHttpDocumentationUrl(), getHttpDocumentationUiUrl(), getHttpTunnelEndpointUrl(), getAttributes(), getApplicationConfiguration(), getMaxProfiles(), getAutoCreateProfile(), getAuthoritativeProfilePicture(), getDisplayNameRegex());
     }
 
     /**

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/exception/profile/ProfileLimitExceededException.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/exception/profile/ProfileLimitExceededException.java
@@ -1,0 +1,51 @@
+package dev.getelements.elements.sdk.model.exception.profile;
+
+import dev.getelements.elements.sdk.model.exception.InvalidDataException;
+
+/**
+ * Thrown when creating a profile would push a user's profile count for an application over the application's
+ * configured {@code maxProfiles}.
+ */
+public class ProfileLimitExceededException extends InvalidDataException {
+
+    /** Creates a new instance. */
+    public ProfileLimitExceededException() {
+    }
+
+    /**
+     * Creates a new instance with the given message.
+     * @param message the detail message
+     */
+    public ProfileLimitExceededException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance with the given message and cause.
+     * @param message the detail message
+     * @param cause the cause
+     */
+    public ProfileLimitExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance with the given cause.
+     * @param cause the cause
+     */
+    public ProfileLimitExceededException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param message the detail message
+     * @param cause the cause
+     * @param enableSuppression whether suppression is enabled
+     * @param writableStackTrace whether the stack trace is writable
+     */
+    public ProfileLimitExceededException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OAuth2SessionRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OAuth2SessionRequest.java
@@ -37,7 +37,7 @@ public class OAuth2SessionRequest {
     @Schema(description = "The name or ID of an application whose primary profile should be attached to the " +
             "session. Only used if profileId and profileSelector are not specified. If the application or the " +
             "user's primary profile for it cannot be resolved, the session is created without a profile.")
-    private String applicationId;
+    private String applicationNameOrId;
 
     /**
      * Returns the request parameters for the token validation request.
@@ -138,17 +138,17 @@ public class OAuth2SessionRequest {
      *
      * @return the application name or ID
      */
-    public String getApplicationId() {
-        return applicationId;
+    public String getApplicationNameOrId() {
+        return applicationNameOrId;
     }
 
     /**
      * Sets the name or ID of the application whose primary profile should be attached to the session.
      *
-     * @param applicationId the application name or ID
+     * @param applicationNameOrId the application name or ID
      */
-    public void setApplicationId(String applicationId) {
-        this.applicationId = applicationId;
+    public void setApplicationNameOrId(String applicationNameOrId) {
+        this.applicationNameOrId = applicationNameOrId;
     }
 
     @Override
@@ -156,12 +156,12 @@ public class OAuth2SessionRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         OAuth2SessionRequest that = (OAuth2SessionRequest) o;
-        return Objects.equals(getRequestParameters(), that.getRequestParameters()) && Objects.equals(getRequestHeaders(), that.getRequestHeaders()) && Objects.equals(getSchemeId(), that.getSchemeId()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector()) && Objects.equals(getApplicationId(), that.getApplicationId());
+        return Objects.equals(getRequestParameters(), that.getRequestParameters()) && Objects.equals(getRequestHeaders(), that.getRequestHeaders()) && Objects.equals(getSchemeId(), that.getSchemeId()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector()) && Objects.equals(getApplicationNameOrId(), that.getApplicationNameOrId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getRequestParameters(), getRequestHeaders(), getSchemeId(), getProfileId(), getProfileSelector(), getApplicationId());
+        return Objects.hash(getRequestParameters(), getRequestHeaders(), getSchemeId(), getProfileId(), getProfileSelector(), getApplicationNameOrId());
     }
 
     @Override
@@ -172,7 +172,7 @@ public class OAuth2SessionRequest {
                 "schemeId='" + schemeId + '\'' +
                 ", profileId='" + profileId + '\'' +
                 ", profileSelector='" + profileSelector + '\'' +
-                ", applicationId='" + applicationId + '\'' +
+                ", applicationNameOrId='" + applicationNameOrId + '\'' +
                 '}';
     }
 

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OAuth2SessionRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OAuth2SessionRequest.java
@@ -34,6 +34,11 @@ public class OAuth2SessionRequest {
             "NOTE: This will not be run if a profileId is specified.")
     private String profileSelector;
 
+    @Schema(description = "The name or ID of an application whose primary profile should be attached to the " +
+            "session. Only used if profileId and profileSelector are not specified. If the application or the " +
+            "user's primary profile for it cannot be resolved, the session is created without a profile.")
+    private String applicationId;
+
     /**
      * Returns the request parameters for the token validation request.
      *
@@ -128,17 +133,35 @@ public class OAuth2SessionRequest {
         this.profileSelector = profileSelector;
     }
 
+    /**
+     * Returns the name or ID of the application whose primary profile should be attached to the session.
+     *
+     * @return the application name or ID
+     */
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    /**
+     * Sets the name or ID of the application whose primary profile should be attached to the session.
+     *
+     * @param applicationId the application name or ID
+     */
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         OAuth2SessionRequest that = (OAuth2SessionRequest) o;
-        return Objects.equals(getRequestParameters(), that.getRequestParameters()) && Objects.equals(getRequestHeaders(), that.getRequestHeaders()) && Objects.equals(getSchemeId(), that.getSchemeId()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector());
+        return Objects.equals(getRequestParameters(), that.getRequestParameters()) && Objects.equals(getRequestHeaders(), that.getRequestHeaders()) && Objects.equals(getSchemeId(), that.getSchemeId()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector()) && Objects.equals(getApplicationId(), that.getApplicationId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getRequestParameters(), getRequestHeaders(), getSchemeId(), getProfileId(), getProfileSelector());
+        return Objects.hash(getRequestParameters(), getRequestHeaders(), getSchemeId(), getProfileId(), getProfileSelector(), getApplicationId());
     }
 
     @Override
@@ -149,6 +172,7 @@ public class OAuth2SessionRequest {
                 "schemeId='" + schemeId + '\'' +
                 ", profileId='" + profileId + '\'' +
                 ", profileSelector='" + profileSelector + '\'' +
+                ", applicationId='" + applicationId + '\'' +
                 '}';
     }
 

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/UsernamePasswordSessionRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/UsernamePasswordSessionRequest.java
@@ -32,7 +32,7 @@ public class UsernamePasswordSessionRequest {
     @Schema(description = "The name or ID of an application whose primary profile should be attached to the " +
             "session. Only used if profileId and profileSelector are not specified. If the application or the " +
             "user's primary profile for it cannot be resolved, the session is created without a profile.")
-    private String applicationId;
+    private String applicationNameOrId;
 
     /**
      * Returns the user ID (login name or email) for this session request.
@@ -111,17 +111,17 @@ public class UsernamePasswordSessionRequest {
      *
      * @return the application name or ID
      */
-    public String getApplicationId() {
-        return applicationId;
+    public String getApplicationNameOrId() {
+        return applicationNameOrId;
     }
 
     /**
      * Sets the name or ID of the application whose primary profile should be attached to the session.
      *
-     * @param applicationId the application name or ID
+     * @param applicationNameOrId the application name or ID
      */
-    public void setApplicationId(String applicationId) {
-        this.applicationId = applicationId;
+    public void setApplicationNameOrId(String applicationNameOrId) {
+        this.applicationNameOrId = applicationNameOrId;
     }
 
     @Override
@@ -129,12 +129,12 @@ public class UsernamePasswordSessionRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UsernamePasswordSessionRequest that = (UsernamePasswordSessionRequest) o;
-        return Objects.equals(getUserId(), that.getUserId()) && Objects.equals(getPassword(), that.getPassword()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector()) && Objects.equals(getApplicationId(), that.getApplicationId());
+        return Objects.equals(getUserId(), that.getUserId()) && Objects.equals(getPassword(), that.getPassword()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector()) && Objects.equals(getApplicationNameOrId(), that.getApplicationNameOrId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getUserId(), getPassword(), getProfileId(), getProfileSelector(), getApplicationId());
+        return Objects.hash(getUserId(), getPassword(), getProfileId(), getProfileSelector(), getApplicationNameOrId());
     }
 
     @Override
@@ -144,7 +144,7 @@ public class UsernamePasswordSessionRequest {
                 ", password='...you keep your secrets" + '\'' +
                 ", profileId='" + profileId + '\'' +
                 ", profileSelector='" + profileSelector + '\'' +
-                ", applicationId='" + applicationId + '\'' +
+                ", applicationNameOrId='" + applicationNameOrId + '\'' +
                 '}';
     }
 

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/UsernamePasswordSessionRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/UsernamePasswordSessionRequest.java
@@ -29,6 +29,11 @@ public class UsernamePasswordSessionRequest {
     @Schema(description = "A query string to select the profile to use.")
     private String profileSelector;
 
+    @Schema(description = "The name or ID of an application whose primary profile should be attached to the " +
+            "session. Only used if profileId and profileSelector are not specified. If the application or the " +
+            "user's primary profile for it cannot be resolved, the session is created without a profile.")
+    private String applicationId;
+
     /**
      * Returns the user ID (login name or email) for this session request.
      *
@@ -101,17 +106,35 @@ public class UsernamePasswordSessionRequest {
         this.profileSelector = profileSelector;
     }
 
+    /**
+     * Returns the name or ID of the application whose primary profile should be attached to the session.
+     *
+     * @return the application name or ID
+     */
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    /**
+     * Sets the name or ID of the application whose primary profile should be attached to the session.
+     *
+     * @param applicationId the application name or ID
+     */
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UsernamePasswordSessionRequest that = (UsernamePasswordSessionRequest) o;
-        return Objects.equals(getUserId(), that.getUserId()) && Objects.equals(getPassword(), that.getPassword()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector());
+        return Objects.equals(getUserId(), that.getUserId()) && Objects.equals(getPassword(), that.getPassword()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector()) && Objects.equals(getApplicationId(), that.getApplicationId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getUserId(), getPassword(), getProfileId(), getProfileSelector());
+        return Objects.hash(getUserId(), getPassword(), getProfileId(), getProfileSelector(), getApplicationId());
     }
 
     @Override
@@ -121,6 +144,7 @@ public class UsernamePasswordSessionRequest {
                 ", password='...you keep your secrets" + '\'' +
                 ", profileId='" + profileId + '\'' +
                 ", profileSelector='" + profileSelector + '\'' +
+                ", applicationId='" + applicationId + '\'' +
                 '}';
     }
 

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/user/UserCreateRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/user/UserCreateRequest.java
@@ -46,6 +46,12 @@ public class UserCreateRequest implements Serializable {
             "a profile for each item in this list.")
     private List<CreateProfileSignupRequest> profiles;
 
+    @Schema(description = "The name or ID of an application for which the user's primary profile should be " +
+            "automatically created, if that application is configured for it (Application#autoCreateProfile and " +
+            "Application#maxProfiles). Optional; if omitted, no automatic profile is created. It is an error to " +
+            "name an application here that also appears in the profiles list.")
+    private String autoCreateProfileApplicationId;
+
     /**
      * Returns the unique login name for the user.
      *
@@ -137,6 +143,24 @@ public class UserCreateRequest implements Serializable {
     }
 
     /**
+     * Returns the name or ID of the application for which the user's primary profile should be auto-created.
+     *
+     * @return the application name or ID, or null if unspecified
+     */
+    public String getAutoCreateProfileApplicationId() {
+        return autoCreateProfileApplicationId;
+    }
+
+    /**
+     * Sets the name or ID of the application for which the user's primary profile should be auto-created.
+     *
+     * @param autoCreateProfileApplicationId the application name or ID
+     */
+    public void setAutoCreateProfileApplicationId(String autoCreateProfileApplicationId) {
+        this.autoCreateProfileApplicationId = autoCreateProfileApplicationId;
+    }
+
+    /**
      * Returns the primary phone number for the user.
      *
      * @return the primary phone number
@@ -195,12 +219,12 @@ public class UserCreateRequest implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UserCreateRequest that = (UserCreateRequest) o;
-        return Objects.equals(name, that.name) && Objects.equals(email, that.email) && Objects.equals(primaryPhoneNb, that.primaryPhoneNb) && Objects.equals(firstName, that.firstName) && Objects.equals(lastName, that.lastName) && Objects.equals(password, that.password) && level == that.level && Objects.equals(profiles, that.profiles);
+        return Objects.equals(name, that.name) && Objects.equals(email, that.email) && Objects.equals(primaryPhoneNb, that.primaryPhoneNb) && Objects.equals(firstName, that.firstName) && Objects.equals(lastName, that.lastName) && Objects.equals(password, that.password) && level == that.level && Objects.equals(profiles, that.profiles) && Objects.equals(autoCreateProfileApplicationId, that.autoCreateProfileApplicationId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, email, primaryPhoneNb, firstName, lastName, password, level, profiles);
+        return Objects.hash(name, email, primaryPhoneNb, firstName, lastName, password, level, profiles, autoCreateProfileApplicationId);
     }
 
     @Override
@@ -214,6 +238,7 @@ public class UserCreateRequest implements Serializable {
                 ", password='" + password + '\'' +
                 ", level=" + level +
                 ", profiles=" + profiles +
+                ", autoCreateProfileApplicationId='" + autoCreateProfileApplicationId + '\'' +
                 '}';
     }
 }

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/user/UserCreateRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/user/UserCreateRequest.java
@@ -50,7 +50,7 @@ public class UserCreateRequest implements Serializable {
             "automatically created, if that application is configured for it (Application#autoCreateProfile and " +
             "Application#maxProfiles). Optional; if omitted, no automatic profile is created. It is an error to " +
             "name an application here that also appears in the profiles list.")
-    private String autoCreateProfileApplicationId;
+    private String autoCreateProfileApplicationNameOrId;
 
     /**
      * Returns the unique login name for the user.
@@ -147,17 +147,17 @@ public class UserCreateRequest implements Serializable {
      *
      * @return the application name or ID, or null if unspecified
      */
-    public String getAutoCreateProfileApplicationId() {
-        return autoCreateProfileApplicationId;
+    public String getAutoCreateProfileApplicationNameOrId() {
+        return autoCreateProfileApplicationNameOrId;
     }
 
     /**
      * Sets the name or ID of the application for which the user's primary profile should be auto-created.
      *
-     * @param autoCreateProfileApplicationId the application name or ID
+     * @param autoCreateProfileApplicationNameOrId the application name or ID
      */
-    public void setAutoCreateProfileApplicationId(String autoCreateProfileApplicationId) {
-        this.autoCreateProfileApplicationId = autoCreateProfileApplicationId;
+    public void setAutoCreateProfileApplicationNameOrId(String autoCreateProfileApplicationNameOrId) {
+        this.autoCreateProfileApplicationNameOrId = autoCreateProfileApplicationNameOrId;
     }
 
     /**
@@ -219,12 +219,12 @@ public class UserCreateRequest implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UserCreateRequest that = (UserCreateRequest) o;
-        return Objects.equals(name, that.name) && Objects.equals(email, that.email) && Objects.equals(primaryPhoneNb, that.primaryPhoneNb) && Objects.equals(firstName, that.firstName) && Objects.equals(lastName, that.lastName) && Objects.equals(password, that.password) && level == that.level && Objects.equals(profiles, that.profiles) && Objects.equals(autoCreateProfileApplicationId, that.autoCreateProfileApplicationId);
+        return Objects.equals(name, that.name) && Objects.equals(email, that.email) && Objects.equals(primaryPhoneNb, that.primaryPhoneNb) && Objects.equals(firstName, that.firstName) && Objects.equals(lastName, that.lastName) && Objects.equals(password, that.password) && level == that.level && Objects.equals(profiles, that.profiles) && Objects.equals(autoCreateProfileApplicationNameOrId, that.autoCreateProfileApplicationNameOrId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, email, primaryPhoneNb, firstName, lastName, password, level, profiles, autoCreateProfileApplicationId);
+        return Objects.hash(name, email, primaryPhoneNb, firstName, lastName, password, level, profiles, autoCreateProfileApplicationNameOrId);
     }
 
     @Override
@@ -238,7 +238,7 @@ public class UserCreateRequest implements Serializable {
                 ", password='" + password + '\'' +
                 ", level=" + level +
                 ", profiles=" + profiles +
-                ", autoCreateProfileApplicationId='" + autoCreateProfileApplicationId + '\'' +
+                ", autoCreateProfileApplicationNameOrId='" + autoCreateProfileApplicationNameOrId + '\'' +
                 '}';
     }
 }

--- a/service-test/src/test/java/dev/getelements/elements/service/AnonUsernamePasswordAuthServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/AnonUsernamePasswordAuthServiceTest.java
@@ -30,7 +30,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 /**
- * Covers the new (Elements 3.9+) applicationId-based primary-profile resolution added to username/password
+ * Covers the new (Elements 3.9+) applicationNameOrId-based primary-profile resolution added to username/password
  * session creation, alongside the pre-existing profileId/profileSelector resolution it must not disturb.
  */
 public class AnonUsernamePasswordAuthServiceTest {
@@ -65,7 +65,7 @@ public class AnonUsernamePasswordAuthServiceTest {
         final var request = new UsernamePasswordSessionRequest();
         request.setUserId(USER_ID);
         request.setPassword("password");
-        request.setApplicationId("app-1");
+        request.setApplicationNameOrId("app-1");
 
         service.createSession(request);
 
@@ -84,7 +84,7 @@ public class AnonUsernamePasswordAuthServiceTest {
         final var request = new UsernamePasswordSessionRequest();
         request.setUserId(USER_ID);
         request.setPassword("password");
-        request.setApplicationId("missing-app");
+        request.setApplicationNameOrId("missing-app");
 
         service.createSession(request);
 
@@ -109,7 +109,7 @@ public class AnonUsernamePasswordAuthServiceTest {
         request.setUserId(USER_ID);
         request.setPassword("password");
         request.setProfileId("explicit-profile-id");
-        request.setApplicationId("app-1");
+        request.setApplicationNameOrId("app-1");
 
         service.createSession(request);
 

--- a/service-test/src/test/java/dev/getelements/elements/service/AnonUsernamePasswordAuthServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/AnonUsernamePasswordAuthServiceTest.java
@@ -1,0 +1,159 @@
+package dev.getelements.elements.service;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+import dev.getelements.elements.sdk.dao.ApplicationDao;
+import dev.getelements.elements.sdk.dao.ProfileDao;
+import dev.getelements.elements.sdk.dao.SessionDao;
+import dev.getelements.elements.sdk.dao.UserDao;
+import dev.getelements.elements.sdk.model.application.Application;
+import dev.getelements.elements.sdk.model.profile.Profile;
+import dev.getelements.elements.sdk.model.session.Session;
+import dev.getelements.elements.sdk.model.session.SessionCreation;
+import dev.getelements.elements.sdk.model.session.UsernamePasswordSessionRequest;
+import dev.getelements.elements.sdk.model.user.User;
+import dev.getelements.elements.sdk.model.util.ValidationHelper;
+import dev.getelements.elements.service.auth.AnonUsernamePasswordAuthService;
+import jakarta.inject.Inject;
+import jakarta.validation.Validator;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.google.inject.Guice.createInjector;
+import static dev.getelements.elements.sdk.service.Constants.SESSION_TIMEOUT_SECONDS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Covers the new (Elements 3.9+) applicationId-based primary-profile resolution added to username/password
+ * session creation, alongside the pre-existing profileId/profileSelector resolution it must not disturb.
+ */
+public class AnonUsernamePasswordAuthServiceTest {
+
+    private static final String USER_ID = "test-user-id";
+
+    @Inject private AnonUsernamePasswordAuthService service;
+    @Inject private UserDao userDao;
+    @Inject private ProfileDao profileDao;
+    @Inject private ApplicationDao applicationDao;
+    @Inject private SessionDao sessionDao;
+    @Inject private ValidationHelper validationHelper;
+
+    @BeforeMethod
+    public void setup() {
+        createInjector(new TestModule()).injectMembers(this);
+        when(sessionDao.create(any(Session.class))).thenReturn(new SessionCreation());
+    }
+
+    @Test
+    public void testApplicationIdResolvesPrimaryProfileWhenNoProfileIdOrSelector() {
+
+        final var user = userWithId(USER_ID);
+        when(userDao.validateUserPassword(anyString(), anyString())).thenReturn(user);
+
+        final var application = applicationWithId("app-1");
+        when(applicationDao.findApplication("app-1")).thenReturn(Optional.of(application));
+
+        final var primaryProfile = profileFor(user, application);
+        when(profileDao.findPrimaryProfile(USER_ID, "app-1")).thenReturn(Optional.of(primaryProfile));
+
+        final var request = new UsernamePasswordSessionRequest();
+        request.setUserId(USER_ID);
+        request.setPassword("password");
+        request.setApplicationId("app-1");
+
+        service.createSession(request);
+
+        final var sessionCaptor = org.mockito.ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertEquals(sessionCaptor.getValue().getProfile().getId(), primaryProfile.getId());
+    }
+
+    @Test
+    public void testApplicationIdFallsBackToNoProfileWhenApplicationNotFound() {
+
+        final var user = userWithId(USER_ID);
+        when(userDao.validateUserPassword(anyString(), anyString())).thenReturn(user);
+        when(applicationDao.findApplication("missing-app")).thenReturn(Optional.empty());
+
+        final var request = new UsernamePasswordSessionRequest();
+        request.setUserId(USER_ID);
+        request.setPassword("password");
+        request.setApplicationId("missing-app");
+
+        service.createSession(request);
+
+        final var sessionCaptor = org.mockito.ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertNull(sessionCaptor.getValue().getProfile());
+
+        verify(profileDao, never()).findPrimaryProfile(any(), any());
+    }
+
+    @Test
+    public void testExplicitProfileIdTakesPrecedenceOverApplicationId() {
+
+        final var user = userWithId(USER_ID);
+        when(userDao.validateUserPassword(anyString(), anyString())).thenReturn(user);
+
+        final var explicitProfile = profileFor(user, applicationWithId("app-1"));
+        explicitProfile.setId("explicit-profile-id");
+        when(profileDao.getActiveProfile("explicit-profile-id")).thenReturn(explicitProfile);
+
+        final var request = new UsernamePasswordSessionRequest();
+        request.setUserId(USER_ID);
+        request.setPassword("password");
+        request.setProfileId("explicit-profile-id");
+        request.setApplicationId("app-1");
+
+        service.createSession(request);
+
+        final var sessionCaptor = org.mockito.ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertEquals(sessionCaptor.getValue().getProfile().getId(), "explicit-profile-id");
+
+        verify(applicationDao, never()).findApplication(any());
+        verify(profileDao, never()).findPrimaryProfile(any(), any());
+    }
+
+    // ---------- helpers ----------
+
+    private static User userWithId(final String id) {
+        final var u = new User();
+        u.setId(id);
+        return u;
+    }
+
+    private static Application applicationWithId(final String id) {
+        final var a = new Application();
+        a.setId(id);
+        return a;
+    }
+
+    private static Profile profileFor(final User user, final Application application) {
+        final var p = new Profile();
+        p.setId("profile-" + user.getId());
+        p.setUser(user);
+        p.setApplication(application);
+        return p;
+    }
+
+    private static class TestModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(UserDao.class).toInstance(mock(UserDao.class));
+            bind(ProfileDao.class).toInstance(mock(ProfileDao.class));
+            bind(ApplicationDao.class).toInstance(mock(ApplicationDao.class));
+            bind(SessionDao.class).toInstance(mock(SessionDao.class));
+            bind(Validator.class).toInstance(mock(Validator.class));
+            bind(ValidationHelper.class).toInstance(mock(ValidationHelper.class));
+            bindConstant().annotatedWith(Names.named(SESSION_TIMEOUT_SECONDS)).to(3600L);
+        }
+    }
+
+}

--- a/service-test/src/test/java/dev/getelements/elements/service/profile/ProfileServiceUtilsTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/profile/ProfileServiceUtilsTest.java
@@ -1,0 +1,124 @@
+package dev.getelements.elements.service.profile;
+
+import dev.getelements.elements.sdk.dao.ApplicationDao;
+import dev.getelements.elements.sdk.dao.UserDao;
+import dev.getelements.elements.sdk.model.application.Application;
+import dev.getelements.elements.sdk.model.exception.InternalException;
+import dev.getelements.elements.sdk.model.exception.InvalidDataException;
+import dev.getelements.elements.sdk.model.profile.CreateProfileRequest;
+import dev.getelements.elements.sdk.model.profile.UpdateProfileRequest;
+import dev.getelements.elements.sdk.model.user.User;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+/**
+ * Covers the (Elements 3.9+) Application#displayNameRegex enforcement added to profile create/update.
+ */
+public class ProfileServiceUtilsTest {
+
+    private static final String APPLICATION_ID = "app-1";
+    private static final String USER_ID = "user-1";
+    private static final String PROFILE_ID = "profile-1";
+
+    private ProfileServiceUtils profileServiceUtils;
+    private ApplicationDao applicationDao;
+    private UserDao userDao;
+
+    @BeforeMethod
+    public void setup() {
+        profileServiceUtils = new ProfileServiceUtils();
+        applicationDao = mock(ApplicationDao.class);
+        userDao = mock(UserDao.class);
+        profileServiceUtils.setApplicationDao(applicationDao);
+        profileServiceUtils.setUserDao(userDao);
+
+        when(userDao.getUser(anyString())).thenReturn(userWithId(USER_ID));
+    }
+
+    @Test
+    public void testCreateAllowsDisplayNameMatchingRegex() {
+        when(applicationDao.getActiveApplication(APPLICATION_ID))
+                .thenReturn(applicationWithRegex(APPLICATION_ID, "^[a-z]+$"));
+
+        final var profile = profileServiceUtils.getProfileForCreate(createRequest("validname"));
+        assertEquals(profile.getDisplayName(), "validname");
+    }
+
+    @Test
+    public void testCreateRejectsDisplayNameNotMatchingRegex() {
+        when(applicationDao.getActiveApplication(APPLICATION_ID))
+                .thenReturn(applicationWithRegex(APPLICATION_ID, "^[a-z]+$"));
+
+        expectThrows(InvalidDataException.class,
+                () -> profileServiceUtils.getProfileForCreate(createRequest("Invalid Name 123")));
+    }
+
+    @Test
+    public void testCreateSkipsCheckWhenRegexBlank() {
+        when(applicationDao.getActiveApplication(APPLICATION_ID))
+                .thenReturn(applicationWithRegex(APPLICATION_ID, null));
+
+        final var profile = profileServiceUtils.getProfileForCreate(createRequest("Anything At All 123"));
+        assertEquals(profile.getDisplayName(), "Anything At All 123");
+    }
+
+    @Test
+    public void testCreateThrowsInternalExceptionWhenRegexDoesNotCompile() {
+        when(applicationDao.getActiveApplication(APPLICATION_ID))
+                .thenReturn(applicationWithRegex(APPLICATION_ID, "[unterminated"));
+
+        expectThrows(InternalException.class,
+                () -> profileServiceUtils.getProfileForCreate(createRequest("anything")));
+    }
+
+    @Test
+    public void testUpdateRejectsDisplayNameNotMatchingRegex() {
+        when(applicationDao.getApplication(APPLICATION_ID))
+                .thenReturn(applicationWithRegex(APPLICATION_ID, "^[a-z]+$"));
+
+        final var updateRequest = new UpdateProfileRequest();
+        updateRequest.setDisplayName("Not Valid");
+
+        expectThrows(InvalidDataException.class,
+                () -> profileServiceUtils.getProfileForUpdate(PROFILE_ID, updateRequest, APPLICATION_ID));
+    }
+
+    @Test
+    public void testUpdateSkipsCheckWhenDisplayNameNotBeingChanged() {
+        final var updateRequest = new UpdateProfileRequest();
+        updateRequest.setMetadata(null);
+
+        final var updates = profileServiceUtils.getProfileForUpdate(PROFILE_ID, updateRequest, APPLICATION_ID);
+        assertEquals(updates.getId(), PROFILE_ID);
+    }
+
+    // ---------- helpers ----------
+
+    private static CreateProfileRequest createRequest(final String displayName) {
+        final var request = new CreateProfileRequest();
+        request.setUserId(USER_ID);
+        request.setApplicationId(APPLICATION_ID);
+        request.setDisplayName(displayName);
+        return request;
+    }
+
+    private static Application applicationWithRegex(final String id, final String regex) {
+        final var application = new Application();
+        application.setId(id);
+        application.setDisplayNameRegex(regex);
+        return application;
+    }
+
+    private static User userWithId(final String id) {
+        final var user = new User();
+        user.setId(id);
+        return user;
+    }
+
+}

--- a/service-test/src/test/java/dev/getelements/elements/service/profile/UserProfileServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/profile/UserProfileServiceTest.java
@@ -1,0 +1,127 @@
+package dev.getelements.elements.service.profile;
+
+import dev.getelements.elements.sdk.dao.ApplicationDao;
+import dev.getelements.elements.sdk.dao.LargeObjectDao;
+import dev.getelements.elements.sdk.dao.ProfileDao;
+import dev.getelements.elements.sdk.model.application.Application;
+import dev.getelements.elements.sdk.model.exception.InvalidDataException;
+import dev.getelements.elements.sdk.model.largeobject.LargeObject;
+import dev.getelements.elements.sdk.model.largeobject.LargeObjectReference;
+import dev.getelements.elements.sdk.model.profile.Profile;
+import dev.getelements.elements.sdk.model.profile.UpdateProfileImageRequest;
+import dev.getelements.elements.sdk.model.user.User;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.expectThrows;
+
+/**
+ * Covers the (Elements 3.9+) Application#authoritativeProfilePicture enforcement on the self-service
+ * profile-image update path.
+ */
+public class UserProfileServiceTest {
+
+    private static final String USER_ID = "user-1";
+    private static final String PROFILE_ID = "profile-1";
+    private static final String APPLICATION_ID = "app-1";
+
+    private UserProfileService userProfileService;
+    private ProfileDao profileDao;
+    private ApplicationDao applicationDao;
+    private LargeObjectDao largeObjectDao;
+    private ProfileImageObjectUtils profileImageObjectUtils;
+    private ProfileServiceUtils profileServiceUtils;
+
+    @BeforeMethod
+    public void setup() {
+
+        profileDao = mock(ProfileDao.class);
+        applicationDao = mock(ApplicationDao.class);
+        largeObjectDao = mock(LargeObjectDao.class);
+        profileImageObjectUtils = mock(ProfileImageObjectUtils.class);
+        profileServiceUtils = mock(ProfileServiceUtils.class);
+
+        when(profileServiceUtils.assignCdnUrl(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        userProfileService = new UserProfileService();
+        userProfileService.setUser(userWithId(USER_ID));
+        userProfileService.setProfileDao(profileDao);
+        userProfileService.setApplicationDao(applicationDao);
+        userProfileService.setLargeObjectDao(largeObjectDao);
+        userProfileService.setProfileImageObjectUtils(profileImageObjectUtils);
+        userProfileService.setProfileServiceUtils(profileServiceUtils);
+
+        final var currentProfile = profileFor(PROFILE_ID, USER_ID, APPLICATION_ID);
+        userProfileService.setCurrentProfileSupplier(() -> currentProfile);
+
+        when(profileDao.getActiveProfile(PROFILE_ID)).thenReturn(profileFor(PROFILE_ID, USER_ID, APPLICATION_ID));
+    }
+
+    @Test
+    public void testUpdateProfileImageRejectedWhenApplicationIsAuthoritative() throws Exception {
+
+        when(applicationDao.getApplication(APPLICATION_ID))
+                .thenReturn(applicationWithAuthoritativePicture(true));
+
+        expectThrows(InvalidDataException.class, () ->
+                userProfileService.updateProfileImage(PROFILE_ID, new UpdateProfileImageRequest()));
+
+        verify(largeObjectDao, never()).createLargeObject(any());
+        verify(largeObjectDao, never()).updateLargeObject(any());
+    }
+
+    @Test
+    public void testUpdateProfileImageAllowedWhenApplicationIsNotAuthoritative() throws Exception {
+
+        when(applicationDao.getApplication(APPLICATION_ID))
+                .thenReturn(applicationWithAuthoritativePicture(false));
+
+        final var existingImage = new LargeObjectReference();
+        existingImage.setId("large-object-1");
+
+        final var currentProfileWithImage = profileFor(PROFILE_ID, USER_ID, APPLICATION_ID);
+        currentProfileWithImage.setImageObject(existingImage);
+        userProfileService.setCurrentProfileSupplier(() -> currentProfileWithImage);
+
+        when(largeObjectDao.getLargeObject("large-object-1")).thenReturn(new LargeObject());
+        when(profileImageObjectUtils.updateProfileImageObject(any(), any(), any())).thenReturn(new LargeObject());
+        when(profileDao.updateActiveProfile(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        final var request = new UpdateProfileImageRequest();
+        request.setMimeType("image/png");
+
+        final var updated = userProfileService.updateProfileImage(PROFILE_ID, request);
+        assertNotNull(updated);
+
+        verify(largeObjectDao).updateLargeObject(any());
+    }
+
+    // ---------- helpers ----------
+
+    private static User userWithId(final String id) {
+        final var user = new User();
+        user.setId(id);
+        return user;
+    }
+
+    private static Profile profileFor(final String profileId, final String userId, final String applicationId) {
+        final var profile = new Profile();
+        profile.setId(profileId);
+        profile.setUser(userWithId(userId));
+        final var application = new Application();
+        application.setId(applicationId);
+        profile.setApplication(application);
+        return profile;
+    }
+
+    private static Application applicationWithAuthoritativePicture(final boolean authoritative) {
+        final var application = new Application();
+        application.setId(APPLICATION_ID);
+        application.setAuthoritativeProfilePicture(authoritative);
+        return application;
+    }
+
+}

--- a/service/src/main/java/dev/getelements/elements/service/auth/AnonUsernamePasswordAuthService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/AnonUsernamePasswordAuthService.java
@@ -54,7 +54,7 @@ public class AnonUsernamePasswordAuthService implements UsernamePasswordAuthServ
         final var profileId = usernamePasswordSessionRequest.getProfileId();
         final var profileSelector = usernamePasswordSessionRequest.getProfileSelector();
 
-        final var applicationId = usernamePasswordSessionRequest.getApplicationId();
+        final var applicationId = usernamePasswordSessionRequest.getApplicationNameOrId();
 
         final var user = getUserDao().validateUserPassword(userId, password);
         final var profile = getProfileIfSpecified(profileId)

--- a/service/src/main/java/dev/getelements/elements/service/auth/AnonUsernamePasswordAuthService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/AnonUsernamePasswordAuthService.java
@@ -1,5 +1,6 @@
 package dev.getelements.elements.service.auth;
 
+import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.ProfileDao;
 import dev.getelements.elements.sdk.dao.SessionDao;
 import dev.getelements.elements.sdk.dao.UserDao;
@@ -37,6 +38,8 @@ public class AnonUsernamePasswordAuthService implements UsernamePasswordAuthServ
 
     private ProfileDao profileDao;
 
+    private ApplicationDao applicationDao;
+
     private ValidationHelper validationHelper;
 
     private long sessionTimeoutSeconds;
@@ -51,8 +54,12 @@ public class AnonUsernamePasswordAuthService implements UsernamePasswordAuthServ
         final var profileId = usernamePasswordSessionRequest.getProfileId();
         final var profileSelector = usernamePasswordSessionRequest.getProfileSelector();
 
+        final var applicationId = usernamePasswordSessionRequest.getApplicationId();
+
         final var user = getUserDao().validateUserPassword(userId, password);
-        final var profile = getProfileIfSpecified(profileId).or(() -> selectProfileIfSpecified(user, profileSelector));
+        final var profile = getProfileIfSpecified(profileId)
+                .or(() -> selectProfileIfSpecified(user, profileSelector))
+                .or(() -> selectPrimaryProfileIfApplicationSpecified(user, applicationId));
 
         profile.ifPresent(p -> {
             if (!Objects.equals(user, p.getUser())) {
@@ -99,6 +106,19 @@ public class AnonUsernamePasswordAuthService implements UsernamePasswordAuthServ
 
     }
 
+    private Optional<Profile> selectPrimaryProfileIfApplicationSpecified(final User user,
+                                                                          final String applicationNameOrId) {
+
+        if (applicationNameOrId == null) {
+            return Optional.empty();
+        }
+
+        return getApplicationDao()
+                .findApplication(applicationNameOrId)
+                .flatMap(application -> getProfileDao().findPrimaryProfile(user.getId(), application.getId()));
+
+    }
+
     public UserDao getUserDao() {
         return userDao;
     }
@@ -124,6 +144,15 @@ public class AnonUsernamePasswordAuthService implements UsernamePasswordAuthServ
     @Inject
     public void setProfileDao(ProfileDao profileDao) {
         this.profileDao = profileDao;
+    }
+
+    public ApplicationDao getApplicationDao() {
+        return applicationDao;
+    }
+
+    @Inject
+    public void setApplicationDao(ApplicationDao applicationDao) {
+        this.applicationDao = applicationDao;
     }
 
     public long getSessionTimeoutSeconds() {

--- a/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
@@ -82,10 +82,10 @@ public class OAuth2AuthServiceOperations {
                 session.setApplication(profile.getApplication());
             }
 
-        } else if (oAuth2SessionRequest.getApplicationId() != null) {
+        } else if (oAuth2SessionRequest.getApplicationNameOrId() != null) {
 
             getApplicationDao()
-                    .findApplication(oAuth2SessionRequest.getApplicationId())
+                    .findApplication(oAuth2SessionRequest.getApplicationNameOrId())
                     .flatMap(application -> getProfileDao().findPrimaryProfile(user.getId(), application.getId()))
                     .ifPresent(profile -> {
                         session.setProfile(profile);

--- a/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
@@ -81,6 +81,17 @@ public class OAuth2AuthServiceOperations {
                 session.setProfile(profile);
                 session.setApplication(profile.getApplication());
             }
+
+        } else if (oAuth2SessionRequest.getApplicationId() != null) {
+
+            getApplicationDao()
+                    .findApplication(oAuth2SessionRequest.getApplicationId())
+                    .flatMap(application -> getProfileDao().findPrimaryProfile(user.getId(), application.getId()))
+                    .ifPresent(profile -> {
+                        session.setProfile(profile);
+                        session.setApplication(profile.getApplication());
+                    });
+
         }
 
         return getSessionDao().create(session);

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
@@ -168,9 +168,9 @@ public class OidcAuthServiceOperations {
 
             if(applicationOptional.isPresent()) {
                 final var application = applicationOptional.get();
-                final var profile = getProfileDao().createOrRefreshProfile(
-                        map(user, application)
-                );
+                final var profile = getProfileDao()
+                        .findPrimaryProfile(user.getId(), application.getId())
+                        .orElseGet(() -> getProfileDao().createOrRefreshProfile(map(user, application)));
 
                 session.setProfile(profile);
                 session.setApplication(application);

--- a/service/src/main/java/dev/getelements/elements/service/profile/ProfileServiceUtils.java
+++ b/service/src/main/java/dev/getelements/elements/service/profile/ProfileServiceUtils.java
@@ -2,6 +2,8 @@ package dev.getelements.elements.service.profile;
 
 import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.UserDao;
+import dev.getelements.elements.sdk.model.application.Application;
+import dev.getelements.elements.sdk.model.exception.InternalException;
 import dev.getelements.elements.sdk.model.exception.InvalidDataException;
 import dev.getelements.elements.sdk.model.exception.application.ApplicationNotFoundException;
 import dev.getelements.elements.sdk.model.exception.user.UserNotFoundException;
@@ -14,12 +16,19 @@ import dev.getelements.elements.sdk.service.name.NameService;
 import dev.getelements.elements.service.largeobject.LargeObjectCdnUtils;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static dev.getelements.elements.sdk.service.Constants.UNSCOPED;
 import static java.util.Objects.nonNull;
 
 public class ProfileServiceUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProfileServiceUtils.class);
 
     private UserDao userDao;
 
@@ -47,16 +56,24 @@ public class ProfileServiceUtils {
         if (profile.getDisplayName() == null || profile.getDisplayName().trim().isEmpty())
             profile.setDisplayName(getNameService().generateQualifiedName());
 
+        validateDisplayNameAgainstApplication(profile.getApplication(), profile.getDisplayName());
+
         return profile;
 
     }
 
-    public Profile getProfileForUpdate(final String profileId, final UpdateProfileRequest profileRequest) {
+    public Profile getProfileForUpdate(final String profileId,
+                                        final UpdateProfileRequest profileRequest,
+                                        final String applicationId) {
 
         final var updates = new Profile();
         updates.setId(profileId);
 
         if (!isNullOrEmpty(profileRequest.getDisplayName())) {
+
+            final var application = getApplicationDao().getApplication(applicationId);
+            validateDisplayNameAgainstApplication(application, profileRequest.getDisplayName());
+
             updates.setDisplayName(profileRequest.getDisplayName());
         }
 
@@ -68,6 +85,42 @@ public class ProfileServiceUtils {
         updates.setMetadata(metadata);
 
         return updates;
+
+    }
+
+    /**
+     * Validates the given display name against the application's configured {@code displayNameRegex}, if any.
+     * If the application has no regex configured (null/blank), this is a no-op. If the regex fails to compile,
+     * this logs the failure and throws an {@link InternalException} (500) rather than silently ignoring it.
+     *
+     * @param application the application the profile belongs to
+     * @param displayName the display name to validate
+     * @throws InvalidDataException if the display name does not match the application's regex
+     * @throws InternalException if the application's configured regex fails to compile
+     */
+    private void validateDisplayNameAgainstApplication(final Application application, final String displayName) {
+
+        final var displayNameRegex = application == null ? null : application.getDisplayNameRegex();
+
+        if (isNullOrEmpty(displayNameRegex)) {
+            return;
+        }
+
+        final Pattern pattern;
+
+        try {
+            pattern = Pattern.compile(displayNameRegex);
+        } catch (PatternSyntaxException ex) {
+            logger.error("Application {} has an invalid displayNameRegex '{}'.",
+                    application.getId(), displayNameRegex, ex);
+            throw new InternalException(
+                    "Application " + application.getId() + " has an invalid displayNameRegex configured.", ex);
+        }
+
+        if (displayName == null || !pattern.matcher(displayName).matches()) {
+            throw new InvalidDataException(
+                    "Display name does not match the required pattern for this application.");
+        }
 
     }
 

--- a/service/src/main/java/dev/getelements/elements/service/profile/SuperUserProfileService.java
+++ b/service/src/main/java/dev/getelements/elements/service/profile/SuperUserProfileService.java
@@ -3,6 +3,7 @@ package dev.getelements.elements.service.profile;
 import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.LargeObjectDao;
 import dev.getelements.elements.sdk.dao.ProfileDao;
+import dev.getelements.elements.sdk.dao.Transaction;
 import dev.getelements.elements.sdk.dao.UserDao;
 import dev.getelements.elements.sdk.model.Pagination;
 import dev.getelements.elements.sdk.model.largeobject.LargeObject;
@@ -17,6 +18,7 @@ import dev.getelements.elements.sdk.service.name.NameService;
 import dev.getelements.elements.sdk.service.profile.ProfileService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import jakarta.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +58,8 @@ public class SuperUserProfileService implements ProfileService {
     private LargeObjectDao largeObjectDao;
 
     private ElementRegistry elementRegistry;
+
+    private Provider<Transaction> transactionProvider;
 
     @Override
     public Pagination<Profile> getProfiles(final int offset, final int count,
@@ -119,7 +123,8 @@ public class SuperUserProfileService implements ProfileService {
 
     private Profile createNewProfile(final CreateProfileRequest profileRequest) {
         final var profile = getProfileServiceUtils().getProfileForCreate(profileRequest);
-        return getProfileDao().createOrReactivateProfile(profile);
+        return getTransactionProvider().get().performAndClose(tx ->
+                tx.getDao(ProfileDao.class).createSlottedProfile(profile, profile.getMetadata()));
     }
 
     @Override
@@ -242,6 +247,15 @@ public class SuperUserProfileService implements ProfileService {
     @Inject
     public void setElementRegistry(ElementRegistry elementRegistry) {
         this.elementRegistry = elementRegistry;
+    }
+
+    public Provider<Transaction> getTransactionProvider() {
+        return transactionProvider;
+    }
+
+    @Inject
+    public void setTransactionProvider(Provider<Transaction> transactionProvider) {
+        this.transactionProvider = transactionProvider;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/profile/SuperUserProfileService.java
+++ b/service/src/main/java/dev/getelements/elements/service/profile/SuperUserProfileService.java
@@ -96,7 +96,9 @@ public class SuperUserProfileService implements ProfileService {
 
     @Override
     public Profile updateProfile(String profileId, UpdateProfileRequest profileRequest) {
-        final var profile = getProfileServiceUtils().getProfileForUpdate(profileId, profileRequest);
+        final var existing = getProfileDao().getActiveProfile(profileId);
+        final var profile = getProfileServiceUtils()
+                .getProfileForUpdate(profileId, profileRequest, existing.getApplication().getId());
         return profileWithImageUrl(getProfileDao().updateActiveProfile(profile));
     }
 

--- a/service/src/main/java/dev/getelements/elements/service/profile/UserProfileService.java
+++ b/service/src/main/java/dev/getelements/elements/service/profile/UserProfileService.java
@@ -4,6 +4,7 @@ package dev.getelements.elements.service.profile;
 import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.LargeObjectDao;
 import dev.getelements.elements.sdk.dao.ProfileDao;
+import dev.getelements.elements.sdk.dao.Transaction;
 import dev.getelements.elements.sdk.model.exception.InvalidDataException;
 import dev.getelements.elements.sdk.model.exception.NotFoundException;
 import dev.getelements.elements.sdk.model.Pagination;
@@ -19,6 +20,7 @@ import dev.getelements.elements.sdk.Event;
 import dev.getelements.elements.sdk.service.profile.ProfileService;
 import dev.getelements.elements.sdk.service.user.UserService;
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +57,8 @@ public class UserProfileService implements ProfileService {
     private LargeObjectDao largeObjectDao;
 
     private ElementRegistry elementRegistry;
+
+    private Provider<Transaction> transactionProvider;
 
     @Override
     public Pagination<Profile> getProfiles(final int offset, final int count,
@@ -151,7 +155,8 @@ public class UserProfileService implements ProfileService {
     private Profile createNewProfile(final CreateProfileRequest profileRequest) {
         final var profile = getProfileServiceUtils().getProfileForCreate(profileRequest);
         profileRequest.setMetadata(null);
-        return getProfileDao().createOrReactivateProfile(profile);
+        return getTransactionProvider().get().performAndClose(tx ->
+                tx.getDao(ProfileDao.class).createSlottedProfile(profile, profile.getMetadata()));
     }
 
     @Override
@@ -279,6 +284,15 @@ public class UserProfileService implements ProfileService {
     @Inject
     public void setElementRegistry(ElementRegistry elementRegistry) {
         this.elementRegistry = elementRegistry;
+    }
+
+    public Provider<Transaction> getTransactionProvider() {
+        return transactionProvider;
+    }
+
+    @Inject
+    public void setTransactionProvider(Provider<Transaction> transactionProvider) {
+        this.transactionProvider = transactionProvider;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/profile/UserProfileService.java
+++ b/service/src/main/java/dev/getelements/elements/service/profile/UserProfileService.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.isNull;
 
 /**
@@ -113,10 +114,16 @@ public class UserProfileService implements ProfileService {
     @Override
     public Profile updateProfile(final String profileId, final UpdateProfileRequest profileRequest) {
 
-        checkUserAndProfile(getProfileDao().getActiveProfile(profileId).getUser().getId());
+        final var existing = getProfileDao().getActiveProfile(profileId);
+        checkUserAndProfile(existing.getUser().getId());
         profileRequest.setMetadata(null);
 
-        final var profile = getProfileServiceUtils().getProfileForUpdate(profileId, profileRequest);
+        if (!isNullOrEmpty(profileRequest.getImageUrl())) {
+            checkProfilePictureNotAuthoritative(existing.getApplication().getId());
+        }
+
+        final var profile = getProfileServiceUtils()
+                .getProfileForUpdate(profileId, profileRequest, existing.getApplication().getId());
         return profileWithImageUrl(getProfileDao().updateActiveProfile(profile));
 
     }
@@ -152,6 +159,14 @@ public class UserProfileService implements ProfileService {
         }
     }
 
+    private void checkProfilePictureNotAuthoritative(final String applicationId) {
+        final var application = getApplicationDao().getApplication(applicationId);
+        if (Boolean.TRUE.equals(application.getAuthoritativeProfilePicture())) {
+            throw new InvalidDataException(
+                    "This application's profile picture is authoritative and cannot be edited via the API.");
+        }
+    }
+
     private Profile createNewProfile(final CreateProfileRequest profileRequest) {
         final var profile = getProfileServiceUtils().getProfileForCreate(profileRequest);
         profileRequest.setMetadata(null);
@@ -174,6 +189,7 @@ public class UserProfileService implements ProfileService {
         final var profile = getCurrentProfile();
 
         checkUserAndProfile(getProfileDao().getActiveProfile(profile.getId()).getUser().getId());
+        checkProfilePictureNotAuthoritative(profile.getApplication().getId());
 
         if (isNull(profile.getImageObject())) {
             logger.warn("Requested update profile which does not have large object assigned yet. Creating new LargeObject");

--- a/service/src/main/java/dev/getelements/elements/service/user/AbstractUserService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/AbstractUserService.java
@@ -122,7 +122,7 @@ public abstract class AbstractUserService implements UserService {
 
     /**
      * Auto-creates the user's primary profile for the application named by
-     * {@link UserCreateRequest#getAutoCreateProfileApplicationId()}, if requested. This is an explicit, opt-in
+     * {@link UserCreateRequest#getAutoCreateProfileApplicationNameOrId()}, if requested. This is an explicit, opt-in
      * action: if that field is null, this is a no-op, preserving pre-existing behavior. If the named application
      * also appears in {@link UserCreateRequest#getProfiles()}, this throws a {@link BadRequestException}, since the
      * two mechanisms conflict for the same application. Otherwise, a profile is only actually created if the
@@ -138,7 +138,7 @@ public abstract class AbstractUserService implements UserService {
     protected Profile autoCreateExplicitProfileIfRequested(final String userId,
                                                             final UserCreateRequest userCreateRequest) {
 
-        final var applicationNameOrId = userCreateRequest.getAutoCreateProfileApplicationId();
+        final var applicationNameOrId = userCreateRequest.getAutoCreateProfileApplicationNameOrId();
 
         if (applicationNameOrId == null) {
             return null;

--- a/service/src/main/java/dev/getelements/elements/service/user/AbstractUserService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/AbstractUserService.java
@@ -1,5 +1,6 @@
 package dev.getelements.elements.service.user;
 
+import dev.getelements.elements.rt.exception.BadRequestException;
 import dev.getelements.elements.sdk.ElementRegistry;
 import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.ProfileDao;
@@ -7,6 +8,7 @@ import dev.getelements.elements.sdk.model.profile.CreateProfileRequest;
 import dev.getelements.elements.sdk.model.profile.CreateProfileSignupRequest;
 import dev.getelements.elements.sdk.model.profile.Profile;
 import dev.getelements.elements.sdk.model.user.User;
+import dev.getelements.elements.sdk.model.user.UserCreateRequest;
 import dev.getelements.elements.sdk.service.name.NameService;
 import dev.getelements.elements.sdk.service.user.UserService;
 import dev.getelements.elements.service.profile.SuperUserProfileService;
@@ -116,6 +118,59 @@ public abstract class AbstractUserService implements UserService {
                 .stream()
                 .map(req -> createProfile(userId, req))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Auto-creates the user's primary profile for the application named by
+     * {@link UserCreateRequest#getAutoCreateProfileApplicationId()}, if requested. This is an explicit, opt-in
+     * action: if that field is null, this is a no-op, preserving pre-existing behavior. If the named application
+     * also appears in {@link UserCreateRequest#getProfiles()}, this throws a {@link BadRequestException}, since the
+     * two mechanisms conflict for the same application. Otherwise, a profile is only actually created if the
+     * application is configured for it (i.e. {@link dev.getelements.elements.sdk.model.application.Application#getAutoCreateProfile()}
+     * is {@code true} and {@link dev.getelements.elements.sdk.model.application.Application#getMaxProfiles()} is at
+     * least 1) -- if not, this silently no-ops rather than erroring, since the field names the feature to invoke,
+     * but the application's own configuration still governs whether it does anything.
+     *
+     * @param userId the id of the newly created {@link User}
+     * @param userCreateRequest the original {@link UserCreateRequest}
+     * @return the auto-created {@link Profile}, or null if none was created
+     */
+    protected Profile autoCreateExplicitProfileIfRequested(final String userId,
+                                                            final UserCreateRequest userCreateRequest) {
+
+        final var applicationNameOrId = userCreateRequest.getAutoCreateProfileApplicationId();
+
+        if (applicationNameOrId == null) {
+            return null;
+        }
+
+        final var application = getApplicationDao().getApplication(applicationNameOrId);
+
+        final var requestedProfiles = userCreateRequest.getProfiles();
+
+        if (requestedProfiles != null) {
+            final var conflicts = requestedProfiles.stream().anyMatch(requested ->
+                    applicationNameOrId.equals(requested.getApplicationId())
+                            || application.getId().equals(requested.getApplicationId()));
+
+            if (conflicts) {
+                throw new BadRequestException(
+                        "Cannot both explicitly request a profile and request auto-create for application " +
+                        applicationNameOrId);
+            }
+        }
+
+        final var maxProfiles = application.getMaxProfiles();
+
+        if (!Boolean.TRUE.equals(application.getAutoCreateProfile()) || maxProfiles == null || maxProfiles < 1) {
+            return null;
+        }
+
+        final var signupRequest = new CreateProfileSignupRequest();
+        signupRequest.setApplicationId(application.getId());
+
+        return createProfile(userId, signupRequest);
+
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/user/AnonUserService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/AnonUserService.java
@@ -3,6 +3,7 @@ package dev.getelements.elements.service.user;
 import dev.getelements.elements.sdk.dao.UserDao;
 import dev.getelements.elements.sdk.model.exception.ForbiddenException;
 import dev.getelements.elements.sdk.model.Pagination;
+import dev.getelements.elements.sdk.model.profile.Profile;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
 import dev.getelements.elements.sdk.model.user.*;
 import dev.getelements.elements.sdk.model.security.PasswordGenerator;
@@ -11,8 +12,9 @@ import dev.getelements.elements.sdk.model.util.MapperRegistry;
 import dev.getelements.elements.sdk.service.user.UserService;
 import jakarta.inject.Inject;
 
+import java.util.ArrayList;
+
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.util.Collections.emptyList;
 
 public class AnonUserService extends AbstractUserService implements UserService {
 
@@ -58,12 +60,17 @@ public class AnonUserService extends AbstractUserService implements UserService 
 
         final var profiles = userCreateRequest.getProfiles();
 
-        if (profiles == null) {
-            response.setProfiles(emptyList());
-        } else {
-            final var createdProfiles = createProfiles(created.getId(), userCreateRequest.getProfiles());
-            response.setProfiles(createdProfiles);
+        final var createdProfiles = profiles == null
+                ? new ArrayList<Profile>()
+                : new ArrayList<>(createProfiles(created.getId(), profiles));
+
+        final var autoCreatedProfile = autoCreateExplicitProfileIfRequested(created.getId(), userCreateRequest);
+
+        if (autoCreatedProfile != null) {
+            createdProfiles.add(autoCreatedProfile);
         }
+
+        response.setProfiles(createdProfiles);
 
         return response;
 

--- a/service/src/main/java/dev/getelements/elements/service/user/SuperuserUserService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/SuperuserUserService.java
@@ -5,6 +5,7 @@ import dev.getelements.elements.sdk.Event;
 import dev.getelements.elements.sdk.dao.SessionDao;
 import dev.getelements.elements.sdk.dao.UserDao;
 import dev.getelements.elements.sdk.model.Pagination;
+import dev.getelements.elements.sdk.model.profile.Profile;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
 import dev.getelements.elements.sdk.model.user.*;
 import dev.getelements.elements.rt.exception.BadRequestException;
@@ -15,6 +16,8 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import dev.getelements.elements.sdk.model.util.MapperRegistry;
 
+import java.util.ArrayList;
+
 import static dev.getelements.elements.sdk.service.user.UserService.*;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -22,7 +25,6 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static dev.getelements.elements.sdk.service.Constants.SESSION_TIMEOUT_SECONDS;
 import static dev.getelements.elements.sdk.service.Constants.UNSCOPED;
 import static dev.getelements.elements.util.PhoneNormalizer.normalizePhoneNb;
-import static java.util.Collections.emptyList;
 
 /**
  *
@@ -90,12 +92,17 @@ public class SuperuserUserService extends AbstractUserService implements UserSer
 
         final var profiles = userCreateRequest.getProfiles();
 
-        if (profiles == null) {
-            response.setProfiles(emptyList());
-        } else {
-            final var createdProfiles = createProfiles(created.getId(), userCreateRequest.getProfiles());
-            response.setProfiles(createdProfiles);
+        final var createdProfiles = profiles == null
+                ? new ArrayList<Profile>()
+                : new ArrayList<>(createProfiles(created.getId(), profiles));
+
+        final var autoCreatedProfile = autoCreateExplicitProfileIfRequested(created.getId(), userCreateRequest);
+
+        if (autoCreatedProfile != null) {
+            createdProfiles.add(autoCreatedProfile);
         }
+
+        response.setProfiles(createdProfiles);
 
         return response;
 

--- a/web-ui-react-jetty/elements-web-ui/client/src/components/ApplicationForm.tsx
+++ b/web-ui-react-jetty/elements-web-ui/client/src/components/ApplicationForm.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 import { ExternalLink, Plus, Pencil, Trash2, Loader2 } from 'lucide-react';
 import { ApplicationConfigurationDialog } from './ApplicationConfigurationDialog';
 import { useState, useMemo } from 'react';
@@ -99,8 +100,13 @@ const createApplicationSchema = (mode: 'create' | 'update') => z.object({
   name: z.string().min(1, 'Name is required'),
   description: z.string().optional(),
   attributes: z.record(z.any()).optional(),
+  // Kept as a string in form state (like other text inputs) and parsed to a number in handleFormSubmit.
+  maxProfiles: z.string().optional(),
+  autoCreateProfile: z.boolean().optional(),
+  authoritativeProfilePicture: z.boolean().optional(),
+  displayNameRegex: z.string().optional(),
   // Only validate applicationConfiguration in create mode
-  applicationConfiguration: mode === 'create' 
+  applicationConfiguration: mode === 'create'
     ? z.array(applicationConfigSchema).optional()
     : z.any().optional(),
 });
@@ -241,6 +247,12 @@ export function ApplicationForm({ initialData = {}, onSubmit, mode }: Applicatio
       name: initialData.name || '',
       description: initialData.description || '',
       attributes: initialData.attributes || {},
+      maxProfiles: initialData.maxProfiles !== undefined && initialData.maxProfiles !== null
+        ? String(initialData.maxProfiles)
+        : '',
+      autoCreateProfile: initialData.autoCreateProfile ?? true,
+      authoritativeProfilePicture: initialData.authoritativeProfilePicture ?? false,
+      displayNameRegex: initialData.displayNameRegex || '',
     },
   });
 
@@ -263,7 +275,12 @@ export function ApplicationForm({ initialData = {}, onSubmit, mode }: Applicatio
         return value !== undefined && value !== null && value !== '';
       })
     ) as ApplicationFormData;
-    
+
+    // maxProfiles is kept as a string in form state; parse it to a number for the API payload.
+    if (cleanedData.maxProfiles !== undefined) {
+      (cleanedData as any).maxProfiles = parseInt(cleanedData.maxProfiles as unknown as string, 10);
+    }
+
     // Preserve _configurations from initialData if it exists (for duplication)
     const dataWithConfigs = (initialData as any)?._configurations 
       ? { ...cleanedData, _configurations: (initialData as any)._configurations }
@@ -308,6 +325,84 @@ export function ApplicationForm({ initialData = {}, onSubmit, mode }: Applicatio
                       <FormControl>
                         <Textarea {...field} placeholder="Application description" data-testid="textarea-description" />
                       </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="maxProfiles"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Max Profiles</FormLabel>
+                      <FormControl>
+                        <Input {...field} type="number" min={0} placeholder="1" data-testid="input-maxProfiles" />
+                      </FormControl>
+                      <FormDescription>
+                        Maximum number of profiles a user may create for this application. Defaults to 1 if left blank.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="autoCreateProfile"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-start space-x-2 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                          data-testid="checkbox-autoCreateProfile"
+                        />
+                      </FormControl>
+                      <div className="space-y-1 leading-none">
+                        <FormLabel className="cursor-pointer">Auto-Create Primary Profile</FormLabel>
+                        <FormDescription>
+                          Automatically create a user's primary profile for this application when requested during user creation.
+                        </FormDescription>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="authoritativeProfilePicture"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-start space-x-2 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                          data-testid="checkbox-authoritativeProfilePicture"
+                        />
+                      </FormControl>
+                      <div className="space-y-1 leading-none">
+                        <FormLabel className="cursor-pointer">Authoritative Profile Picture</FormLabel>
+                        <FormDescription>
+                          If checked, users cannot edit their own profile picture via the API for this application -- it must be set by backend/Element code.
+                        </FormDescription>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="displayNameRegex"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Display Name Regex</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="^[A-Za-z0-9 ]+$" data-testid="input-displayNameRegex" />
+                      </FormControl>
+                      <FormDescription>
+                        Optional Java regular expression a profile's display name must match for this application. Leave blank to skip this check.
+                      </FormDescription>
                       <FormMessage />
                     </FormItem>
                   )}


### PR DESCRIPTION
## Summary
- Adds `Application.maxProfiles` (default 1) / `autoCreateProfile` (default true), read-time defaulted for legacy applications.
- Introduces an internal, race-safe profile-slot mechanism (`MongoProfileSlot`/`MongoProfileSlotId`, following the `HexableId` pattern) so slot assignment and the `maxProfiles` check are atomic under concurrent profile creation, via MongoDB transactions (`Transaction`/`performAndClose`).
- Adds `ProfileDao.findPrimaryProfile`/`getPrimaryProfile` (slot 0) and a new `createSlottedProfile` creation path; deprecates `createOrReactivateProfile`/`createOrRefreshProfile` in favor of it (both are intentionally left ungated/untouched for reactivation and the OIDC get-or-create login path).
- Wires the new path through `UserProfileService`/`SuperUserProfileService` inside a `Transaction`.
- Adds an opt-in `UserCreateRequest.autoCreateProfileApplicationId` field so user creation can auto-create a primary profile for a named application (400 if it conflicts with an explicit `profiles` entry for the same app).
- Adds an `applicationId` field to `UsernamePasswordSessionRequest`/`OAuth2SessionRequest` that resolves and attaches the user's primary profile, falling back silently to no profile if unresolved. OIDC session creation now prefers the primary profile before its existing get-or-create fallback.
- Updates the manual (`applications.md`, `creating-a-user.md`, `sessions.md`, `user-authentication-in-elements.md`, new `3-9-release-notes.md`) — separate PR in `elements-manual`.

Filed #13 (DB migration script framework) as a related follow-up, since existing profiles created before this feature deploys will need a backfilled slot-0 document.

## Test plan
- [x] `mvn install -DskipTests` full reactor build succeeds
- [x] New `MongoProfileSlotDaoTest` (5 tests, incl. a concurrency test asserting exactly `maxProfiles` succeed under contention) — passing
- [x] New `AnonUsernamePasswordAuthServiceTest` (3 tests covering the new `applicationId` resolution + precedence over `profileId`) — passing
- [x] Full `mongo-test` suite: 21487 tests, 0 failures
- [x] Full `service-test` suite: 272 tests, 0 failures

Closes #11