### PR TITLE
Fix: add missing profile-limit fields to CreateApplicationRequest/UpdateApplicationRequest

### DIFF
--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/application/CreateApplicationRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/application/CreateApplicationRequest.java
@@ -3,6 +3,7 @@ package dev.getelements.elements.sdk.model.application;
 import dev.getelements.elements.sdk.model.Constants;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.io.Serializable;
@@ -24,6 +25,25 @@ public class CreateApplicationRequest implements Serializable {
     private String description;
 
     private Map<String, Object> attributes;
+
+    @Min(0)
+    @Schema(description = "The maximum number of profiles a user may create for this application. " +
+            "If unspecified, defaults to 1.")
+    private Integer maxProfiles;
+
+    @Schema(description = "Whether a user's primary profile for this application should be created " +
+            "automatically when the user is created. If unspecified, defaults to true.")
+    private Boolean autoCreateProfile;
+
+    @Schema(description = "If true, a user cannot edit their own profile picture for this application via the " +
+            "REST API -- it must be set by backend/Element code instead. If false (the default), users may edit " +
+            "their own profile picture via the REST API.")
+    private Boolean authoritativeProfilePicture;
+
+    @Schema(description = "A Java regular expression that a profile's display name must match for this " +
+            "application, or the profile create/update is rejected. If blank or unspecified, no additional " +
+            "check is performed.")
+    private String displayNameRegex;
 
     /**
      * Returns the application description.
@@ -71,5 +91,82 @@ public class CreateApplicationRequest implements Serializable {
      */
     public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
+    }
+
+    /**
+     * Gets the maximum number of profiles a user may create for this application. If null (unspecified), the
+     * server treats this as {@code 1}.
+     *
+     * @return the maximum number of profiles per user, or null if unspecified
+     */
+    public Integer getMaxProfiles() {
+        return maxProfiles;
+    }
+
+    /**
+     * Sets the maximum number of profiles a user may create for this application.
+     *
+     * @param maxProfiles the maximum number of profiles per user
+     */
+    public void setMaxProfiles(Integer maxProfiles) {
+        this.maxProfiles = maxProfiles;
+    }
+
+    /**
+     * Gets whether a user's primary profile for this application should be created automatically when the user
+     * is created. If null (unspecified), the server treats this as {@code true}.
+     *
+     * @return whether to automatically create a primary profile, or null if unspecified
+     */
+    public Boolean getAutoCreateProfile() {
+        return autoCreateProfile;
+    }
+
+    /**
+     * Sets whether a user's primary profile for this application should be created automatically when the user
+     * is created.
+     *
+     * @param autoCreateProfile whether to automatically create a primary profile
+     */
+    public void setAutoCreateProfile(Boolean autoCreateProfile) {
+        this.autoCreateProfile = autoCreateProfile;
+    }
+
+    /**
+     * Gets whether a user can edit their own profile picture for this application via the REST API. If null
+     * (unspecified), the server treats this as {@code false}.
+     *
+     * @return whether the profile picture is authoritative (backend-only), or null if unspecified
+     */
+    public Boolean getAuthoritativeProfilePicture() {
+        return authoritativeProfilePicture;
+    }
+
+    /**
+     * Sets whether a user can edit their own profile picture for this application via the REST API.
+     *
+     * @param authoritativeProfilePicture whether the profile picture is authoritative (backend-only)
+     */
+    public void setAuthoritativeProfilePicture(Boolean authoritativeProfilePicture) {
+        this.authoritativeProfilePicture = authoritativeProfilePicture;
+    }
+
+    /**
+     * Gets the Java regular expression a profile's display name must match for this application. If null or
+     * blank, no additional check is performed.
+     *
+     * @return the display name regular expression, or null if unspecified
+     */
+    public String getDisplayNameRegex() {
+        return displayNameRegex;
+    }
+
+    /**
+     * Sets the Java regular expression a profile's display name must match for this application.
+     *
+     * @param displayNameRegex the display name regular expression
+     */
+    public void setDisplayNameRegex(String displayNameRegex) {
+        this.displayNameRegex = displayNameRegex;
     }
 }

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/application/UpdateApplicationRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/application/UpdateApplicationRequest.java
@@ -3,6 +3,7 @@ package dev.getelements.elements.sdk.model.application;
 import dev.getelements.elements.sdk.model.Constants;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.util.Map;
