### PR TITLE
Run complete build + docker + javadoc publish on every branch

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -1,21 +1,40 @@
 name: Publish docs
 description: >
   Aggregates Javadoc, grabs the built OpenAPI spec, and publishes both to
-  the gh-pages branch under a subdirectory named after the given version,
-  regenerating the root index. Used for every rc/release tag AND for every
-  main snapshot build (main is perpetually the same version between release
-  cuts, so its directory is simply overwritten in place each time -- still
-  useful, just not immutable the way an rc/release directory is). Assumes
-  the reactor has already been built (so the OpenAPI spec and compiled
-  classes for the aggregate javadoc already exist) and that git user/email
-  are configured for the checkout the caller made.
+  the namazu-apidocs S3 bucket under the "elements/<version>" prefix
+  (served at apidocs.namazustudios.com/elements/), regenerating the root
+  index and invalidating the CloudFront distribution in front of it. Used
+  for every rc/release tag AND for every main snapshot build (main is
+  perpetually the same version between release cuts, so its prefix is
+  simply overwritten in place each time -- still useful, just not
+  immutable the way an rc/release prefix is). Assumes the reactor has
+  already been built (so the OpenAPI spec and compiled classes for the
+  aggregate javadoc already exist).
 
 inputs:
   version:
     description: Version string to publish under (e.g. 3.9.0-rc-1, or 3.9.0-SNAPSHOT for main)
     required: true
-  github-token:
-    description: Token used to push to gh-pages
+  aws-access-key-id:
+    description: AWS access key ID for the namazu-apidocs S3 bucket
+    required: true
+  aws-secret-access-key:
+    description: AWS secret access key for the namazu-apidocs S3 bucket
+    required: true
+  aws-region:
+    description: AWS region the namazu-apidocs S3 bucket lives in
+    required: true
+    default: us-east-1
+  s3-bucket:
+    description: S3 bucket to publish into
+    required: true
+    default: namazu-apidocs
+  s3-prefix:
+    description: Key prefix within the bucket to publish under
+    required: true
+    default: elements
+  cloudfront-distribution-id:
+    description: CloudFront distribution ID fronting the bucket, invalidated after publish
     required: true
 
 runs:
@@ -24,7 +43,6 @@ runs:
     - shell: bash
       env:
         VERSION: ${{ inputs.version }}
-        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
 
@@ -48,46 +66,54 @@ runs:
           exit 1
         fi
 
-        REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-        rm -rf /tmp/gh-pages
-        if git ls-remote --exit-code --heads "$REPO_URL" gh-pages >/dev/null 2>&1; then
-          git clone --branch gh-pages --single-branch "$REPO_URL" /tmp/gh-pages
-        else
-          git clone "$REPO_URL" /tmp/gh-pages
-          git -C /tmp/gh-pages checkout --orphan gh-pages
-          git -C /tmp/gh-pages rm -rf .
-        fi
+        rm -rf "/tmp/apidocs-publish/$VERSION"
+        mkdir -p "/tmp/apidocs-publish/$VERSION/javadoc"
+        cp -r "$APIDOCS_DIR"/. "/tmp/apidocs-publish/$VERSION/javadoc/"
+        cp rest-api/target/classes/META-INF/openapi.json "/tmp/apidocs-publish/$VERSION/openapi.json"
 
-        rm -rf "/tmp/gh-pages/$VERSION"
-        mkdir -p "/tmp/gh-pages/$VERSION/javadoc"
-        cp -r "$APIDOCS_DIR"/. "/tmp/gh-pages/$VERSION/javadoc/"
-        cp rest-api/target/classes/META-INF/openapi.json "/tmp/gh-pages/$VERSION/openapi.json"
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        BUCKET: ${{ inputs.s3-bucket }}
+        PREFIX: ${{ inputs.s3-prefix }}
+      run: |
+        set -euo pipefail
+
+        aws s3 sync "/tmp/apidocs-publish/$VERSION" "s3://$BUCKET/$PREFIX/$VERSION" --delete
+
+        # Regenerate the root index by listing every version "directory"
+        # already published under this prefix (including the one just
+        # uploaded above), newest-looking version string first.
+        VERSIONS="$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "$PREFIX/" --delimiter "/" \
+          --query 'CommonPrefixes[].Prefix' --output text \
+          | tr '\t' '\n' \
+          | sed -E "s#^$PREFIX/##; s#/\$##" \
+          | sort -rV)"
 
         {
           echo "<!doctype html><html><body><h1>Namazu Elements API Docs</h1><ul>"
-          for d in $(cd /tmp/gh-pages && ls -d */ | sed 's#/##' | sort -rV); do
+          for d in $VERSIONS; do
             echo "<li><a href=\"$d/javadoc/\">$d</a> (<a href=\"$d/openapi.json\">openapi.json</a>)</li>"
           done
           echo "</ul></body></html>"
-        } > /tmp/gh-pages/index.html
+        } > /tmp/apidocs-index.html
 
