### PR TITLE
Wire GuiceOptions into GuiceSpiModule, with tests

### DIFF
--- a/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/GuiceSpiModule.java
+++ b/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/GuiceSpiModule.java
@@ -1,21 +1,29 @@
 package dev.getelements.elements.sdk.spi.guice;
 
+import com.google.inject.Binding;
 import com.google.inject.Key;
+import com.google.inject.Module;
 import com.google.inject.PrivateModule;
+import com.google.inject.spi.Elements;
 import dev.getelements.elements.sdk.Element;
 import dev.getelements.elements.sdk.ElementRegistry;
 import dev.getelements.elements.sdk.annotation.ElementServiceImplementation.DefaultImplementation;
+import dev.getelements.elements.sdk.exception.SdkException;
 import dev.getelements.elements.sdk.spi.guice.record.GuiceElementModuleRecord;
+import dev.getelements.elements.sdk.spi.guice.record.GuiceOptionsRecord;
 import dev.getelements.elements.sdk.record.ElementRecord;
 import dev.getelements.elements.sdk.record.ElementServiceRecord;
 import jakarta.inject.Provider;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.inject.name.Names.bindProperties;
 import static com.google.inject.name.Names.named;
+import static dev.getelements.elements.sdk.spi.guice.annotations.GuiceOptions.LoadingStrategy.GUICE_MODULE_ONLY;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Used to bind services.
@@ -26,11 +34,34 @@ public class GuiceSpiModule extends PrivateModule {
 
     private final ElementRecord elementRecord;
 
+    private final GuiceOptionsRecord options;
+
+    private final List<Module> guiceElementModules;
+
     public GuiceSpiModule(
             final ElementRegistry parent,
             final ElementRecord elementRecord) {
+
         this.parent = requireNonNull(parent, "parent");
         this.elementRecord = requireNonNull(elementRecord, "elementRecord");
+
+        final var elementPackage = elementRecord.definition().pkg();
+        this.options = GuiceOptionsRecord.fromPackage(elementPackage);
+
+        this.guiceElementModules = GuiceElementModuleRecord
+                .fromPackage(elementPackage)
+                .map(GuiceElementModuleRecord::newModule)
+                .toList();
+
+        // Validated here, eagerly, rather than inside configure() -- Guice catches exceptions thrown from a
+        // module's configure() and folds them into its own CreationException alongside whatever other errors
+        // it collects (e.g. the very [Guice/ExposedButNotBound] error this is meant to preempt), so a throw from
+        // configure() never actually reaches the caller as a clean SdkException. Throwing here, before
+        // Guice.createInjector() is ever invoked, does.
+        if (options.strict()) {
+            validateDeferredKeysAreBound(elementPackage);
+        }
+
     }
 
     @Override
@@ -41,20 +72,31 @@ public class GuiceSpiModule extends PrivateModule {
         binder().requireExplicitBindings();
         bindProperties(binder(), attributes);
 
-        final var targets  = new HashSet<Class<?>>();
-        final var ownKeys  = new HashSet<Key<?>>();
+        final var targets = new HashSet<Class<?>>();
+        final var ownKeys = new HashSet<Key<?>>();
 
-        elementRecord
-                .services()
-                .stream()
-                .filter(esr -> DefaultImplementation.class.equals(esr.implementation().type()))
-                .forEach(esr -> exposeService(ownKeys, esr));
+        if (options.strategy() == GUICE_MODULE_ONLY) {
 
-        elementRecord
-                .services()
-                .stream()
-                .filter(esr -> !DefaultImplementation.class.equals(esr.implementation().type()))
-                .forEach(esr -> bindAndExposeService(targets, ownKeys, esr));
+            // Defers exclusively to the installed @GuiceElementModule(s); ElementService#implementation() is
+            // ignored entirely (per GuiceOptions' documented contract) to avoid double-defining bindings the
+            // author's own module already supplies.
+            elementRecord.services().forEach(esr -> exposeService(ownKeys, esr));
+
+        } else {
+
+            elementRecord
+                    .services()
+                    .stream()
+                    .filter(esr -> DefaultImplementation.class.equals(esr.implementation().type()))
+                    .forEach(esr -> exposeService(ownKeys, esr));
+
+            elementRecord
+                    .services()
+                    .stream()
+                    .filter(esr -> !DefaultImplementation.class.equals(esr.implementation().type()))
+                    .forEach(esr -> bindAndExposeService(targets, ownKeys, esr));
+
+        }
 
         elementRecord
                 .dependencies()
@@ -62,12 +104,78 @@ public class GuiceSpiModule extends PrivateModule {
                 .flatMap(dep -> dep.findDependencies(parent))
                 .forEach(element -> bindDependentElement(ownKeys, element));
 
-        final var elementPackage = elementRecord.definition().pkg();
+        guiceElementModules.forEach(this::install);
 
-        GuiceElementModuleRecord
-                .fromPackage(elementPackage)
-                .map(GuiceElementModuleRecord::newModule)
-                .forEach(this::install);
+    }
+
+    /**
+     * Computes the set of exported keys that this module will {@code expose()} without binding itself -- i.e. the
+     * ones relying on something else (an installed {@code @GuiceElementModule}) to have bound them.
+     */
+    private Set<Key<?>> computeDeferredKeys() {
+
+        final var deferredKeys = new HashSet<Key<?>>();
+
+        if (options.strategy() == GUICE_MODULE_ONLY) {
+            elementRecord.services().forEach(esr -> deferredKeys.addAll(exportedKeys(esr)));
+        } else {
+            elementRecord
+                    .services()
+                    .stream()
+                    .filter(esr -> DefaultImplementation.class.equals(esr.implementation().type()))
+                    .forEach(esr -> deferredKeys.addAll(exportedKeys(esr)));
+        }
+
+        return deferredKeys;
+
+    }
+
+    /**
+     * With {@link GuiceOptionsRecord#strict()} enabled, verifies every deferred key (see {@link #computeDeferredKeys()})
+     * is actually bound by one of the installed {@code @GuiceElementModule}s, raising a clear, actionable error at
+     * load time instead of letting Guice's generic {@code [Guice/ExposedButNotBound]} error surface later at
+     * injector-creation time.
+     */
+    private void validateDeferredKeysAreBound(final Package elementPackage) {
+
+        final var deferredKeys = computeDeferredKeys();
+
+        if (deferredKeys.isEmpty()) {
+            return;
+        }
+
+        final var boundKeys = Elements
+                .getElements(guiceElementModules)
+                .stream()
+                .filter(element -> element instanceof Binding<?>)
+                .map(element -> ((Binding<?>) element).getKey())
+                .collect(toSet());
+
+        final var unbound = deferredKeys
+                .stream()
+                .filter(key -> !boundKeys.contains(key))
+                .toList();
+
+        if (!unbound.isEmpty()) {
+            throw new SdkException(
+                    "Element package '" + elementPackage.getName() + "' declares GuiceOptions(strategy=" +
+                    options.strategy() + ", strict=true), but the following exported service(s) are not bound " +
+                    "by any installed @GuiceElementModule: " + unbound + ". Provide an " +
+                    "@ElementServiceImplementation, or add a @GuiceElementModule that explicitly binds them."
+            );
+        }
+
+    }
+
+    private Set<Key<?>> exportedKeys(final ElementServiceRecord elementServiceRecord) {
+
+        final var export = elementServiceRecord.export();
+
+        final var keys = export.isNamed()
+                ? export.exposed().stream().map(anInterface -> Key.get(anInterface, named(export.name())))
+                : export.exposed().stream().map(Key::get);
+
+        return keys.collect(toSet());
 
     }
 

--- a/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/annotations/GuiceOptions.java
+++ b/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/annotations/GuiceOptions.java
@@ -1,0 +1,60 @@
+package dev.getelements.elements.sdk.spi.guice.annotations;
+
+import dev.getelements.elements.sdk.annotation.ElementService;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static dev.getelements.elements.sdk.spi.guice.annotations.GuiceOptions.LoadingStrategy.LEGACY;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Adds options for the Guice loader SPI. This allows an element author control over how the module's loader works
+ * and enables/disable certain options making for easier loading.
+ *
+ * @since 3.9
+ */
+@Target(PACKAGE)
+@Retention(RUNTIME)
+public @interface GuiceOptions {
+
+    /**
+     * Specifies the loading strategy to be used by this element.
+     *
+     * @return the {@link LoadingStrategy}
+     */
+    LoadingStrategy strategy() default LEGACY;
+
+    /**
+     * Sets strict validation rules, attempting to raise as many errors at load time as possible. Depends on the
+     * loading strategy.
+     *
+     * @return true, if strict mode is enabled
+     */
+    boolean strict() default false;
+
+    /**
+     * Specifies how the Guice based SPI loads the Element. This here to reduce some of the friction and fagile nature
+     * of the original legacy loading system which uses a combination of annotations to expose servies. Guice largely
+     * replaces that, but will often times conflict with itself wasting a lot cycles in the process.
+     */
+    enum LoadingStrategy {
+
+        /**
+         * Legacy loader which preserves the 3.8 and prior behavior honoring all SDK annotations.
+         */
+        LEGACY,
+
+        /**
+         * Defers loading exclusively to all {@link GuiceElementModule}s, ignoring bindings that would otherwise be
+         * defined in the SDK annotations to avoid doubly defining them. It is still required to export services to
+         * other {@link dev.getelements.elements.sdk.Element}s using the {@link ElementService}. Note that with this
+         * strategy set, {@link ElementService#implementation()} is ignored.
+         */
+        GUICE_MODULE_ONLY
+
+    }
+
+}
+

--- a/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/record/GuiceOptionsRecord.java
+++ b/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/record/GuiceOptionsRecord.java
@@ -1,0 +1,35 @@
+package dev.getelements.elements.sdk.spi.guice.record;
+
+import dev.getelements.elements.sdk.spi.guice.annotations.GuiceOptions;
+
+import static dev.getelements.elements.sdk.spi.guice.annotations.GuiceOptions.LoadingStrategy.LEGACY;
+
+/**
+ * A record type for {@link GuiceOptions}, resolved from a {@link Package} with the {@link GuiceOptions} annotation
+ * defaulted to its documented defaults when the annotation is absent.
+ *
+ * @param strategy the {@link GuiceOptions.LoadingStrategy}
+ * @param strict whether strict validation is enabled
+ */
+public record GuiceOptionsRecord(GuiceOptions.LoadingStrategy strategy, boolean strict) {
+
+    /**
+     * The default options used when a package bears no {@link GuiceOptions} annotation.
+     */
+    public static final GuiceOptionsRecord DEFAULT = new GuiceOptionsRecord(LEGACY, false);
+
+    /**
+     * Resolves the {@link GuiceOptionsRecord} for the supplied {@link Package}, falling back to {@link #DEFAULT}
+     * if the package bears no {@link GuiceOptions} annotation.
+     *
+     * @param aPackage the {@link Package} which may bear the {@link GuiceOptions} annotation
+     * @return the resolved {@link GuiceOptionsRecord}
+     */
+    public static GuiceOptionsRecord fromPackage(final Package aPackage) {
+        final var guiceOptions = aPackage.getAnnotation(GuiceOptions.class);
+        return guiceOptions == null
+                ? DEFAULT
+                : new GuiceOptionsRecord(guiceOptions.strategy(), guiceOptions.strict());
+    }
+
+}

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/GuiceSpiModuleLoadingStrategyTest.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/GuiceSpiModuleLoadingStrategyTest.java
@@ -1,0 +1,79 @@
+package dev.getelements.elements.sdk.spi.guice;
+
+import com.google.inject.Guice;
+import dev.getelements.elements.sdk.exception.SdkException;
+import dev.getelements.elements.sdk.spi.DefaultElementLoaderFactory;
+import dev.getelements.elements.sdk.spi.RootElementRegistry;
+import dev.getelements.elements.sdk.spi.guice.fixture.guicemoduleonly.SharedTestService;
+import dev.getelements.elements.sdk.spi.guice.fixture.legacy.LegacyTestService;
+import dev.getelements.elements.sdk.spi.guice.fixture.strict.UnboundTestService;
+import dev.getelements.elements.sdk.util.SimpleAttributes;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+/**
+ * Proves both {@code GuiceOptions.LoadingStrategy} code paths through {@link GuiceSpiModule}: the default
+ * {@code LEGACY} behavior is unchanged (issue #32 must not regress existing Elements), and the opt-in
+ * {@code GUICE_MODULE_ONLY} strategy lets a third-party Element author defer entirely to their own
+ * {@code @GuiceElementModule}, avoiding the exact {@code [Guice/ExposedButNotBound]} crash reported in #32.
+ */
+public class GuiceSpiModuleLoadingStrategyTest {
+
+    private final DefaultElementLoaderFactory factory = new DefaultElementLoaderFactory();
+
+    @Test
+    public void legacyStrategyBindsAndExposesAnnotationDerivedImplementation() {
+
+        final var elementRecord = factory.getElementRecordFromPackage(
+                new SimpleAttributes(Map.of()),
+                LegacyTestService.class.getPackage()
+        );
+
+        final var injector = Guice.createInjector(new GuiceSpiModule(new RootElementRegistry(), elementRecord));
+        final var service = injector.getInstance(LegacyTestService.class);
+
+        assertEquals(service.get(), "legacy");
+
+    }
+
+    @Test
+    public void guiceModuleOnlyStrategyDefersEntirelyToTheInstalledModule() {
+
+        final var elementRecord = factory.getElementRecordFromPackage(
+                new SimpleAttributes(Map.of()),
+                SharedTestService.class.getPackage()
+        );
+
+        final var injector = Guice.createInjector(new GuiceSpiModule(new RootElementRegistry(), elementRecord));
+        final var service = injector.getInstance(SharedTestService.class);
+
+        // If the annotation-derived AnnotationDerivedImpl binding had not been skipped, Guice would have thrown
+        // a duplicate-binding CreationException before this point (two bind() calls for the same key).
+        assertEquals(service.get(), "guice-module-derived");
+
+    }
+
+    @Test
+    public void strictModeRaisesAClearErrorForAnUnboundExportedService() {
+
+        final var elementRecord = factory.getElementRecordFromPackage(
+                new SimpleAttributes(Map.of()),
+                UnboundTestService.class.getPackage()
+        );
+
+        // Expecting SdkException (thrown by GuiceSpiModule's own strict-mode validation, during configure())
+        // rather than Guice's generic CreationException (thrown later, at injector-creation time) proves the
+        // new validation actually ran and pre-empted the default failure mode.
+        final var exception = expectThrows(SdkException.class, () ->
+                Guice.createInjector(new GuiceSpiModule(new RootElementRegistry(), elementRecord)));
+
+        assertTrue(exception.getMessage().contains("UnboundTestService"));
+
+    }
+
+}

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/AnnotationDerivedImpl.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/AnnotationDerivedImpl.java
@@ -1,0 +1,21 @@
+package dev.getelements.elements.sdk.spi.guice.fixture.guicemoduleonly;
+
+import dev.getelements.elements.sdk.annotation.ElementServiceExport;
+import dev.getelements.elements.sdk.annotation.ElementServiceImplementation;
+
+/**
+ * Annotated as though it were the implementation the legacy annotation-driven scan would auto-bind. Under
+ * {@code GuiceOptions.LoadingStrategy.GUICE_MODULE_ONLY} this must be ignored entirely in favor of whatever
+ * {@link GuiceModuleOnlyTestFixtureModule} binds -- if it were not ignored, installing both would conflict
+ * (Guice does not allow the same key to be bound twice).
+ */
+@ElementServiceExport(SharedTestService.class)
+@ElementServiceImplementation
+public class AnnotationDerivedImpl implements SharedTestService {
+
+    @Override
+    public String get() {
+        return "annotation-derived";
+    }
+
+}

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/GuiceModuleDerivedImpl.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/GuiceModuleDerivedImpl.java
@@ -1,0 +1,10 @@
+package dev.getelements.elements.sdk.spi.guice.fixture.guicemoduleonly;
+
+public class GuiceModuleDerivedImpl implements SharedTestService {
+
+    @Override
+    public String get() {
+        return "guice-module-derived";
+    }
+
+}

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/GuiceModuleOnlyTestFixtureModule.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/GuiceModuleOnlyTestFixtureModule.java
@@ -1,0 +1,13 @@
+package dev.getelements.elements.sdk.spi.guice.fixture.guicemoduleonly;
+
+import com.google.inject.AbstractModule;
+
+public class GuiceModuleOnlyTestFixtureModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(GuiceModuleDerivedImpl.class);
+        bind(SharedTestService.class).to(GuiceModuleDerivedImpl.class);
+    }
+
+}

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/SharedTestService.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/SharedTestService.java
@@ -1,0 +1,7 @@
+package dev.getelements.elements.sdk.spi.guice.fixture.guicemoduleonly;
+
+public interface SharedTestService {
+
+    String get();
+
+}

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/package-info.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/guicemoduleonly/package-info.java
@@ -1,0 +1,8 @@
+@ElementDefinition
+@GuiceOptions(strategy = GuiceOptions.LoadingStrategy.GUICE_MODULE_ONLY)
+@GuiceElementModule(GuiceModuleOnlyTestFixtureModule.class)
+package dev.getelements.elements.sdk.spi.guice.fixture.guicemoduleonly;
+
+import dev.getelements.elements.sdk.annotation.ElementDefinition;
+import dev.getelements.elements.sdk.spi.guice.annotations.GuiceElementModule;
+import dev.getelements.elements.sdk.spi.guice.annotations.GuiceOptions;

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/legacy/LegacyTestService.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/legacy/LegacyTestService.java
@@ -1,0 +1,7 @@
+package dev.getelements.elements.sdk.spi.guice.fixture.legacy;
+
+public interface LegacyTestService {
+
+    String get();
+
+}

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/legacy/LegacyTestServiceImpl.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/legacy/LegacyTestServiceImpl.java
@@ -1,0 +1,15 @@
+package dev.getelements.elements.sdk.spi.guice.fixture.legacy;
+
+import dev.getelements.elements.sdk.annotation.ElementServiceExport;
+import dev.getelements.elements.sdk.annotation.ElementServiceImplementation;
+
+@ElementServiceExport(LegacyTestService.class)
+@ElementServiceImplementation
+public class LegacyTestServiceImpl implements LegacyTestService {
+
+    @Override
+    public String get() {
+        return "legacy";
+    }
+
+}

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/legacy/package-info.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/legacy/package-info.java
@@ -1,0 +1,4 @@
+@ElementDefinition
+package dev.getelements.elements.sdk.spi.guice.fixture.legacy;
+
+import dev.getelements.elements.sdk.annotation.ElementDefinition;

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/strict/UnboundTestService.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/strict/UnboundTestService.java
@@ -1,0 +1,14 @@
+package dev.getelements.elements.sdk.spi.guice.fixture.strict;
+
+import dev.getelements.elements.sdk.annotation.ElementServiceExport;
+
+/**
+ * Exported but deliberately never bound anywhere (no {@code @ElementServiceImplementation}, no
+ * {@code @GuiceElementModule} on the containing package) -- exercises {@code GuiceOptions.strict()}'s validation.
+ */
+@ElementServiceExport
+public interface UnboundTestService {
+
+    String get();
+
+}

