### PR TITLE
Add gated auto-create-profile support to OAuth2/OIDC login flows

### DIFF
--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcSessionRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcSessionRequest.java
@@ -22,6 +22,12 @@ public class OidcSessionRequest {
             "NOTE: This will not be run if a profileId is specified.")
     private String profileSelector;
 
+    @Schema(description = "The name or ID of an application whose primary profile should be attached to the " +
+            "session, auto-creating it (subject to the application's autoCreateProfile/maxProfiles settings) if " +
+            "it does not exist. Only used if profileId and profileSelector are not specified. If unspecified, " +
+            "the application encoded in the JWT's own claims (if any) is used instead, without auto-create.")
+    private String applicationNameOrId;
+
     /**
      * Returns the JWT to parse.
      *
@@ -76,17 +82,35 @@ public class OidcSessionRequest {
         this.profileSelector = profileSelector;
     }
 
+    /**
+     * Returns the name or ID of the application whose primary profile should be attached to the session.
+     *
+     * @return the application name or ID
+     */
+    public String getApplicationNameOrId() {
+        return applicationNameOrId;
+    }
+
+    /**
+     * Sets the name or ID of the application whose primary profile should be attached to the session.
+     *
+     * @param applicationNameOrId the application name or ID
+     */
+    public void setApplicationNameOrId(String applicationNameOrId) {
+        this.applicationNameOrId = applicationNameOrId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         OidcSessionRequest that = (OidcSessionRequest) o;
-        return Objects.equals(getJwt(), that.getJwt()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector());
+        return Objects.equals(getJwt(), that.getJwt()) && Objects.equals(getProfileId(), that.getProfileId()) && Objects.equals(getProfileSelector(), that.getProfileSelector()) && Objects.equals(getApplicationNameOrId(), that.getApplicationNameOrId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getJwt(), getProfileId(), getProfileSelector());
+        return Objects.hash(getJwt(), getProfileId(), getProfileSelector(), getApplicationNameOrId());
     }
 
     @Override
@@ -95,6 +119,7 @@ public class OidcSessionRequest {
                 "jwt='" + jwt + '\'' +
                 ", profileId='" + profileId + '\'' +
                 ", profileSelector='" + profileSelector + '\'' +
+                ", applicationNameOrId='" + applicationNameOrId + '\'' +
                 '}';
     }
 

--- a/service-test/src/test/java/dev/getelements/elements/service/OAuth2AuthServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OAuth2AuthServiceTest.java
@@ -8,11 +8,13 @@ import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.OAuth2AuthSchemeDao;
 import dev.getelements.elements.sdk.dao.ProfileDao;
 import dev.getelements.elements.sdk.dao.SessionDao;
+import dev.getelements.elements.sdk.model.application.Application;
 import dev.getelements.elements.sdk.model.auth.BodyType;
 import dev.getelements.elements.sdk.model.auth.HttpMethod;
 import dev.getelements.elements.sdk.model.auth.OAuth2AuthScheme;
 import dev.getelements.elements.sdk.model.auth.OAuth2RequestKeyValue;
 import dev.getelements.elements.sdk.model.exception.auth.AuthValidationException;
+import dev.getelements.elements.sdk.model.profile.Profile;
 import dev.getelements.elements.sdk.model.session.OAuth2SessionRequest;
 import dev.getelements.elements.sdk.model.session.Session;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