-        cd /tmp/gh-pages
-        git config user.name "Continuous Integration"
-        git config user.email "ci@getelements.dev"
-        git add -A
-        git commit -m "Publish docs for $VERSION"
+        aws s3 cp /tmp/apidocs-index.html "s3://$BUCKET/$PREFIX/index.html" --content-type text/html
 
-        # gh-pages can be pushed to by more than one workflow (main snapshot
-        # builds and tag publishes can race); retry a few times against a
-        # freshly rebased branch rather than assume no one else is pushing.
-        for attempt in 1 2 3 4 5; do
-          if git push origin gh-pages; then
-            exit 0
-          fi
-          echo "push rejected, retrying ($attempt/5)..."
-          sleep $(( attempt * 5 ))
-          git fetch origin gh-pages
-          git rebase origin/gh-pages
-        done
-        echo "::error::failed to push gh-pages after retries"
-        exit 1
+    - name: Invalidate CloudFront cache
+      shell: bash
+      env:
+        PREFIX: ${{ inputs.s3-prefix }}
+        DISTRIBUTION_ID: ${{ inputs.cloudfront-distribution-id }}
+      run: |
+        set -euo pipefail
+        aws cloudfront create-invalidation \
+          --distribution-id "$DISTRIBUTION_ID" \
+          --paths "/$PREFIX/*"

--- a/.github/workflows/complete-build.yml
+++ b/.github/workflows/complete-build.yml
@@ -8,11 +8,16 @@ name: Complete Build
 # resulting tag triggers tag-publish.yml instead, which does the real
 # Central/release publish and does not call this).
 #
-# Maven artifact publishing to the GitHub Packages snapshot repo is opt-in
-# via publish-packages, and deliberately NOT the default: every branch
-# shares the same reactor version, so publishing packages from every branch
-# would just have them fight over the same GitHub Packages coordinates.
-# Only main sets this true.
+# Every branch attempts a Central-only snapshot deploy (make deploy) as
+# part of its build/test step, even though Central rejects/ignores
+# -SNAPSHOT uploads and nothing actually ends up published there -- running
+# the real sign+deploy pipeline (not just `install`) catches signing/
+# packaging failures a plain install wouldn't. Publishing to the GitHub
+# Packages snapshot repo is a real publish (unlike the Central no-op) and
+# is opt-in via publish-packages, deliberately NOT the default: every
+# branch shares the same reactor version, so publishing packages from every
+# branch would just have them fight over the same GitHub Packages
+# coordinates. Only main sets this true.
 
 on:
   workflow_call:
@@ -39,6 +44,9 @@ jobs:
       - name: Build setup
         id: build-setup
         uses: ./.github/actions/build-setup
+        with:
+          import-gpg: 'true'
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
 
       - name: Install (skip tests)
         # Populates every module into the local repo first. Some tests
@@ -50,16 +58,25 @@ jobs:
         # exists.
         run: make install_no_tests
 
-      - name: Build, test, and publish snapshot to GitHub Packages
+      - name: Build, test, and publish snapshot to Central (no-op) + GitHub Packages
         if: inputs.publish-packages
         env:
+          SONATYPE_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           GITHUB_USERNAME: ${{ github.actor }}
           GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: make deploy_github
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: make deploy_central
 
-      - name: Build and test (no package publish)
+      - name: Build, test, and attempt snapshot deploy to Central (no-op)
         if: ${{ !inputs.publish-packages }}