@@ -21,6 +22,25 @@ public class UpdateApplicationRequest {
     private String description;
 
     private Map<String, Object> attributes;
+
+    @Min(0)
+    @Schema(description = "The maximum number of profiles a user may create for this application. " +
+            "If unspecified, defaults to 1.")
+    private Integer maxProfiles;
+
+    @Schema(description = "Whether a user's primary profile for this application should be created " +
+            "automatically when the user is created. If unspecified, defaults to true.")
+    private Boolean autoCreateProfile;
+
+    @Schema(description = "If true, a user cannot edit their own profile picture for this application via the " +
+            "REST API -- it must be set by backend/Element code instead. If false (the default), users may edit " +
+            "their own profile picture via the REST API.")
+    private Boolean authoritativeProfilePicture;
+
+    @Schema(description = "A Java regular expression that a profile's display name must match for this " +
+            "application, or the profile create/update is rejected. If blank or unspecified, no additional " +
+            "check is performed.")
+    private String displayNameRegex;
 
     /**
      * Returns the application description.
@@ -68,5 +88,82 @@ public class UpdateApplicationRequest {
      */
     public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
+    }
+
+    /**
+     * Gets the maximum number of profiles a user may create for this application. If null (unspecified), the
+     * server treats this as {@code 1}.
+     *
+     * @return the maximum number of profiles per user, or null if unspecified
+     */
+    public Integer getMaxProfiles() {
+        return maxProfiles;
+    }
+
+    /**
+     * Sets the maximum number of profiles a user may create for this application.
+     *
+     * @param maxProfiles the maximum number of profiles per user
+     */
+    public void setMaxProfiles(Integer maxProfiles) {
+        this.maxProfiles = maxProfiles;
+    }
+
+    /**
+     * Gets whether a user's primary profile for this application should be created automatically when the user
+     * is created. If null (unspecified), the server treats this as {@code true}.
+     *
+     * @return whether to automatically create a primary profile, or null if unspecified
+     */
+    public Boolean getAutoCreateProfile() {
+        return autoCreateProfile;
+    }
+
+    /**
+     * Sets whether a user's primary profile for this application should be created automatically when the user
+     * is created.
+     *
+     * @param autoCreateProfile whether to automatically create a primary profile
+     */
+    public void setAutoCreateProfile(Boolean autoCreateProfile) {
+        this.autoCreateProfile = autoCreateProfile;
+    }
+
+    /**
+     * Gets whether a user can edit their own profile picture for this application via the REST API. If null
+     * (unspecified), the server treats this as {@code false}.
+     *
+     * @return whether the profile picture is authoritative (backend-only), or null if unspecified
+     */
+    public Boolean getAuthoritativeProfilePicture() {
+        return authoritativeProfilePicture;
+    }
+
+    /**
+     * Sets whether a user can edit their own profile picture for this application via the REST API.
+     *
+     * @param authoritativeProfilePicture whether the profile picture is authoritative (backend-only)
+     */
+    public void setAuthoritativeProfilePicture(Boolean authoritativeProfilePicture) {
+        this.authoritativeProfilePicture = authoritativeProfilePicture;
+    }
+
+    /**
+     * Gets the Java regular expression a profile's display name must match for this application. If null or
+     * blank, no additional check is performed.
+     *
+     * @return the display name regular expression, or null if unspecified
+     */
+    public String getDisplayNameRegex() {
+        return displayNameRegex;
+    }
+
+    /**
+     * Sets the Java regular expression a profile's display name must match for this application.
+     *
+     * @param displayNameRegex the display name regular expression
+     */
+    public void setDisplayNameRegex(String displayNameRegex) {
+        this.displayNameRegex = displayNameRegex;
     }
 }


### PR DESCRIPTION
## Summary

Fixes #33. Issue #11's per-application profile limits (PR #19) landed `maxProfiles`, `autoCreateProfile`, `authoritativeProfilePicture`, and `displayNameRegex` on `Application` and fully wired Mongo persistence/enforcement downstream, but never added these fields to the two REST-facing request DTOs -- so Jackson rejected them (`Unrecognized field "maxProfiles"`) before Dozer/Mongo ever saw the request body. The admin web UI already sends these fields on application create/update, which is what's triggering the reports against `3.9.0-rc-1`.

- Adds the four fields (with getters/setters/`@Schema` docs, mirroring `Application.java` exactly) to `CreateApplicationRequest` and `UpdateApplicationRequest`.
- No other layer needs changes -- `SuperUserApplicationService`'s Dozer mapping is by field name, and `MongoApplicationDao.createApplication`/`updateApplication` already apply defaults and persist all four fields correctly.

Branched from `main`; will be merged onto the release branch manually.

Also filed #32 for a separate, pre-existing (not-a-3.9-regression) Guice binding gap reported against the same RC build -- no fix included here, tracked separately.

## Test plan

- [x] `mvn -pl sdk-model,rest-api,service,mongo-dao -am install` -- builds clean, existing tests pass
- [x] Standalone Jackson deserialization check confirms both DTOs now accept `maxProfiles`/`autoCreateProfile`/`authoritativeProfilePicture`/`displayNameRegex`