@@ -56,6 +58,12 @@ public class OAuth2AuthServiceTest {
 
     @Inject
     private SessionDao sessionDao;
+
+    @Inject
+    private ApplicationDao applicationDao;
+
+    @Inject
+    private ProfileDao profileDao;
 
     @BeforeMethod
     public void setup() {
@@ -134,6 +142,97 @@ public class OAuth2AuthServiceTest {
             // should not create session on failure
             verify(sessionDao, never()).create(any(Session.class));
         }
+    }
+
+    @Test
+    public void testAutoCreatesPrimaryProfileWhenConfigured() throws Exception {
+
+        final var scheme = baseScheme("steam_game1");
+        scheme.setMethod(HttpMethod.GET);
+        scheme.setResponseIdMapping("steamid");
+        scheme.setValidStatusCodes(List.of(200));
+
+        final var req = baseReq("scheme-auto", Map.of(), Map.of());
+        req.setApplicationNameOrId("app-1");
+
+        when(schemeDao.getAuthScheme(req.getSchemeId())).thenReturn(scheme);
+
+        final var body = "{\"steamid\":\"abc\"}";
+        when(invoker.execute(eq(scheme), any(ResolvedRequest.class)))
+                .thenReturn(new ParsedResponse(200, body, MAPPER.readTree(body)));
+
+        final var user = new User();
+        user.setId("user-1");
+
+        @SuppressWarnings("unchecked")
+        final BiFunction<String, String, User> userMapper = mock(BiFunction.class);
+        when(userMapper.apply(anyString(), anyString())).thenReturn(user);
+
+        final var application = new Application();
+        application.setId("app-1");
+        application.setAutoCreateProfile(true);
+        application.setMaxProfiles(1);
+
+        when(applicationDao.findApplication("app-1")).thenReturn(java.util.Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-1", "app-1")).thenReturn(java.util.Optional.empty());
+
+        final var createdProfile = new Profile();
+        createdProfile.setId("profile-1");
+        when(profileDao.createSlottedProfile(any(Profile.class), anyMap())).thenReturn(createdProfile);
+
+        ops.createOrUpdateUserWithToken(req, userMapper);
+
+        final var profileCaptor = ArgumentCaptor.forClass(Profile.class);
+        verify(profileDao).createSlottedProfile(profileCaptor.capture(), anyMap());
+        assertEquals(profileCaptor.getValue().getUser(), user);
+        assertEquals(profileCaptor.getValue().getApplication(), application);
+
+        final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertEquals(sessionCaptor.getValue().getProfile(), createdProfile);
+        assertEquals(sessionCaptor.getValue().getApplication(), application);
+    }
+
+    @Test
+    public void testDoesNotAutoCreatePrimaryProfileWhenNotConfigured() throws Exception {
+
+        final var scheme = baseScheme("steam_game1");
+        scheme.setMethod(HttpMethod.GET);
+        scheme.setResponseIdMapping("steamid");
+        scheme.setValidStatusCodes(List.of(200));
+
+        final var req = baseReq("scheme-auto-off", Map.of(), Map.of());
+        req.setApplicationNameOrId("app-2");
+
+        when(schemeDao.getAuthScheme(req.getSchemeId())).thenReturn(scheme);
+
+        final var body = "{\"steamid\":\"abc\"}";
+        when(invoker.execute(eq(scheme), any(ResolvedRequest.class)))
+                .thenReturn(new ParsedResponse(200, body, MAPPER.readTree(body)));
+
+        final var user = new User();
+        user.setId("user-2");
+
+        @SuppressWarnings("unchecked")
+        final BiFunction<String, String, User> userMapper = mock(BiFunction.class);
+        when(userMapper.apply(anyString(), anyString())).thenReturn(user);
+
+        final var application = new Application();
+        application.setId("app-2");
+        application.setAutoCreateProfile(false);
+        application.setMaxProfiles(1);
+
+        when(applicationDao.findApplication("app-2")).thenReturn(java.util.Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-2", "app-2")).thenReturn(java.util.Optional.empty());
+
+        ops.createOrUpdateUserWithToken(req, userMapper);
+
+        verify(profileDao, never()).createSlottedProfile(any(Profile.class), anyMap());
+
+        final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertNull(sessionCaptor.getValue().getProfile());
+        assertNull(sessionCaptor.getValue().getApplication());
     }
 
     // ---------- Case builders ----------

--- a/service-test/src/test/java/dev/getelements/elements/service/OidcAuthServiceOperationsProfileTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OidcAuthServiceOperationsProfileTest.java
@@ -1,0 +1,246 @@
+package dev.getelements.elements.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+import dev.getelements.elements.sdk.dao.ApplicationDao;
+import dev.getelements.elements.sdk.dao.OidcAuthSchemeDao;
+import dev.getelements.elements.sdk.dao.ProfileDao;
+import dev.getelements.elements.sdk.dao.SessionDao;
+import dev.getelements.elements.sdk.model.application.Application;
+import dev.getelements.elements.sdk.model.auth.JWK;
+import dev.getelements.elements.sdk.model.auth.OidcAuthScheme;
+import dev.getelements.elements.sdk.model.profile.Profile;
+import dev.getelements.elements.sdk.model.session.OidcSessionRequest;
+import dev.getelements.elements.sdk.model.session.Session;
+import dev.getelements.elements.sdk.model.session.SessionCreation;
+import dev.getelements.elements.sdk.model.user.User;
+import dev.getelements.elements.sdk.service.name.NameService;
+import dev.getelements.elements.service.auth.oidc.OidcAuthServiceOperations;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Client;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static com.google.inject.Guice.createInjector;
+import static com.google.inject.name.Names.named;
+import static dev.getelements.elements.sdk.model.Constants.API_OUTSIDE_URL;
+import static dev.getelements.elements.sdk.service.Constants.OIDC_JWKS_REFRESH_SECONDS;
+import static dev.getelements.elements.sdk.service.Constants.SESSION_TIMEOUT_SECONDS;
+import static java.lang.System.currentTimeMillis;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+/**
+ * Covers the auto-create-primary-profile gap fixed for OIDC logins: {@link OidcSessionRequest#getApplicationNameOrId()}
+ * should behave like the equivalent OAuth2 field, gated on {@code Application#getAutoCreateProfile()}/
+ * {@code Application#getMaxProfiles()}, while the legacy JWT {@code aud}-claim-driven path (no request-level field)
+ * must keep using the ungated {@code createOrRefreshProfile} exactly as before.
+ */
+public class OidcAuthServiceOperationsProfileTest {
+
+    private static final String ISSUER = "https://issuer.test";
+    private static final String KID = "test-kid";
+
+    @Inject
+    private OidcAuthServiceOperations ops;
+
+    @Inject
+    private OidcAuthSchemeDao schemeDao;
+
+    @Inject
+    private ApplicationDao applicationDao;
+
+    @Inject
+    private ProfileDao profileDao;
+
+    @Inject
+    private SessionDao sessionDao;
+
+    private RSAPublicKey publicKey;
+
+    private Algorithm algorithm;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+
+        createInjector(new TestModule()).injectMembers(this);
+        when(sessionDao.create(any(Session.class))).thenReturn(new SessionCreation());
+
+        final var kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        final var kp = kpg.generateKeyPair();
+
+        publicKey = (RSAPublicKey) kp.getPublic();
+        algorithm = Algorithm.RSA256(publicKey, (RSAPrivateKey) kp.getPrivate());
+
+    }
+
+    private OidcAuthScheme scheme() {
+
+        final var n = Base64.getUrlEncoder().encodeToString(publicKey.getModulus().toByteArray());
+        final var e = Base64.getUrlEncoder().encodeToString(publicKey.getPublicExponent().toByteArray());
+        final var jwk = new JWK("RS256", KID, "RSA", "sig", e, n);
+
+        final var scheme = new OidcAuthScheme();
+        scheme.setIssuer(ISSUER);
+        scheme.setKeys(List.of(jwk));
+
+        return scheme;
+
+    }
+
+    private String token(final String audience) {
+
+        var builder = JWT.create()
+                .withIssuer(ISSUER)
+                .withSubject("test-subject")
+                .withKeyId(KID)
+                .withExpiresAt(new Date(currentTimeMillis() + 60_000));
+
+        if (audience != null) {
+            builder = builder.withAudience(audience);
+        }
+
+        return builder.sign(algorithm);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private BiFunction<com.auth0.jwt.interfaces.DecodedJWT, OidcAuthScheme, User> userMapper(final User user) {
+        final BiFunction<com.auth0.jwt.interfaces.DecodedJWT, OidcAuthScheme, User> mapper = mock(BiFunction.class);
+        when(mapper.apply(any(), any())).thenReturn(user);
+        return mapper;
+    }
+
+    @Test
+    public void testAutoCreatesPrimaryProfileWhenRequestedAndConfigured() {
+
+        when(schemeDao.findAuthScheme(ISSUER)).thenReturn(Optional.of(scheme()));
+
+        final var req = new OidcSessionRequest();
+        req.setJwt(token(null));
+        req.setApplicationNameOrId("app-1");
+
+        final var user = new User();
+        user.setId("user-1");
+
+        final var application = new Application();
+        application.setId("app-1");
+        application.setAutoCreateProfile(true);
+        application.setMaxProfiles(1);
+
+        when(applicationDao.findActiveApplication("app-1")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-1", "app-1")).thenReturn(Optional.empty());
+
+        final var createdProfile = new Profile();
+        createdProfile.setId("profile-1");
+        when(profileDao.createSlottedProfile(any(Profile.class), anyMap())).thenReturn(createdProfile);
+
+        ops.createOrUpdateUserWithToken(req, userMapper(user));
+
+        final var profileCaptor = ArgumentCaptor.forClass(Profile.class);
+        verify(profileDao).createSlottedProfile(profileCaptor.capture(), anyMap());
+        assertEquals(profileCaptor.getValue().getUser(), user);
+        assertEquals(profileCaptor.getValue().getApplication(), application);
+        verify(profileDao, never()).createOrRefreshProfile(any());
+
+        final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertEquals(sessionCaptor.getValue().getProfile(), createdProfile);
+        assertEquals(sessionCaptor.getValue().getApplication(), application);
+    }
+
+    @Test
+    public void testDoesNotAutoCreatePrimaryProfileWhenRequestedButNotConfigured() {
+
+        when(schemeDao.findAuthScheme(ISSUER)).thenReturn(Optional.of(scheme()));
+
+        final var req = new OidcSessionRequest();
+        req.setJwt(token(null));
+        req.setApplicationNameOrId("app-2");
+
+        final var user = new User();
+        user.setId("user-2");
+
+        final var application = new Application();
+        application.setId("app-2");
+        application.setAutoCreateProfile(false);
+        application.setMaxProfiles(1);
+
+        when(applicationDao.findActiveApplication("app-2")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-2", "app-2")).thenReturn(Optional.empty());
+
+        ops.createOrUpdateUserWithToken(req, userMapper(user));
+
+        verify(profileDao, never()).createSlottedProfile(any(), anyMap());
+        verify(profileDao, never()).createOrRefreshProfile(any());
+
+        final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertNull(sessionCaptor.getValue().getProfile());
+        assertNull(sessionCaptor.getValue().getApplication());
+    }
+
+    @Test
+    public void testLegacyAudClaimPathStillUsesUngatedCreateOrRefresh() {
+
+        when(schemeDao.findAuthScheme(ISSUER)).thenReturn(Optional.of(scheme()));
+
+        final var req = new OidcSessionRequest();
+        req.setJwt(token("app-3")); // aud claim drives resolution; no applicationNameOrId on the request
+
+        final var user = new User();
+        user.setId("user-3");
+
+        final var application = new Application();
+        application.setId("app-3");
+        application.setAutoCreateProfile(false); // deliberately not configured -- legacy path ignores this
+        application.setMaxProfiles(0);
+
+        when(applicationDao.findActiveApplication("app-3")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-3", "app-3")).thenReturn(Optional.empty());
+
+        final var createdProfile = new Profile();
+        createdProfile.setId("profile-3");
+        when(profileDao.createOrRefreshProfile(any(Profile.class))).thenReturn(createdProfile);
+
+        ops.createOrUpdateUserWithToken(req, userMapper(user));
+
+        verify(profileDao).createOrRefreshProfile(any(Profile.class));
+        verify(profileDao, never()).createSlottedProfile(any(), anyMap());
+
+        final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertEquals(sessionCaptor.getValue().getProfile(), createdProfile);
+    }
+
+    private static class TestModule extends AbstractModule {
+
+        @Override
+        protected void configure() {
+            bind(OidcAuthSchemeDao.class).toInstance(mock(OidcAuthSchemeDao.class));
+            bind(SessionDao.class).toInstance(mock(SessionDao.class));
+            bind(ProfileDao.class).toInstance(mock(ProfileDao.class));
+            bind(NameService.class).toInstance(mock(NameService.class));
+            bind(ApplicationDao.class).toInstance(mock(ApplicationDao.class));
+            bind(Client.class).toInstance(mock(Client.class));
+            bindConstant().annotatedWith(Names.named(SESSION_TIMEOUT_SECONDS)).to(3600L);
+            bindConstant().annotatedWith(Names.named(OIDC_JWKS_REFRESH_SECONDS)).to(3600L);
+            bind(String.class).annotatedWith(named(API_OUTSIDE_URL)).toInstance("http://localhost:8080/api/rest");
+        }
+    }
+
+}

--- a/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
@@ -6,11 +6,13 @@ import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.OAuth2AuthSchemeDao;
 import dev.getelements.elements.sdk.dao.ProfileDao;
 import dev.getelements.elements.sdk.dao.SessionDao;
+import dev.getelements.elements.sdk.model.application.Application;
 import dev.getelements.elements.sdk.model.auth.OAuth2RequestKeyValue;
 import dev.getelements.elements.sdk.model.exception.InternalException;
 import dev.getelements.elements.sdk.model.auth.OAuth2AuthScheme;
 import dev.getelements.elements.sdk.model.exception.auth.AuthSchemeValidationException;
 import dev.getelements.elements.sdk.model.exception.auth.AuthValidationException;
+import dev.getelements.elements.sdk.model.profile.Profile;
 import dev.getelements.elements.sdk.model.session.OAuth2SessionRequest;
 import dev.getelements.elements.sdk.model.session.Session;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
@@ -86,15 +88,38 @@ public class OAuth2AuthServiceOperations {
 
             getApplicationDao()
                     .findApplication(oAuth2SessionRequest.getApplicationNameOrId())
-                    .flatMap(application -> getProfileDao().findPrimaryProfile(user.getId(), application.getId()))
-                    .ifPresent(profile -> {
-                        session.setProfile(profile);
-                        session.setApplication(profile.getApplication());
+                    .ifPresent(application -> {
+
+                        final var profile = getProfileDao()
+                                .findPrimaryProfile(user.getId(), application.getId())
+                                .orElseGet(() -> autoCreatePrimaryProfileIfConfigured(user, application));
+
+                        if (profile != null) {
+                            session.setProfile(profile);
+                            session.setApplication(application);
+                        }
+
                     });
 
         }
 
         return getSessionDao().create(session);
+    }
+
+    private Profile autoCreatePrimaryProfileIfConfigured(final User user, final Application application) {
+
+        final var maxProfiles = application.getMaxProfiles();
+
+        if (!Boolean.TRUE.equals(application.getAutoCreateProfile()) || maxProfiles == null || maxProfiles < 1) {
+            return null;
+        }
+
+        final var profile = new Profile();
+        profile.setUser(user);
+        profile.setApplication(application);
+
+        return getProfileDao().createSlottedProfile(profile, Map.of());
+
     }
 
     private String resolveExternalUserId(final OAuth2AuthScheme scheme,

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
@@ -99,7 +99,7 @@ public class OidcAuthServiceOperations {
         // and today's schemes carry no client id to check the audience against.
         verify(decodedJWT, scheme, null, null);
 
-        return buildSession(decodedJWT, scheme, userMapper);
+        return buildSession(decodedJWT, scheme, userMapper, oidcSessionRequest.getApplicationNameOrId());
     }
 
     /**
@@ -146,18 +146,25 @@ public class OidcAuthServiceOperations {
             final DecodedJWT decodedJWT,
             final OidcAuthScheme scheme,
             final BiFunction<DecodedJWT, OidcAuthScheme, User> userMapper) {
-        return buildSession(decodedJWT, scheme, userMapper);
+        return buildSession(decodedJWT, scheme, userMapper, null);
     }
 
     private SessionCreation buildSession(final DecodedJWT decodedJWT,
                                           final OidcAuthScheme scheme,
-                                          final BiFunction<DecodedJWT, OidcAuthScheme, User> userMapper) {
+                                          final BiFunction<DecodedJWT, OidcAuthScheme, User> userMapper,
+                                          final String requestedApplicationNameOrId) {
 
         // Maps the user, writing it to the database.
         final User user = userMapper.apply(decodedJWT, scheme);
         final long expiry = MILLISECONDS.convert(getSessionTimeoutSeconds(), SECONDS) + currentTimeMillis();
         final var session = new Session();
-        final var applicationId = decodedJWT.getClaim(OidcAuthServiceOperations.Claim.APPLICATION_ID.value).asString();
+
+        // The request-supplied application takes precedence over the JWT's own aud claim. It lets a caller
+        // explicitly opt into a gated auto-create (subject to autoCreateProfile/maxProfiles); the aud claim
+        // alone preserves the legacy, deliberately ungated get-or-create behavior.
+        final var applicationId = requestedApplicationNameOrId != null
+                ? requestedApplicationNameOrId
+                : decodedJWT.getClaim(OidcAuthServiceOperations.Claim.APPLICATION_ID.value).asString();
 
         session.setUser(user);
         session.setExpiry(expiry);
@@ -167,17 +174,37 @@ public class OidcAuthServiceOperations {
             final var applicationOptional = getApplicationDao().findActiveApplication(applicationId);
 
             if(applicationOptional.isPresent()) {
-                final var application = applicationOptional.get();
-                final var profile = getProfileDao()
-                        .findPrimaryProfile(user.getId(), application.getId())
-                        .orElseGet(() -> getProfileDao().createOrRefreshProfile(map(user, application)));
 
-                session.setProfile(profile);
-                session.setApplication(application);
+                final var application = applicationOptional.get();
+                final var existingProfile = getProfileDao().findPrimaryProfile(user.getId(), application.getId());
+
+                final Profile profile = existingProfile.isPresent()
+                        ? existingProfile.get()
+                        : requestedApplicationNameOrId != null
+                                ? autoCreatePrimaryProfileIfConfigured(user, application)
+                                : getProfileDao().createOrRefreshProfile(map(user, application));
+
+                if (profile != null) {
+                    session.setProfile(profile);
+                    session.setApplication(application);
+                }
+
             }
         }
 
         return getSessionDao().create(session);
+    }
+
+    private Profile autoCreatePrimaryProfileIfConfigured(final User user, final Application application) {
+
+        final var maxProfiles = application.getMaxProfiles();
+
+        if (!Boolean.TRUE.equals(application.getAutoCreateProfile()) || maxProfiles == null || maxProfiles < 1) {
+            return null;
+        }
+
+        return getProfileDao().createSlottedProfile(map(user, application), Map.of());
+
     }
 
     private void verify(final DecodedJWT jwt,


### PR DESCRIPTION
## Summary

Fixes #36. OAuth2 and OIDC logins were missing the same auto-create-primary-profile support the username/password signup path has (`Application.getAutoCreateProfile()`/`getMaxProfiles()`, via `AbstractUserService.autoCreateExplicitProfileIfRequested`).

- `OAuth2SessionRequest.applicationNameOrId` previously only attached an *existing* primary profile (`ProfileDao.findPrimaryProfile`). It now falls back to a gated auto-create via `ProfileDao.createSlottedProfile` when no primary profile exists yet, subject to the application's own `autoCreateProfile`/`maxProfiles` configuration.
- `OidcSessionRequest` had no application-related field at all. Added `applicationNameOrId`, mirroring the OAuth2 field. When set, it takes precedence over the JWT's own `aud` claim and drives the same gated auto-create path.
- OIDC's existing JWT-`aud`-claim-driven path (used when `applicationNameOrId` is not set on the request) is left completely unchanged — it continues to use the deliberately ungated, deprecated `ProfileDao.createOrRefreshProfile`, per that method's own documented rationale for this legacy path.

## Test plan

- Added `OidcAuthServiceOperationsProfileTest` (new): auto-create when configured, no auto-create when not configured, and legacy aud-claim path unaffected.
- Extended `OAuth2AuthServiceTest` with auto-create/no-auto-create cases.
- `mvn -pl sdk-model,service,service-test -am install -DskipTests` and `mvn -pl service-test -Dtest=OAuth2AuthServiceTest,OidcAuthServiceOperationsProfileTest,UserOidcAuthServiceTest,AnonOidcAuthServiceTest,OidcAuthServiceOperationsValidationTest test` — 32/32 passing.