-        run: make build
+        env:
+          SONATYPE_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: make deploy
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/complete-build.yml
+++ b/.github/workflows/complete-build.yml
@@ -1,0 +1,101 @@
+name: Complete Build
+
+# Reusable workflow: full build+test, Docker image build+push (to Docker
+# Hub and GHCR), and Javadoc/OpenAPI publish to S3/CloudFront. Callable from
+# any branch-triggered workflow that wants this behavior -- currently
+# main-build.yml (every ordinary branch push) and release-branch-push.yml
+# (release/* pushes that haven't cut an RC yet; once an RC is cut, the
+# resulting tag triggers tag-publish.yml instead, which does the real
+# Central/release publish and does not call this).
+#
+# Maven artifact publishing to the GitHub Packages snapshot repo is opt-in
+# via publish-packages, and deliberately NOT the default: every branch
+# shares the same reactor version, so publishing packages from every branch
+# would just have them fight over the same GitHub Packages coordinates.
+# Only main sets this true.
+
+on:
+  workflow_call:
+    inputs:
+      publish-packages:
+        description: Whether to publish Maven artifacts to the GitHub Packages snapshot repo
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build setup
+        id: build-setup
+        uses: ./.github/actions/build-setup
+
+      - name: Install (skip tests)
+        # Populates every module into the local repo first. Some tests
+        # (e.g. sdk-test's ShrinkWrap-resolved fixtures) resolve a sibling
+        # module's jar from the local repo at test-execution time rather
+        # than via a normal reactor dependency edge, so they only see it if
+        # it's already installed -- a single deploy/install pass builds
+        # modules in reactor order and can hit that test before the fixture
+        # exists.
+        run: make install_no_tests
+
+      - name: Build, test, and publish snapshot to GitHub Packages
+        if: inputs.publish-packages
+        env:
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: make deploy_github
+
+      - name: Build and test (no package publish)
+        if: ${{ !inputs.publish-packages }}
+        run: make build
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker images
+        run: make docker
+
+      - name: Compute short SHA
+        id: short-sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Publish Javadoc + OpenAPI spec to apidocs.namazustudios.com
+        # The reactor's version stays the same -SNAPSHOT between release-
+        # branch cuts, and is identical across every branch besides (nothing
+        # bumps it per-branch) -- append the short SHA so each build gets
+        # its own prefix instead of every branch's builds clobbering the
+        # same path.
+        uses: ./.github/actions/publish-docs
+        with:
+          version: ${{ steps.build-setup.outputs.maven-version }}-${{ steps.short-sha.outputs.sha }}
+          aws-access-key-id: ${{ secrets.APIDOCS_S3_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.APIDOCS_S3_SECRET_ACCESS_KEY }}
+          cloudfront-distribution-id: E30XJUM7BR8918

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -11,7 +11,9 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
+  # contents: write was only needed for the old gh-pages push; docs now
+  # publish to S3, so this only needs read access to check out the repo.
+  contents: read
   packages: write
 
 jobs:
@@ -68,13 +70,15 @@ jobs:
         id: short-sha
         run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Publish Javadoc + OpenAPI spec to gh-pages
+      - name: Publish Javadoc + OpenAPI spec to apidocs.namazustudios.com
         # main sits at the same -SNAPSHOT version between release-branch
-        # cuts, so unlike an rc/release tag's immutable directory, this would
+        # cuts, so unlike an rc/release tag's immutable prefix, this would
         # just overwrite the same path on every push. Append the short SHA