--- a/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/strict/package-info.java
+++ b/sdk-spi-guice/src/test/java/dev/getelements/elements/sdk/spi/guice/fixture/strict/package-info.java
@@ -1,0 +1,6 @@
+@ElementDefinition
+@GuiceOptions(strategy = GuiceOptions.LoadingStrategy.GUICE_MODULE_ONLY, strict = true)
+package dev.getelements.elements.sdk.spi.guice.fixture.strict;
+
+import dev.getelements.elements.sdk.annotation.ElementDefinition;
+import dev.getelements.elements.sdk.spi.guice.annotations.GuiceOptions;


### PR DESCRIPTION
## Summary

Relates to #32. `GuiceOptions` (package-level, `@since 3.9`) existed on disk but `GuiceSpiModule` never read it -- this wires it up as the opt-in escape hatch it was designed to be, for third-party Element authors who hit the exact `[Guice/ExposedButNotBound]` crash reported in #32 (an exported service with no locally-discovered implementation that nothing else happens to bind).

- **`LEGACY`** (default) is byte-for-byte unchanged: the existing two-pass bind/expose split, verbatim. Every element that doesn't declare `@GuiceOptions` (100% of elements today) sees zero behavior change.
- **`GUICE_MODULE_ONLY`** defers entirely to the author's own `@GuiceElementModule`(s): every exported service is expose-only, `ElementService#implementation()` is ignored (per `GuiceOptions`' own documented contract), avoiding double-defined bindings when an author's module and the SDK's own annotation scanning would otherwise both try to bind the same key.
- **`strict`** validates that every key deferred to a `@GuiceElementModule` is actually bound by one, *before* `Guice.createInjector()` ever runs -- a clear `SdkException` naming the exact service, instead of Guice's generic `[Guice/ExposedButNotBound]` error. This has to happen in the constructor rather than `configure()`: Guice folds exceptions thrown from `configure()` into its own `CreationException` alongside whatever other errors it collects, so throwing there never actually reaches the caller as a clean exception -- confirmed by test failure while iterating.

New `GuiceSpiModuleLoadingStrategyTest` exercises all three paths against real annotated fixture packages (scanned the same way the production loader builds an `ElementRecord`, not hand-built records).

**Not applied anywhere in this repo** -- confirmed out of scope, this is purely third-party-facing infrastructure. This repo's own #32 crash site (`sdk-service`'s `MatchmakingApplicationConfigurationService` and 8 siblings, which are bound only through the legacy `ScopedServicesModule`/`UnscopedServicesModule` path, not the SPI path this PR touches) is a separate, unrelated fix, not addressed here.

Branched from `main`.

## Test plan

- [x] `mvn -pl sdk-spi-guice test` -- new `GuiceSpiModuleLoadingStrategyTest` passes (all 3 scenarios: LEGACY unchanged, GUICE_MODULE_ONLY avoids the double-bind conflict, strict mode raises a clear error)
- [x] `mvn -pl sdk-spi,sdk-spi-shrinkwrap,sdk-test,sdk-spi-guice test` -- existing SPI/element-loading suites still pass unmodified
- [x] `mvn clean install -DskipTests -Dmaven.javadoc.skip=true` -- full tree builds clean