-        # so each snapshot build gets its own directory instead of clobbering
+        # so each snapshot build gets its own prefix instead of clobbering
         # the last one.
         uses: ./.github/actions/publish-docs
         with:
           version: ${{ steps.build-setup.outputs.maven-version }}-${{ steps.short-sha.outputs.sha }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          aws-access-key-id: ${{ secrets.APIDOCS_S3_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.APIDOCS_S3_SECRET_ACCESS_KEY }}
+          cloudfront-distribution-id: E30XJUM7BR8918

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -1,84 +1,20 @@
-name: Main Snapshot Build
+name: Branch Build
 
-# Continuous build for trunk. main is always a -SNAPSHOT and never touches
-# Maven Central (Central rejects -SNAPSHOT versions outright) -- publishes
-# only go to the GitHub Packages snapshot repo, plus Docker images to both
-# Docker Hub and GHCR. main's version is never bumped by this workflow; that
-# only ever happens via the manual "Set Version" workflow.
+# Every push to any branch (except release/*, which has its own dedicated
+# workflow with version-bump logic -- see release-branch-push.yml) gets a
+# complete build+test, Docker image build+push, and Javadoc/OpenAPI publish
+# via complete-build.yml. Only main also publishes Maven artifacts to the
+# GitHub Packages snapshot repo (see complete-build.yml for why that's not
+# every branch). main's version is never bumped by this workflow; that only
+# ever happens via the manual "Set Version" workflow.
 
 on:
   push:
-    branches: [ main ]
-
-permissions:
-  # contents: write was only needed for the old gh-pages push; docs now
-  # publish to S3, so this only needs read access to check out the repo.
-  contents: read
-  packages: write
+    branches: [ '**', '!release/**' ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Build setup
-        id: build-setup
-        uses: ./.github/actions/build-setup
-
-      - name: Install (skip tests)
-        # Populates every module into the local repo first. Some tests
-        # (e.g. sdk-test's ShrinkWrap-resolved fixtures) resolve a sibling
-        # module's jar from the local repo at test-execution time rather
-        # than via a normal reactor dependency edge, so they only see it if
-        # it's already installed -- a single deploy pass builds modules in
-        # reactor order and can hit that test before the fixture exists.
-        run: make install_no_tests
-
-      - name: Build, test, and publish snapshot to GitHub Packages
-        env:
-          GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: make deploy_github
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker images
-        run: make docker
-
-      - name: Compute short SHA
-        id: short-sha
-        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Publish Javadoc + OpenAPI spec to apidocs.namazustudios.com
-        # main sits at the same -SNAPSHOT version between release-branch
-        # cuts, so unlike an rc/release tag's immutable prefix, this would
-        # just overwrite the same path on every push. Append the short SHA
-        # so each snapshot build gets its own prefix instead of clobbering
-        # the last one.
-        uses: ./.github/actions/publish-docs
-        with:
-          version: ${{ steps.build-setup.outputs.maven-version }}-${{ steps.short-sha.outputs.sha }}
-          aws-access-key-id: ${{ secrets.APIDOCS_S3_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.APIDOCS_S3_SECRET_ACCESS_KEY }}
-          cloudfront-distribution-id: E30XJUM7BR8918
+    uses: ./.github/workflows/complete-build.yml
+    with:
+      publish-packages: ${{ github.ref == 'refs/heads/main' }}
+    secrets: inherit

--- a/.github/workflows/release-branch-push.yml
+++ b/.github/workflows/release-branch-push.yml
@@ -4,9 +4,11 @@ name: Release Branch Auto-Bump
 # first RC cut (version has an -rc-N suffix), every non-bot push auto-bumps
 # to the next rc and tags it -- the resulting tag push is what actually
 # triggers tag-publish.yml to build/test/publish. If no RC has been cut yet
-# (branch still sitting at a plain -SNAPSHOT), this just builds+tests as a
-# sanity check; cutting the first RC is a deliberate, separate manual action
-# (cut-rc.yml), never automatic.
+# (branch still sitting at a plain -SNAPSHOT), the build job below runs the
+# same complete build+test+docker+javadoc publish every other branch gets
+# (via complete-build.yml) as a sanity check and to keep its published
+# snapshot docs current; cutting the first RC is a deliberate, separate
+# manual action (cut-rc.yml), never automatic.
 #
 # The `[ci skip]` guard below is required, not optional: this workflow's own
 # bump commit is itself a push to release/*, so without the guard every bump
@@ -24,6 +26,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    outputs:
+      rc-cut: ${{ steps.check.outputs.rc-cut }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,13 +37,16 @@ jobs:
       - name: Build setup
         uses: ./.github/actions/build-setup
 
-      - name: Bump RC or build-only
+      - name: Bump RC or flag build-only
+        id: check
         run: |
           set -euo pipefail
           CURRENT=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "Current version: $CURRENT"
 
           if [[ "$CURRENT" == *-rc-* ]]; then
+            echo "rc-cut=true" >> "$GITHUB_OUTPUT"
+
             NEXT=$(.github/scripts/compute-version.sh bump-rc "$CURRENT")
             echo "Bumping $CURRENT -> $NEXT"
 
@@ -52,7 +59,12 @@ jobs:
             git push origin "HEAD:${GITHUB_REF_NAME}"
             git push origin "refs/tags/$NEXT"
           else
-            echo "No RC cut yet on '$CURRENT' -- building only, nothing to publish."
-            make install_no_tests
-            make build
+            echo "rc-cut=false" >> "$GITHUB_OUTPUT"
+            echo "No RC cut yet on '$CURRENT' -- building/testing/publishing only, nothing tagged."
           fi
+
+  build:
+    needs: bump
+    if: needs.bump.outputs.rc-cut == 'false'
+    uses: ./.github/workflows/complete-build.yml
+    secrets: inherit

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -111,11 +111,13 @@ jobs:
       - name: Build and push Docker images
         run: make docker
 
-      - name: Publish Javadoc + OpenAPI spec to gh-pages
+      - name: Publish Javadoc + OpenAPI spec to apidocs.namazustudios.com
         uses: ./.github/actions/publish-docs
         with:
           version: ${{ needs.guard.outputs.version }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          aws-access-key-id: ${{ secrets.APIDOCS_S3_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.APIDOCS_S3_SECRET_ACCESS_KEY }}
+          cloudfront-distribution-id: E30XJUM7BR8918
 
       - name: Create GitHub Release
         if: needs.guard.outputs.is_release == 'true'


### PR DESCRIPTION
## Summary
- Extracts the build/test + Docker build-push + Javadoc/OpenAPI publish steps out of `main-build.yml` into a reusable `workflow_call` workflow, `complete-build.yml`.
- `main-build.yml` (renamed "Branch Build") now triggers on `branches: ['**', '!release/**']` instead of just `main`, calling `complete-build.yml`.
- `release-branch-push.yml`'s pre-RC case (ordinary pushes to a `release/*` branch before its first RC is cut) now also calls `complete-build.yml` instead of just building -- so it gets docker+javadoc publish too.
- Every branch's build/test step now attempts a Central-only snapshot deploy (`make deploy`, GPG-signed) rather than a plain `install`. Central rejects/ignores `-SNAPSHOT` uploads and nothing ends up published there, but running the real sign+deploy pipeline catches signing/packaging failures a plain install wouldn't.

## Scope decision
GitHub Packages publishing stays **main-only**, gated by a new `publish-packages` input on `complete-build.yml` (`${{ github.ref == 'refs/heads/main' }}`). Unlike the Central attempt (a no-op for SNAPSHOTs), GitHub Packages actually publishes -- every branch shares the same reactor `-SNAPSHOT` version, so publishing packages from every branch push would have them overwrite each other's coordinates. main runs `make deploy_central` (both Central + GitHub Packages); every other branch runs `make deploy` (Central-only, no-op). Build, javadoc publish, and docker publish run on every branch as intended.

## Cost/exposure (confirmed intended)
Every push to every branch now runs the full test suite, attempts a GPG-signed Central deploy, builds/pushes multi-arch Docker images publicly (Docker Hub `elementalcomputing/*` + GHCR), and publishes Javadoc/OpenAPI to `apidocs.namazustudios.com/elements/` (tagged by version+short-SHA, so no collisions). **Confirmed this breadth is desired** -- S3 lifecycle rules (e.g. transition to Glacier after N days) are being configured separately to manage the growing set of published docs. Note the root `index.html` this generates lists every published version-prefix via `s3api list-objects-v2`; a Glacier transition doesn't remove an entry from that listing, only expiration/deletion would -- worth keeping in mind when tuning the lifecycle policy if a self-pruning index matters.

## Depends on
Stacked on #26 (S3/CloudFront `publish-docs`) -- this PR's base branch is `feature/publish-apidocs-to-s3`, not `main`. Merge #26 first, then retarget/merge this one.

## Test plan
- [x] YAML syntax validated for all changed/new files
- [ ] Can't run these workflows from this session (no Actions access) -- first real run happens on next push after merge