### PR TITLE
Support account-linking in the OIDC browser-redirect login-attempt flow

### DIFF
--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/auth/MongoOidcLoginAttemptDao.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/auth/MongoOidcLoginAttemptDao.java
@@ -82,6 +82,50 @@ public class MongoOidcLoginAttemptDao implements OidcLoginAttemptDao {
     }
 
     @Override
+    public Optional<OidcLoginAttempt> markLinkReady(final String state, final String linkClaimsJson) {
+
+        final var query = getDatastore().find(MongoOidcLoginAttempt.class)
+                .filter(and(eq("state", state), eq("status", PENDING)));
+
+        final var entity = getMongoDBUtils().perform(ds -> query.modify(
+                set("status", LINK_READY),
+                set("linkClaimsJson", linkClaimsJson)
+        ).execute(new ModifyOptions().upsert(false).returnDocument(AFTER)));
+
+        return Optional.ofNullable(entity).map(this::transform);
+
+    }
+
+    @Override
+    public Optional<OidcLoginAttempt> findLinkReadyById(final String id) {
+
+        final var entity = getDatastore().find(MongoOidcLoginAttempt.class)
+                .filter(and(eq("_id", id), eq("status", LINK_READY)))
+                .first();
+
+        return notExpired(entity).map(this::transform);
+
+    }
+
+    @Override
+    public Optional<OidcLoginAttempt> claimLinkReadyById(final String id) {
+
+        final var query = getDatastore().find(MongoOidcLoginAttempt.class)
+                .filter(and(eq("_id", id), eq("status", LINK_READY)));
+
+        // returnDocument(BEFORE): the caller that wins the race gets the pre-claim document, which still has
+        // linkClaimsJson populated. A concurrent second caller's modify() no longer matches (status is CLAIMED)
+        // and returns null, so the claims can never be consumed twice.
+        final var entity = getMongoDBUtils().perform(ds -> query.modify(
+                set("status", CLAIMED),
+                unset("linkClaimsJson")
+        ).execute(new ModifyOptions().upsert(false).returnDocument(BEFORE)));
+
+        return notExpired(entity).map(this::transform);
+
+    }
+
+    @Override
     public Optional<OidcLoginAttempt> claimCompleteById(final String id) {
 
         final var query = getDatastore().find(MongoOidcLoginAttempt.class)

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcLoginAttempt.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcLoginAttempt.java
@@ -53,6 +53,12 @@ public class MongoOidcLoginAttempt {
     @Property
     private String linkedUserId;
 
+    @Property
+    private String linkClaimsJson;
+
+    @Property
+    private String confirmToken;
+
     public String getId() {
         return id;
     }
@@ -141,6 +147,22 @@ public class MongoOidcLoginAttempt {
         this.linkedUserId = linkedUserId;
     }
 
+    public String getLinkClaimsJson() {
+        return linkClaimsJson;
+    }
+
+    public void setLinkClaimsJson(String linkClaimsJson) {
+        this.linkClaimsJson = linkClaimsJson;
+    }
+
+    public String getConfirmToken() {
+        return confirmToken;
+    }
+
+    public void setConfirmToken(String confirmToken) {
+        this.confirmToken = confirmToken;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -156,14 +178,16 @@ public class MongoOidcLoginAttempt {
                 && Objects.equals(getExpiry(), that.getExpiry())
                 && Objects.equals(getSuccessRedirectUrl(), that.getSuccessRedirectUrl())
                 && Objects.equals(getErrorRedirectUrl(), that.getErrorRedirectUrl())
-                && Objects.equals(getLinkedUserId(), that.getLinkedUserId());
+                && Objects.equals(getLinkedUserId(), that.getLinkedUserId())
+                && Objects.equals(getLinkClaimsJson(), that.getLinkClaimsJson())
+                && Objects.equals(getConfirmToken(), that.getConfirmToken());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getId(), getProvider(), getState(), getNonce(), getStatus(),
                 getSessionToken(), getFailureReason(), getExpiry(), getSuccessRedirectUrl(), getErrorRedirectUrl(),
-                getLinkedUserId());
+                getLinkedUserId(), getLinkClaimsJson(), getConfirmToken());
     }
 
 }

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcLoginAttempt.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcLoginAttempt.java
@@ -50,6 +50,9 @@ public class MongoOidcLoginAttempt {
     @Property
     private String errorRedirectUrl;
 
+    @Property
+    private String linkedUserId;
+
     public String getId() {
         return id;
     }
@@ -130,6 +133,14 @@ public class MongoOidcLoginAttempt {
         this.errorRedirectUrl = errorRedirectUrl;
     }
 
+    public String getLinkedUserId() {
+        return linkedUserId;
+    }
+
+    public void setLinkedUserId(String linkedUserId) {
+        this.linkedUserId = linkedUserId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -144,13 +155,15 @@ public class MongoOidcLoginAttempt {
                 && Objects.equals(getFailureReason(), that.getFailureReason())
                 && Objects.equals(getExpiry(), that.getExpiry())
                 && Objects.equals(getSuccessRedirectUrl(), that.getSuccessRedirectUrl())
-                && Objects.equals(getErrorRedirectUrl(), that.getErrorRedirectUrl());
+                && Objects.equals(getErrorRedirectUrl(), that.getErrorRedirectUrl())
+                && Objects.equals(getLinkedUserId(), that.getLinkedUserId());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getId(), getProvider(), getState(), getNonce(), getStatus(),
-                getSessionToken(), getFailureReason(), getExpiry(), getSuccessRedirectUrl(), getErrorRedirectUrl());
+                getSessionToken(), getFailureReason(), getExpiry(), getSuccessRedirectUrl(), getErrorRedirectUrl(),
+                getLinkedUserId());
     }
 
 }

--- a/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcAuthResource.java
+++ b/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcAuthResource.java
@@ -6,12 +6,20 @@ import dev.getelements.elements.sdk.model.session.SessionCreation;
 import dev.getelements.elements.sdk.model.util.ValidationHelper;
 import dev.getelements.elements.sdk.service.auth.OidcAuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+/**
+ * Direct, synchronous OIDC login: the client already possesses an {@code id_token} (e.g. from a native platform
+ * Sign-In SDK) and validates it against a statically-configured OIDC Auth Scheme in one call. For a client that
+ * has no other way to obtain an {@code id_token}, see {@link OidcSessionResource}'s browser-redirect flow instead;
+ * that resource's {@code idToken} shortcut shares this validation code path.
+ */
 @Path("auth/oidc")
 public class OidcAuthResource {
 
@@ -19,6 +27,14 @@ public class OidcAuthResource {
 
     private OidcAuthService oidcAuthService;
 
+    /**
+     * Validates the supplied {@code id_token} and returns the resulting session, implicitly creating a new
+     * account if no user is associated with the supplied credentials yet, or linking to the scheme if the
+     * caller's existing session/account was not previously linked to it.
+     *
+     * @param oidcSessionRequest the JWT to validate
+     * @return the resulting session
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
@@ -30,6 +46,10 @@ public class OidcAuthResource {
                     "will include that account information in the response. If there is an account, or this method " +
                     "receives an existing session key, this will link to the existing scheme if the account was " +
                     "not previously linked.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The JWT was valid; the resulting session is returned."),
+            @ApiResponse(responseCode = "400", description = "The request failed validation, or is missing the JWT.")
+    })
     public SessionCreation createOidcSession(final OidcSessionRequest oidcSessionRequest) {
 
         getValidationHelper().validateModel(oidcSessionRequest);

--- a/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcCallbackResource.java
+++ b/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcCallbackResource.java
@@ -3,6 +3,7 @@ package dev.getelements.elements.rest.auth;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptCallbackResult;
 import dev.getelements.elements.sdk.service.auth.OidcLoginAttemptService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -71,17 +72,40 @@ public class OidcCallbackResource {
 
     private OidcLoginAttemptService oidcLoginAttemptService;
 
+    /**
+     * Handles the provider's redirect callback, delegating to {@link OidcLoginAttemptService#handleCallback} to
+     * validate the exchanged identity and advance the matching pending attempt. Always returns {@code 200} HTML
+     * or a {@code 302} redirect to the provider-configured success/error URL — never a JSON error body — since
+     * the outcome is reported to the waiting client via {@link OidcSessionResource}'s poll/confirm endpoints, not
+     * via this response.
+     *
+     * @param provider the provider identifier from the callback path
+     * @param code the authorization code from the provider, or {@code null} if the provider reported an error
+     * @param state the state value identifying the pending attempt
+     * @param error the provider's error query parameter (e.g. user denied consent), or {@code null} on success
+     * @param uriInfo the request URI, used to forward query parameters onto a configured redirect target
+     * @return an HTML page, or a redirect to the provider-configured success/error URL
+     */
     @GET
     @Produces(MediaType.TEXT_HTML)
     @Operation(
             summary = "OIDC provider redirect target",
             description = "Not called by game clients. The provider redirects the system browser here after " +
                     "the user completes (or denies) authorization.")
-    public Response callback(@PathParam("provider") final String provider,
-                              @QueryParam("code") final String code,
-                              @QueryParam("state") final String state,
-                              @QueryParam("error") final String error,
-                              @Context final UriInfo uriInfo) {
+    public Response callback(
+            @PathParam("provider")
+            @Parameter(description = "The provider identifier this login attempt was begun for.")
+            final String provider,
+            @QueryParam("code")
+            @Parameter(description = "The authorization code from the provider, absent if error is set.")
+            final String code,
+            @QueryParam("state")
+            @Parameter(description = "The state value identifying the pending attempt.")
+            final String state,
+            @QueryParam("error")
+            @Parameter(description = "The provider's reported error, e.g. the user denied consent.")
+            final String error,
+            @Context final UriInfo uriInfo) {
 
         if (state == null || (error == null && code == null)) {
             return html(FAILURE_HTML, provider, code, state, error);

--- a/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcSessionResource.java
+++ b/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcSessionResource.java
@@ -11,6 +11,9 @@ import dev.getelements.elements.sdk.model.util.ValidationHelper;
 import dev.getelements.elements.sdk.service.auth.OidcAuthService;
 import dev.getelements.elements.sdk.service.auth.OidcLoginAttemptService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -31,6 +34,17 @@ public class OidcSessionResource {
 
     private OidcAuthService oidcAuthService;
 
+    /**
+     * Begins the browser-redirect flow (only {@code provider} supplied), returning a pending attempt with a
+     * poll {@code id}, the provider's {@code authorizeUrl}, and a {@code confirmToken}; or, if {@code idToken} is
+     * also supplied, validates it directly and returns a completed session synchronously, skipping the
+     * browser/poll steps entirely. If the caller already holds an Elements session, a pending attempt links the
+     * external identity to that user on success instead of creating one — see
+     * {@link OidcLoginAttemptService#begin}.
+     *
+     * @param request the provider to begin an attempt for, and/or an already-possessed id_token
+     * @return {@code 201} with the pending attempt, or {@code 200} with the completed session
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
@@ -40,6 +54,13 @@ public class OidcSessionResource {
                     "returns an id plus the authorize URL to open in the system browser. Additionally " +
                     "supplying 'idToken' instead validates it directly and returns a completed session " +
                     "synchronously, sharing validation code with the callback path.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "A pending browser-redirect attempt was created."),
+            @ApiResponse(responseCode = "200",
+                    description = "The supplied idToken was valid; the completed session is returned."),
+            @ApiResponse(responseCode = "400", description = "The request failed validation, or is missing both " +
+                    "provider and idToken.")
+    })
     public Response createOidcSession(final OidcLoginAttemptRequest request) {
 
         getValidationHelper().validateModel(request);
@@ -64,6 +85,15 @@ public class OidcSessionResource {
 
     }
 
+    /**
+     * Polls a pending attempt by id. Returns {@code COMPLETE} with the session exactly once, on the poll that
+     * first observes completion. A linking attempt is never finalizable this way — once its external identity is
+     * validated it becomes link-ready, and this throws {@link dev.getelements.elements.sdk.model.exception.ForbiddenException}
+     * directing the caller to {@link #confirmOidcSessionLink} instead. See {@link OidcLoginAttemptService#poll}.
+     *
+     * @param id the opaque poll id returned by {@link #createOidcSession}
+     * @return the current status of the attempt
+     */
     @GET
     @Path("{id}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -74,7 +104,17 @@ public class OidcSessionResource {
                     "id, returns 404. An account-linking attempt cannot be finalized this way -- once its " +
                     "external identity is validated, this returns an error directing the caller to " +
                     "POST {id}/confirm instead.")
-    public OidcLoginAttemptStatusResponse pollOidcSession(@PathParam("id") final String id) {
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current PENDING, COMPLETE, or FAILED status."),
+            @ApiResponse(responseCode = "404",
+                    description = "The id is unknown, already consumed, or has expired."),
+            @ApiResponse(responseCode = "403", description = "This is a linking attempt whose external identity " +
+                    "has already been validated; call POST {id}/confirm instead.")
+    })
+    public OidcLoginAttemptStatusResponse pollOidcSession(
+            @PathParam("id")
+            @Parameter(description = "The opaque poll id returned by POST /oidc/session.")
+            final String id) {
 
         final var status = getOidcLoginAttemptService().poll(id);
 
@@ -86,6 +126,16 @@ public class OidcSessionResource {
 
     }
 
+    /**
+     * Finalizes a linking attempt by presenting the {@code confirmToken} returned only in the original
+     * {@link #createOidcSession} response for this attempt — the actual account-link mutation, deferred out of
+     * the provider callback because it cannot verify it's talking to the same party that began the attempt. Not
+     * applicable to (and never needed for) an anonymous attempt. See {@link OidcLoginAttemptService#confirmLink}.
+     *
+     * @param id the opaque poll id
+     * @param request the confirmToken returned by {@link #createOidcSession} for this attempt
+     * @return the completed session
+     */
     @POST
     @Path("{id}/confirm")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -95,8 +145,19 @@ public class OidcSessionResource {
             description = "Presents the confirmToken returned in the original POST /oidc/session response for " +
                     "this attempt, completing the deferred account-link mutation and returning the resulting " +
                     "session. Only applicable to a linking attempt; not needed for an anonymous one.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The link succeeded; the completed session is " +
+                    "returned. Like the poll endpoint, this is returned exactly once."),
+            @ApiResponse(responseCode = "404", description = "The id is unknown, not awaiting confirmation, " +
+                    "already claimed, or expired."),
+            @ApiResponse(responseCode = "403", description = "confirmToken is missing or doesn't match. Not " +
+                    "consumed; retry with the correct token."),
+            @ApiResponse(responseCode = "400", description = "The request failed validation (confirmToken blank).")
+    })
     public OidcLoginAttemptStatusResponse confirmOidcSessionLink(
-            @PathParam("id") final String id,
+            @PathParam("id")
+            @Parameter(description = "The opaque poll id returned by POST /oidc/session.")
+            final String id,
             final OidcLoginAttemptConfirmRequest request) {
 
         getValidationHelper().validateModel(request);

--- a/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcSessionResource.java
+++ b/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcSessionResource.java
@@ -1,6 +1,7 @@
 package dev.getelements.elements.rest.auth;
 
 import dev.getelements.elements.sdk.model.exception.NotFoundException;
+import dev.getelements.elements.sdk.model.session.OidcLoginAttemptConfirmRequest;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptRequest;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptResponse;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptState;
@@ -56,7 +57,8 @@ public class OidcSessionResource {
         }
 
         final var begin = getOidcLoginAttemptService().begin(request.getProvider());
-        final var body = OidcLoginAttemptResponse.pending(begin.getId(), begin.getAuthorizeUrl(), begin.getExpiresAt());
+        final var body = OidcLoginAttemptResponse.pending(
+                begin.getId(), begin.getAuthorizeUrl(), begin.getExpiresAt(), begin.getConfirmToken());
 
         return Response.status(Response.Status.CREATED).entity(body).build();
 
@@ -69,10 +71,37 @@ public class OidcSessionResource {
             summary = "Polls a pending OIDC login attempt",
             description = "Returns COMPLETE with the session exactly once, on the poll that first observes " +
                     "completion; a subsequent poll for the same id, or a poll for an unknown/expired " +
-                    "id, returns 404.")
+                    "id, returns 404. An account-linking attempt cannot be finalized this way -- once its " +
+                    "external identity is validated, this returns an error directing the caller to " +
+                    "POST {id}/confirm instead.")
     public OidcLoginAttemptStatusResponse pollOidcSession(@PathParam("id") final String id) {
 
         final var status = getOidcLoginAttemptService().poll(id);
+
+        if (status.getStatus() == OidcLoginAttemptState.EXPIRED) {
+            throw new NotFoundException();
+        }
+
+        return status;
+
+    }
+
+    @POST
+    @Path("{id}/confirm")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Finalizes an account-linking OIDC login attempt",
+            description = "Presents the confirmToken returned in the original POST /oidc/session response for " +
+                    "this attempt, completing the deferred account-link mutation and returning the resulting " +
+                    "session. Only applicable to a linking attempt; not needed for an anonymous one.")
+    public OidcLoginAttemptStatusResponse confirmOidcSessionLink(
+            @PathParam("id") final String id,
+            final OidcLoginAttemptConfirmRequest request) {
+
+        getValidationHelper().validateModel(request);
+
+        final var status = getOidcLoginAttemptService().confirmLink(id, request.getConfirmToken());
 
         if (status.getStatus() == OidcLoginAttemptState.EXPIRED) {
             throw new NotFoundException();

--- a/rest-api/src/main/java/dev/getelements/elements/rest/user/UserLinkResource.java
+++ b/rest-api/src/main/java/dev/getelements/elements/rest/user/UserLinkResource.java
@@ -11,6 +11,8 @@ import dev.getelements.elements.sdk.service.auth.OidcLinkService;
 import dev.getelements.elements.sdk.service.user.EmailPasswordLinkService;
 import dev.getelements.elements.sdk.service.user.UsernamePasswordLinkService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
@@ -41,6 +43,16 @@ public class UserLinkResource {
         return getOAuth2LinkService().createSession(request);
     }
 
+    /**
+     * Links an external OIDC identity from a possessed {@code id_token} to the calling user, validated the same
+     * way an OIDC login is. If the token's external identity is already linked to a different user, the request
+     * fails; linking to the calling user's own already-linked identity is a no-op success. For a client with no
+     * other way to obtain an {@code id_token}, the browser-redirect flow can also link — see
+     * {@link dev.getelements.elements.rest.auth.OidcSessionResource}.
+     *
+     * @param request the OIDC session request containing the id_token to validate and link
+     * @return the resulting session
+     */
     @POST
     @Path("oidc")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -49,6 +61,12 @@ public class UserLinkResource {
             summary = "Link OIDC Identity",
             description = "Links an external OIDC identity to the currently authenticated user. " +
                     "Requires an active user session. Returns the updated session information.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The identity was linked (or already was); the " +
+                    "resulting session is returned."),
+            @ApiResponse(responseCode = "403", description = "No active USER/SUPERUSER session, or the external " +
+                    "identity is already linked to a different user.")
+    })
     public SessionCreation linkOidc(final OidcSessionRequest request) {
         return getOidcLinkService().createSession(request);
     }

--- a/sdk-dao/src/main/java/dev/getelements/elements/sdk/dao/OidcLoginAttemptDao.java
+++ b/sdk-dao/src/main/java/dev/getelements/elements/sdk/dao/OidcLoginAttemptDao.java
@@ -56,6 +56,42 @@ public interface OidcLoginAttemptDao {
     Optional<OidcLoginAttempt> markFailed(String state, String reason);
 
     /**
+     * Atomically transitions a PENDING attempt matching the given state to LINK_READY, storing the serialized
+     * external-identity claims validated by the callback for a linking attempt. A no-op (empty result) if no
+     * PENDING attempt matches — mirrors {@link #markComplete}'s replay-safety guarantee. Unlike
+     * {@link #markComplete}, this deliberately does not create a session; the account-link mutation is deferred
+     * to {@link #claimLinkReadyById}, gated on presenting the attempt's {@code confirmToken}.
+     *
+     * @param state the state value
+     * @param linkClaimsJson the serialized external-identity claims
+     * @return an {@link Optional} containing the updated attempt, or empty if the guard did not match
+     */
+    Optional<OidcLoginAttempt> markLinkReady(String state, String linkClaimsJson);
+
+    /**
+     * Finds a LINK_READY attempt by id, without mutating it. Used both to detect that a plain poll should be
+     * rejected in favor of the confirm flow, and by the confirm flow itself to check {@code confirmToken} before
+     * consuming anything — a wrong token must never burn the attempt.
+     *
+     * @param id the opaque poll id
+     * @return an {@link Optional} containing the attempt, or empty if missing, expired, or not LINK_READY
+     */
+    Optional<OidcLoginAttempt> findLinkReadyById(String id);
+
+    /**
+     * Atomically claims a LINK_READY attempt matching the given id, transitioning it to a terminal claimed state
+     * and clearing the stored claims so it cannot be observed again. Returns the pre-claim attempt (with
+     * {@code linkClaimsJson} still populated) to the caller that wins the race; a no-op (empty result) if no
+     * LINK_READY attempt matches — including on every subsequent call for the same id. Callers must have already
+     * verified {@code confirmToken} before calling this — it performs no token check of its own.
+     *
+     * @param id the opaque poll id
+     * @return an {@link Optional} containing the pre-claim attempt, or empty if already claimed, not yet
+     *         link-ready, expired, or unknown
+     */
+    Optional<OidcLoginAttempt> claimLinkReadyById(String id);
+
+    /**
      * Atomically claims a COMPLETE attempt matching the given id, transitioning it to a terminal claimed
      * state and clearing the stored session so it cannot be observed again. Returns the pre-claim attempt (with
      * the session still populated) to the caller that wins the race; a no-op (empty result) if no COMPLETE

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/OidcLoginAttempt.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/OidcLoginAttempt.java
@@ -44,6 +44,14 @@ public class OidcLoginAttempt {
     /** Optional. If set, the callback redirects the browser here on failure instead of the default HTML page. */
     private String errorRedirectUrl;
 
+    /**
+     * The id of the already-authenticated user this attempt was started on behalf of, set at {@code begin()}
+     * time when the caller had an existing Elements session. When set, a successful callback links the external
+     * identity to this user instead of creating/finding a user by external id. {@code null} for an anonymous
+     * (first-time login) attempt.
+     */
+    private String linkedUserId;
+
     public String getId() {
         return id;
     }
@@ -122,6 +130,14 @@ public class OidcLoginAttempt {
 
     public void setErrorRedirectUrl(String errorRedirectUrl) {
         this.errorRedirectUrl = errorRedirectUrl;
+    }
+
+    public String getLinkedUserId() {
+        return linkedUserId;
+    }
+
+    public void setLinkedUserId(String linkedUserId) {
+        this.linkedUserId = linkedUserId;
     }
 
 }

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/OidcLoginAttempt.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/OidcLoginAttempt.java
@@ -52,6 +52,22 @@ public class OidcLoginAttempt {
      */
     private String linkedUserId;
 
+    /**
+     * Serialized external-identity claims (scheme name, external user id, email, profile claims) validated by
+     * the callback for a linking attempt, set when transitioning to {@link OidcLoginAttemptStatus#LINK_READY}.
+     * Consumed exactly once, by the authenticated poll that performs the deferred account-link mutation.
+     */
+    private String linkClaimsJson;
+
+    /**
+     * A random, high-entropy token generated at {@code begin()} time and returned only in that response — never
+     * exposed to the browser/IdP leg of the flow the way {@code state}/{@code nonce} are. Presenting it back on
+     * {@code POST .../confirm} is the sole proof that the caller finalizing a linking attempt is the same party
+     * that started it, since the callback that validates the external identity is always hit by an
+     * unauthenticated provider redirect and cannot make that determination itself.
+     */
+    private String confirmToken;
+
     public String getId() {
         return id;
     }
@@ -138,6 +154,22 @@ public class OidcLoginAttempt {
 
     public void setLinkedUserId(String linkedUserId) {
         this.linkedUserId = linkedUserId;
+    }
+
+    public String getLinkClaimsJson() {
+        return linkClaimsJson;
+    }
+
+    public void setLinkClaimsJson(String linkClaimsJson) {
+        this.linkClaimsJson = linkClaimsJson;
+    }
+
+    public String getConfirmToken() {
+        return confirmToken;
+    }
+
+    public void setConfirmToken(String confirmToken) {
+        this.confirmToken = confirmToken;
     }
 
 }

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/OidcLoginAttemptStatus.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/OidcLoginAttemptStatus.java
@@ -16,8 +16,19 @@ public enum OidcLoginAttemptStatus {
     FAILED,
 
     /**
-     * The completed session has already been claimed by a poller. A terminal state distinct from
-     * {@link #COMPLETE} so a second poll cannot observe the session a second time.
+     * The callback validated an external identity for a linking attempt (one with
+     * {@link OidcLoginAttempt#getLinkedUserId()} set), but has deliberately not yet performed the account-link
+     * mutation. The callback itself is always hit by an unauthenticated provider redirect, so it cannot verify
+     * it's talking to the same caller who started the attempt; only an authenticated poll whose session matches
+     * {@link OidcLoginAttempt#getLinkedUserId()} may complete the link. Distinct from {@link #COMPLETE}, which
+     * carries an already-created session ready to be claimed as-is.
+     */
+    LINK_READY,
+
+    /**
+     * The completed session has already been claimed by a poller, or a link-ready attempt has already been
+     * consumed by a poll. A terminal state distinct from {@link #COMPLETE}/{@link #LINK_READY} so a second poll
+     * cannot observe either a second time.
      */
     CLAIMED
 

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptBegin.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptBegin.java
@@ -12,11 +12,16 @@ public class OidcLoginAttemptBegin {
      * @param id the opaque poll id
      * @param authorizeUrl the fully-built provider authorize URL
      * @param expiresAt the epoch second after which the attempt expires
+     * @param confirmToken a secret returned only to the caller of {@code begin()}, presented back on
+     *                     {@code POST .../confirm} to finalize an account-linking attempt. Present for every
+     *                     attempt, but only ever required for a linking one.
      */
-    public OidcLoginAttemptBegin(final String id, final String authorizeUrl, final long expiresAt) {
+    public OidcLoginAttemptBegin(final String id, final String authorizeUrl, final long expiresAt,
+                                  final String confirmToken) {
         this.id = id;
         this.authorizeUrl = authorizeUrl;
         this.expiresAt = expiresAt;
+        this.confirmToken = confirmToken;
     }
 
     private String id;
@@ -24,6 +29,8 @@ public class OidcLoginAttemptBegin {
     private String authorizeUrl;
 
     private long expiresAt;
+
+    private String confirmToken;
 
     public String getId() {
         return id;
@@ -47,6 +54,14 @@ public class OidcLoginAttemptBegin {
 
     public void setExpiresAt(long expiresAt) {
         this.expiresAt = expiresAt;
+    }
+
+    public String getConfirmToken() {
+        return confirmToken;
+    }
+
+    public void setConfirmToken(String confirmToken) {
+        this.confirmToken = confirmToken;
     }
 
 }

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptBegin.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptBegin.java
@@ -1,6 +1,9 @@
 package dev.getelements.elements.sdk.model.session;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /** The result of starting a pending browser-redirect OIDC login attempt. Service-layer only. */
+@Schema(description = "The result of starting a pending browser-redirect OIDC login attempt.")
 public class OidcLoginAttemptBegin {
 
     /** Creates a new instance. */
@@ -24,42 +27,87 @@ public class OidcLoginAttemptBegin {
         this.confirmToken = confirmToken;
     }
 
+    @Schema(description = "The opaque id used to poll GET /oidc/session/{id}.")
     private String id;
 
+    @Schema(description = "The fully-built provider authorize URL to open in the system browser.")
     private String authorizeUrl;
 
+    @Schema(description = "The epoch second after which the attempt expires.")
     private long expiresAt;
 
+    @Schema(description = "A secret returned only to the caller of begin(), presented back on " +
+            "POST .../confirm to finalize an account-linking attempt.")
     private String confirmToken;
 
+    /**
+     * Returns the opaque poll id.
+     *
+     * @return the id
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Sets the opaque poll id.
+     *
+     * @param id the id
+     */
     public void setId(String id) {
         this.id = id;
     }
 
+    /**
+     * Returns the fully-built provider authorize URL.
+     *
+     * @return the authorize URL
+     */
     public String getAuthorizeUrl() {
         return authorizeUrl;
     }
 
+    /**
+     * Sets the fully-built provider authorize URL.
+     *
+     * @param authorizeUrl the authorize URL
+     */
     public void setAuthorizeUrl(String authorizeUrl) {
         this.authorizeUrl = authorizeUrl;
     }
 
+    /**
+     * Returns the epoch second after which the attempt expires.
+     *
+     * @return the expiry
+     */
     public long getExpiresAt() {
         return expiresAt;
     }
 
+    /**
+     * Sets the epoch second after which the attempt expires.
+     *
+     * @param expiresAt the expiry
+     */
     public void setExpiresAt(long expiresAt) {
         this.expiresAt = expiresAt;
     }
 
+    /**
+     * Returns the secret used to finalize a linking attempt.
+     *
+     * @return the confirmToken
+     */
     public String getConfirmToken() {
         return confirmToken;
     }
 
+    /**
+     * Sets the secret used to finalize a linking attempt.
+     *
+     * @param confirmToken the confirmToken
+     */
     public void setConfirmToken(String confirmToken) {
         this.confirmToken = confirmToken;
     }

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptConfirmRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptConfirmRequest.java
@@ -1,0 +1,48 @@
+package dev.getelements.elements.sdk.model.session;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.Objects;
+
+/**
+ * Request body for {@code POST /oidc/session/{id}/confirm}, which finalizes an account-linking browser-redirect
+ * OIDC login attempt. {@link #getConfirmToken()} is the secret returned only in the original
+ * {@code POST /oidc/session} response for that attempt.
+ */
+@Schema(description = "Finalizes an account-linking OIDC login attempt by presenting the confirmToken returned " +
+        "when the attempt was started.")
+public class OidcLoginAttemptConfirmRequest {
+
+    /** Creates a new instance. */
+    public OidcLoginAttemptConfirmRequest() {}
+
+    @NotBlank
+    @Schema(description = "The confirmToken returned in the original POST /oidc/session response.")
+    private String confirmToken;
+
+    public String getConfirmToken() {
+        return confirmToken;
+    }
+
+    public void setConfirmToken(String confirmToken) {
+        this.confirmToken = confirmToken;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof OidcLoginAttemptConfirmRequest that)) return false;
+        return Objects.equals(confirmToken, that.confirmToken);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(confirmToken);
+    }
+
+    @Override
+    public String toString() {
+        return "OidcLoginAttemptConfirmRequest{confirmToken='[redacted]'}";
+    }
+
+}

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptResponse.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptResponse.java
@@ -25,6 +25,11 @@ public class OidcLoginAttemptResponse {
     @Schema(description = "The epoch second after which the attempt expires. Only set for pending attempts.")
     private Long expiresAt;
 
+    @Schema(description = "A secret returned only to the caller of this request, presented back on " +
+            "POST /oidc/session/{id}/confirm to finalize an account-linking attempt. Present for every pending " +
+            "attempt, but only ever required for a linking one. Only set for pending attempts.")
+    private String confirmToken;
+
     @Schema(description = "The completed Elements session. Only set when idToken direct validation completed synchronously.")
     private SessionCreation session;
 
@@ -34,13 +39,16 @@ public class OidcLoginAttemptResponse {
      * @param id           the opaque poll id
      * @param authorizeUrl the provider authorize URL
      * @param expiresAt    the epoch second expiry
+     * @param confirmToken the secret used to finalize a linking attempt
      * @return the response
      */
-    public static OidcLoginAttemptResponse pending(final String id, final String authorizeUrl, final long expiresAt) {
+    public static OidcLoginAttemptResponse pending(final String id, final String authorizeUrl, final long expiresAt,
+                                                    final String confirmToken) {
         final var response = new OidcLoginAttemptResponse();
         response.setId(id);
         response.setAuthorizeUrl(authorizeUrl);
         response.setExpiresAt(expiresAt);
+        response.setConfirmToken(confirmToken);
         return response;
     }
 
@@ -78,6 +86,14 @@ public class OidcLoginAttemptResponse {
 
     public void setExpiresAt(Long expiresAt) {
         this.expiresAt = expiresAt;
+    }
+
+    public String getConfirmToken() {
+        return confirmToken;
+    }
+
+    public void setConfirmToken(String confirmToken) {
+        this.confirmToken = confirmToken;
     }
 
     public SessionCreation getSession() {

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcSessionRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcSessionRequest.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 import java.util.Objects;
 
 /** Request to create a session using an OIDC (OpenID Connect) JWT token. */
+@Schema(description = "Validates a possessed id_token and returns the resulting session, either creating a new " +
+        "account or linking to/reusing an existing one.")
 public class OidcSessionRequest {
 
     /** Creates a new instance. */

--- a/sdk-service/src/main/java/dev/getelements/elements/sdk/service/auth/OidcLoginAttemptService.java
+++ b/sdk-service/src/main/java/dev/getelements/elements/sdk/service/auth/OidcLoginAttemptService.java
@@ -9,9 +9,10 @@ import dev.getelements.elements.sdk.model.session.OidcLoginAttemptStatusResponse
 import static dev.getelements.elements.sdk.service.Constants.UNSCOPED;
 
 /**
- * Orchestrates the pre-authentication, provider-agnostic browser-redirect OIDC login flow for thick clients: begin
- * a pending attempt, poll for completion, and handle the provider's callback. Always anonymous — a caller has no
- * Elements session yet when using this service, by definition.
+ * Orchestrates the provider-agnostic browser-redirect OIDC login flow for thick clients: begin a pending
+ * attempt, poll for completion, and handle the provider's callback. If the caller already has an Elements
+ * session when calling {@link #begin}, a successful attempt links the external identity to that user instead
+ * of creating/finding a user by external id; otherwise it behaves as a first-time, anonymous login.
  */
 @ElementPublic
 @ElementServiceExport
@@ -21,7 +22,8 @@ public interface OidcLoginAttemptService {
     /**
      * Begins a pending login attempt for the given provider, building the provider's authorize URL and returning
      * an opaque id used to poll for completion. The success/error redirect URLs applied on callback, if any,
-     * come from the provider's own configuration — server-authoritative, not caller-supplied.
+     * come from the provider's own configuration — server-authoritative, not caller-supplied. If the caller
+     * already has an Elements session, the attempt links to that user on success rather than creating one.
      *
      * @param provider the provider identifier (e.g. "twitch")
      * @return the pending attempt's id, authorize URL, and expiry

--- a/sdk-service/src/main/java/dev/getelements/elements/sdk/service/auth/OidcLoginAttemptService.java
+++ b/sdk-service/src/main/java/dev/getelements/elements/sdk/service/auth/OidcLoginAttemptService.java
@@ -40,6 +40,21 @@ public interface OidcLoginAttemptService {
     OidcLoginAttemptStatusResponse poll(String id);
 
     /**
+     * Finalizes an account-linking attempt by presenting the {@code confirmToken} returned only in the original
+     * {@code begin()} response. The callback that validates the external identity is always hit by an
+     * unauthenticated provider redirect and cannot verify it's talking to the same party that called
+     * {@code begin()}, so the account-link mutation is deferred here instead, gated on possession of that secret.
+     * Not applicable to (and never satisfied by) an anonymous attempt — see {@link #poll}, which rejects a
+     * linking attempt outright and directs the caller here instead.
+     *
+     * @param id the opaque poll id
+     * @param confirmToken the secret returned in the original {@code begin()} response for this attempt
+     * @return the completed session, or an EXPIRED-equivalent result if the attempt is unknown, not awaiting
+     *         confirmation, already claimed, or expired
+     */
+    OidcLoginAttemptStatusResponse confirmLink(String id, String confirmToken);
+
+    /**
      * Handles the provider's redirect callback: looks up the pending attempt by state, exchanges the code for an
      * id_token, validates it, creates the Elements session, and marks the attempt COMPLETE. Fails closed (marks
      * the attempt FAILED) on any missing/expired/mismatched state, nonce mismatch, or exchange or validation

--- a/service-guice/src/main/java/dev/getelements/elements/service/guice/UnscopedServicesModule.java
+++ b/service-guice/src/main/java/dev/getelements/elements/service/guice/UnscopedServicesModule.java
@@ -37,7 +37,7 @@ import dev.getelements.elements.service.auth.oauth2.AnonOAuth2AuthService;
 import dev.getelements.elements.service.auth.oauth2.SuperUserOAuth2AuthSchemeService;
 import dev.getelements.elements.service.auth.oidc.AnonOidcAuthService;
 import dev.getelements.elements.service.auth.oidc.SuperUserOidcAuthSchemeService;
-import dev.getelements.elements.service.auth.oidc.StandardOidcLoginAttemptService;
+import dev.getelements.elements.service.auth.oidc.AnonOidcLoginAttemptService;
 import dev.getelements.elements.service.auth.oidc.SuperUserOidcProviderConfigurationService;
 import dev.getelements.elements.service.blockchain.crypto.evm.SuperUserEvmSmartContractInvocationService;
 import dev.getelements.elements.service.blockchain.crypto.flow.SuperUserFlowSmartContractInvocationService;
@@ -120,7 +120,7 @@ public class UnscopedServicesModule extends AbstractModule {
 
         bind(OidcLoginAttemptService.class)
                 .annotatedWith(named(UNSCOPED))
-                .to(StandardOidcLoginAttemptService.class);
+                .to(AnonOidcLoginAttemptService.class);
 
         bind(OAuth2AuthService.class)
                 .annotatedWith(named(UNSCOPED))

--- a/service-test/src/test/java/dev/getelements/elements/service/OidcLoginAttemptOperationsTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OidcLoginAttemptOperationsTest.java
@@ -6,6 +6,8 @@ import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.OidcLoginAttemptDao;
 import dev.getelements.elements.sdk.dao.OidcProviderConfigurationDao;
 import dev.getelements.elements.sdk.dao.SessionDao;
+import dev.getelements.elements.sdk.dao.UserDao;
+import dev.getelements.elements.sdk.dao.UserUidDao;
 import dev.getelements.elements.sdk.model.auth.JWK;
 import dev.getelements.elements.sdk.model.auth.OidcAuthScheme;
 import dev.getelements.elements.sdk.model.auth.OidcLoginAttempt;
@@ -14,11 +16,15 @@ import dev.getelements.elements.sdk.model.auth.OidcProviderConfiguration;
 import dev.getelements.elements.sdk.model.auth.TokenEndpointAuthMethod;
 import dev.getelements.elements.sdk.model.exception.InvalidDataException;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
+import dev.getelements.elements.sdk.model.user.User;
+import dev.getelements.elements.sdk.model.user.UserUid;
 import dev.getelements.elements.service.auth.oidc.AnonOidcAuthService;
 import dev.getelements.elements.service.auth.oidc.OidcAuthServiceOperations;
 import dev.getelements.elements.service.auth.oidc.OidcDiscoveryDocument;
 import dev.getelements.elements.service.auth.oidc.OidcLoginAttemptOperations;
 import dev.getelements.elements.service.auth.oidc.OidcProviderConfigurationOperations;
+import dev.getelements.elements.service.auth.oidc.UserOidcAuthService;
+import dev.getelements.elements.sdk.ElementRegistry;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
@@ -62,6 +68,8 @@ public class OidcLoginAttemptOperationsTest {
     private OidcProviderConfigurationOperations oidcProviderConfigurationOperations;
     private OidcAuthServiceOperations oidcAuthServiceOperations;
     private AnonOidcAuthService anonOidcAuthService;
+    private UserOidcAuthService userOidcAuthService;
+    private UserDao userDao;
     private Client client;
 
     private OidcLoginAttemptOperations operations;
@@ -84,6 +92,16 @@ public class OidcLoginAttemptOperationsTest {
         anonOidcAuthService = mock(AnonOidcAuthService.class);
         client = mock(Client.class);
 
+        // Real UserOidcAuthService — exercises the actual uid-linking logic rather than mocking it away.
+        userOidcAuthService = new UserOidcAuthService();
+        final var userUidDao = mock(UserUidDao.class);
+        when(userUidDao.createUserUidStrict(any(UserUid.class))).then(i -> i.getArgument(0));
+        userOidcAuthService.setUserUidDao(userUidDao);
+        userOidcAuthService.setUserDao(mock(UserDao.class));
+        userOidcAuthService.setElementRegistry(mock(ElementRegistry.class));
+
+        userDao = mock(UserDao.class);
+
         // Real OidcAuthServiceOperations — exercises the actual shared validation/session-building code rather
         // than mocking it away. The token carries an 'aud' claim (needed for the audience check), which also
         // triggers buildSession's optional Application lookup, so ApplicationDao/SessionDao need mocking too.
@@ -105,6 +123,8 @@ public class OidcLoginAttemptOperationsTest {
         operations.setOidcProviderConfigurationOperations(oidcProviderConfigurationOperations);
         operations.setOidcAuthServiceOperations(oidcAuthServiceOperations);
         operations.setAnonOidcAuthService(anonOidcAuthService);
+        operations.setUserOidcAuthService(userOidcAuthService);
+        operations.setUserDao(userDao);
         operations.setClient(client);
         operations.setTtlSeconds(300L);
 
@@ -215,6 +235,31 @@ public class OidcLoginAttemptOperationsTest {
 
     }
 
+    @Test
+    public void testBeginWithoutLinkingUserLeavesLinkedUserIdNull() {
+
+        operations.begin(PROVIDER);
+
+        final var attemptCaptor = ArgumentCaptor.forClass(OidcLoginAttempt.class);
+        verify(oidcLoginAttemptDao).create(attemptCaptor.capture());
+        assertNull(attemptCaptor.getValue().getLinkedUserId());
+
+    }
+
+    @Test
+    public void testBeginWithLinkingUserStampsLinkedUserId() {
+
+        final var user = new User();
+        user.setId("current-user-id");
+
+        operations.begin(PROVIDER, user);
+
+        final var attemptCaptor = ArgumentCaptor.forClass(OidcLoginAttempt.class);
+        verify(oidcLoginAttemptDao).create(attemptCaptor.capture());
+        assertEquals(attemptCaptor.getValue().getLinkedUserId(), "current-user-id");
+
+    }
+
     // ── handleCallback() ─────────────────────────────────────────────────────
 
     @Test
@@ -314,6 +359,40 @@ public class OidcLoginAttemptOperationsTest {
 
         assertTrue(result.isSuccess());
         assertEquals(result.getRedirectUrl(), "https://game.example.com/success");
+
+    }
+
+    @Test
+    public void testHandleCallbackForLinkingAttemptLinksToStoredUserInsteadOfAnon() {
+
+        final var state = "linking-state";
+        final var nonce = "linking-nonce";
+        final var attempt = pendingAttempt(state, nonce);
+        attempt.setLinkedUserId("current-user-id");
+
+        when(oidcLoginAttemptDao.findPendingByState(PROVIDER, state)).thenReturn(Optional.of(attempt));
+        when(oidcLoginAttemptDao.markComplete(eq(state), anyString())).thenReturn(Optional.of(attempt));
+
+        final var linkedUser = new User();
+        linkedUser.setId("current-user-id");
+        when(userDao.getUser("current-user-id")).thenReturn(linkedUser);
+
+        final var idToken = JWT.create()
+                .withIssuer(ISSUER)
+                .withSubject("twitch-sub")
+                .withAudience(CLIENT_ID)
+                .withClaim("nonce", nonce)
+                .withKeyId(KID)
+                .withExpiresAt(new Date(currentTimeMillis() + 60_000))
+                .sign(algorithm);
+
+        stubTokenExchange(idToken);
+
+        final var result = operations.handleCallback(PROVIDER, "auth-code", state, null);
+
+        assertTrue(result.isSuccess());
+        verifyNoInteractions(anonOidcAuthService);
+        verify(userDao).getUser("current-user-id");
 
     }
 

--- a/service-test/src/test/java/dev/getelements/elements/service/OidcLoginAttemptOperationsTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OidcLoginAttemptOperationsTest.java
@@ -14,7 +14,9 @@ import dev.getelements.elements.sdk.model.auth.OidcLoginAttempt;
 import dev.getelements.elements.sdk.model.auth.OidcLoginAttemptStatus;
 import dev.getelements.elements.sdk.model.auth.OidcProviderConfiguration;
 import dev.getelements.elements.sdk.model.auth.TokenEndpointAuthMethod;
+import dev.getelements.elements.sdk.model.exception.ForbiddenException;
 import dev.getelements.elements.sdk.model.exception.InvalidDataException;
+import dev.getelements.elements.sdk.model.session.OidcLoginAttemptStatusResponse;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
 import dev.getelements.elements.sdk.model.user.User;
 import dev.getelements.elements.sdk.model.user.UserUid;
@@ -193,6 +195,8 @@ public class OidcLoginAttemptOperationsTest {
 
         assertNotNull(begin.getId());
         assertTrue(begin.getExpiresAt() > currentTimeMillis() / 1000);
+        assertNotNull(begin.getConfirmToken());
+        assertFalse(begin.getConfirmToken().isBlank());
 
         final var url = begin.getAuthorizeUrl();
         assertTrue(url.startsWith(AUTHORIZATION_ENDPOINT));
@@ -203,6 +207,8 @@ public class OidcLoginAttemptOperationsTest {
         assertTrue(url.contains("scope=openid"));
         assertTrue(url.contains("claims=email"));
         assertFalse(url.contains(CLIENT_SECRET), "authorize URL must never contain the client secret");
+        assertFalse(url.contains(begin.getConfirmToken()),
+                "confirmToken must never travel through the browser/IdP leg of the flow");
 
         final var attemptCaptor = ArgumentCaptor.forClass(OidcLoginAttempt.class);
         verify(oidcLoginAttemptDao).create(attemptCaptor.capture());
@@ -213,6 +219,7 @@ public class OidcLoginAttemptOperationsTest {
         assertEquals(persisted.getStatus(), OidcLoginAttemptStatus.PENDING);
         assertNotNull(persisted.getState());
         assertNotNull(persisted.getNonce());
+        assertEquals(persisted.getConfirmToken(), begin.getConfirmToken());
 
     }
 
@@ -363,7 +370,7 @@ public class OidcLoginAttemptOperationsTest {
     }
 
     @Test
-    public void testHandleCallbackForLinkingAttemptLinksToStoredUserInsteadOfAnon() {
+    public void testHandleCallbackForLinkingAttemptMarksLinkReadyWithoutMutating() {
 
         final var state = "linking-state";
         final var nonce = "linking-nonce";
@@ -371,11 +378,7 @@ public class OidcLoginAttemptOperationsTest {
         attempt.setLinkedUserId("current-user-id");
 
         when(oidcLoginAttemptDao.findPendingByState(PROVIDER, state)).thenReturn(Optional.of(attempt));
-        when(oidcLoginAttemptDao.markComplete(eq(state), anyString())).thenReturn(Optional.of(attempt));
-
-        final var linkedUser = new User();
-        linkedUser.setId("current-user-id");
-        when(userDao.getUser("current-user-id")).thenReturn(linkedUser);
+        when(oidcLoginAttemptDao.markLinkReady(eq(state), anyString())).thenReturn(Optional.of(attempt));
 
         final var idToken = JWT.create()
                 .withIssuer(ISSUER)
@@ -391,9 +394,105 @@ public class OidcLoginAttemptOperationsTest {
         final var result = operations.handleCallback(PROVIDER, "auth-code", state, null);
 
         assertTrue(result.isSuccess());
+        verify(oidcLoginAttemptDao).markLinkReady(eq(state), anyString());
+        verify(oidcLoginAttemptDao, never()).markComplete(any(), any());
         verifyNoInteractions(anonOidcAuthService);
-        verify(userDao).getUser("current-user-id");
+        verifyNoInteractions(userDao);
 
+        final var claimsCaptor = ArgumentCaptor.forClass(String.class);
+        verify(oidcLoginAttemptDao).markLinkReady(eq(state), claimsCaptor.capture());
+        assertTrue(claimsCaptor.getValue().contains("twitch-sub"));
+
+    }
+
+    // ── poll() ───────────────────────────────────────────────────────────────
+
+    @Test(expectedExceptions = ForbiddenException.class)
+    public void testPollOnLinkReadyAttemptThrows() {
+        when(oidcLoginAttemptDao.claimCompleteById("link-ready-id")).thenReturn(Optional.empty());
+        when(oidcLoginAttemptDao.findLinkReadyById("link-ready-id"))
+                .thenReturn(Optional.of(linkReadyAttempt()));
+        operations.poll("link-ready-id");
+    }
+
+    // ── confirmLink() ────────────────────────────────────────────────────────
+
+    @Test
+    public void testConfirmLinkWithCorrectTokenPerformsLinkAndReturnsSession() {
+
+        final var attempt = linkReadyAttempt();
+
+        when(oidcLoginAttemptDao.findLinkReadyById("link-ready-id")).thenReturn(Optional.of(attempt));
+        when(oidcLoginAttemptDao.claimLinkReadyById("link-ready-id")).thenReturn(Optional.of(attempt));
+
+        final var linkedUser = new User();
+        linkedUser.setId("current-user-id");
+        when(userDao.getUser("current-user-id")).thenReturn(linkedUser);
+
+        final var result = operations.confirmLink("link-ready-id", "correct-token");
+
+        assertEquals(result.getStatus(), dev.getelements.elements.sdk.model.session.OidcLoginAttemptState.COMPLETE);
+        assertNotNull(result.getSession());
+        verify(userDao).getUser("current-user-id");
+        verify(oidcLoginAttemptDao).claimLinkReadyById("link-ready-id");
+
+    }
+
+    @Test(expectedExceptions = ForbiddenException.class)
+    public void testConfirmLinkWithWrongTokenThrowsAndDoesNotConsume() {
+
+        when(oidcLoginAttemptDao.findLinkReadyById("link-ready-id"))
+                .thenReturn(Optional.of(linkReadyAttempt()));
+
+        try {
+            operations.confirmLink("link-ready-id", "wrong-token");
+        } finally {
+            verify(oidcLoginAttemptDao, never()).claimLinkReadyById(any());
+        }
+
+    }
+
+    @Test(expectedExceptions = ForbiddenException.class)
+    public void testConfirmLinkWithNullTokenThrowsAndDoesNotConsume() {
+        when(oidcLoginAttemptDao.findLinkReadyById("link-ready-id"))
+                .thenReturn(Optional.of(linkReadyAttempt()));
+        try {
+            operations.confirmLink("link-ready-id", null);
+        } finally {
+            verify(oidcLoginAttemptDao, never()).claimLinkReadyById(any());
+        }
+    }
+
+    @Test
+    public void testConfirmLinkOnUnknownIdReturnsExpired() {
+        when(oidcLoginAttemptDao.findLinkReadyById("unknown-id")).thenReturn(Optional.empty());
+        final var result = operations.confirmLink("unknown-id", "any-token");
+        assertEquals(result.getStatus(), dev.getelements.elements.sdk.model.session.OidcLoginAttemptState.EXPIRED);
+    }
+
+    @Test
+    public void testConfirmLinkLosingClaimRaceReturnsExpired() {
+
+        when(oidcLoginAttemptDao.findLinkReadyById("link-ready-id"))
+                .thenReturn(Optional.of(linkReadyAttempt()));
+        when(oidcLoginAttemptDao.claimLinkReadyById("link-ready-id")).thenReturn(Optional.empty());
+
+        final var result = operations.confirmLink("link-ready-id", "correct-token");
+
+        assertEquals(result.getStatus(), dev.getelements.elements.sdk.model.session.OidcLoginAttemptState.EXPIRED);
+        verifyNoInteractions(userDao);
+
+    }
+
+    private OidcLoginAttempt linkReadyAttempt() {
+        final var attempt = pendingAttempt("linking-state", "linking-nonce");
+        attempt.setId("link-ready-id");
+        attempt.setStatus(OidcLoginAttemptStatus.LINK_READY);
+        attempt.setLinkedUserId("current-user-id");
+        attempt.setConfirmToken("correct-token");
+        attempt.setLinkClaimsJson(
+                "{\"schemeName\":\"twitch\",\"externalUserId\":\"twitch-sub\",\"email\":null,\"profileClaims\":{}}");
+        return attempt;
     }
 
     @Test

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/AnonOidcLoginAttemptService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/AnonOidcLoginAttemptService.java
@@ -1,0 +1,43 @@
+package dev.getelements.elements.service.auth.oidc;
+
+import dev.getelements.elements.sdk.model.session.OidcLoginAttemptBegin;
+import dev.getelements.elements.sdk.model.session.OidcLoginAttemptCallbackResult;
+import dev.getelements.elements.sdk.model.session.OidcLoginAttemptStatusResponse;
+import dev.getelements.elements.sdk.service.auth.OidcLoginAttemptService;
+import jakarta.inject.Inject;
+
+/**
+ * Anonymous (first-time login) browser-redirect OIDC attempt. Dispatched by
+ * {@link OidcLoginAttemptServiceProvider} when the caller has no existing Elements session; see
+ * {@link UserOidcLoginAttemptService} for the account-linking counterpart.
+ */
+public class AnonOidcLoginAttemptService implements OidcLoginAttemptService {
+
+    private OidcLoginAttemptOperations oidcLoginAttemptOperations;
+
+    @Override
+    public OidcLoginAttemptBegin begin(final String provider) {
+        return getOidcLoginAttemptOperations().begin(provider);
+    }
+
+    @Override
+    public OidcLoginAttemptStatusResponse poll(final String id) {
+        return getOidcLoginAttemptOperations().poll(id);
+    }
+
+    @Override
+    public OidcLoginAttemptCallbackResult handleCallback(final String provider, final String code,
+                                                           final String state, final String error) {
+        return getOidcLoginAttemptOperations().handleCallback(provider, code, state, error);
+    }
+
+    public OidcLoginAttemptOperations getOidcLoginAttemptOperations() {
+        return oidcLoginAttemptOperations;
+    }
+
+    @Inject
+    public void setOidcLoginAttemptOperations(OidcLoginAttemptOperations oidcLoginAttemptOperations) {
+        this.oidcLoginAttemptOperations = oidcLoginAttemptOperations;
+    }
+
+}

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/AnonOidcLoginAttemptService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/AnonOidcLoginAttemptService.java
@@ -26,6 +26,11 @@ public class AnonOidcLoginAttemptService implements OidcLoginAttemptService {
     }
 
     @Override
+    public OidcLoginAttemptStatusResponse confirmLink(final String id, final String confirmToken) {
+        return getOidcLoginAttemptOperations().confirmLink(id, confirmToken);
+    }
+
+    @Override
     public OidcLoginAttemptCallbackResult handleCallback(final String provider, final String code,
                                                            final String state, final String error) {
         return getOidcLoginAttemptOperations().handleCallback(provider, code, state, error);

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
@@ -221,7 +221,9 @@ public class OidcAuthServiceOperations {
 
         final var kid = jwt.getHeaderClaim(OidcClaim.KID.getValue()).asString();
 
-        final var jwk = scheme.getKeys()
+        // A scheme with no keys fetched yet (or a legacy record predating the keys field) has null here rather
+        // than an empty list; treated the same as "no matching key" so it falls through to the fetch-on-miss path.
+        final var jwk = (scheme.getKeys() == null ? List.<JWK>of() : scheme.getKeys())
                 .stream()
                 .filter(k -> Objects.equals(k.getKid(), kid))
                 .findFirst()

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
@@ -149,6 +149,22 @@ public class OidcAuthServiceOperations {
         return buildSession(decodedJWT, scheme, userMapper);
     }
 
+    /**
+     * Builds and persists a session for an already-resolved user, with no token of its own to run through
+     * {@link #buildSession}. Used by the login-attempt confirm flow, where the user was resolved (and any
+     * account-link mutation already performed) from claims persisted by an earlier callback, not a live JWT.
+     *
+     * @param user the already-resolved user
+     * @return the created session
+     */
+    public SessionCreation createSessionForResolvedUser(final User user) {
+        final long expiry = MILLISECONDS.convert(getSessionTimeoutSeconds(), SECONDS) + currentTimeMillis();
+        final var session = new Session();
+        session.setUser(user);
+        session.setExpiry(expiry);
+        return getSessionDao().create(session);
+    }
+
     private SessionCreation buildSession(final DecodedJWT decodedJWT,
                                           final OidcAuthScheme scheme,
                                           final BiFunction<DecodedJWT, OidcAuthScheme, User> userMapper) {

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLinkClaims.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLinkClaims.java
@@ -1,0 +1,52 @@
+package dev.getelements.elements.service.auth.oidc;
+
+import java.util.Map;
+
+/**
+ * External-identity claims validated by the callback for a linking login attempt, persisted on
+ * {@code OidcLoginAttempt#getLinkClaimsJson()} while the mutation itself is deferred to the confirm flow. Internal
+ * wire-format DTO only.
+ */
+public class OidcLinkClaims {
+
+    private String schemeName;
+
+    private String externalUserId;
+
+    private String email;
+
+    private Map<String, String> profileClaims;
+
+    public String getSchemeName() {
+        return schemeName;
+    }
+
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
+    }
+
+    public String getExternalUserId() {
+        return externalUserId;
+    }
+
+    public void setExternalUserId(String externalUserId) {
+        this.externalUserId = externalUserId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Map<String, String> getProfileClaims() {
+        return profileClaims;
+    }
+
+    public void setProfileClaims(Map<String, String> profileClaims) {
+        this.profileClaims = profileClaims;
+    }
+
+}

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
@@ -1,8 +1,11 @@
 package dev.getelements.elements.service.auth.oidc;
 
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.getelements.elements.sdk.dao.OidcLoginAttemptDao;
 import dev.getelements.elements.sdk.dao.OidcProviderConfigurationDao;
+import dev.getelements.elements.sdk.dao.UserDao;
+import dev.getelements.elements.sdk.model.auth.OidcAuthScheme;
 import dev.getelements.elements.sdk.model.auth.OidcLoginAttempt;
 import dev.getelements.elements.sdk.model.auth.OidcLoginAttemptStatus;
 import dev.getelements.elements.sdk.model.auth.OidcProviderConfiguration;
@@ -14,6 +17,7 @@ import dev.getelements.elements.sdk.model.session.OidcLoginAttemptBegin;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptCallbackResult;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptStatusResponse;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
+import dev.getelements.elements.sdk.model.user.User;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.client.Client;
@@ -22,6 +26,8 @@ import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.BiFunction;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -38,6 +44,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * completion, and handling the provider's callback. All state (id/state/nonce), the code exchange, and
  * id_token validation happen here, server-side, per the design — the client only ever sees an opaque id and
  * the Elements session it eventually resolves to.
+ *
+ * <p>Supports both anonymous (first-time login) and account-linking attempts. Which behavior applies is decided
+ * once, at {@link #begin(String, User)} time, when the caller's own session (if any) is known, and is carried on
+ * the persisted {@link OidcLoginAttempt#getLinkedUserId()} field through to {@link #handleCallback}, since the
+ * callback itself is always hit by an unauthenticated provider redirect with no session of its own.
  */
 public class OidcLoginAttemptOperations {
 
@@ -59,11 +70,31 @@ public class OidcLoginAttemptOperations {
 
     private AnonOidcAuthService anonOidcAuthService;
 
+    private UserOidcAuthService userOidcAuthService;
+
+    private UserDao userDao;
+
     private Client client;
 
     private long ttlSeconds;
 
     public OidcLoginAttemptBegin begin(final String provider) {
+        return begin(provider, null);
+    }
+
+    /**
+     * Begins a pending login attempt, optionally on behalf of an already-authenticated user. When
+     * {@code linkingUser} is non-null (the caller had an existing Elements session when starting the attempt),
+     * the attempt is stamped with that user's id so a later successful callback links the external identity to
+     * them instead of creating/finding a user by external id — the callback itself, hit by an unauthenticated
+     * provider redirect, has no session of its own to make that determination.
+     *
+     * @param provider the provider identifier
+     * @param linkingUser the already-authenticated user to link on success, or {@code null} for an anonymous
+     *                    (first-time login) attempt
+     * @return the pending attempt's id, authorize URL, and expiry
+     */
+    public OidcLoginAttemptBegin begin(final String provider, final User linkingUser) {
 
         final var config = findConfigOrThrow(provider);
         final var discoveryDocument = getOidcProviderConfigurationOperations().resolveDiscovery(config);
@@ -84,6 +115,10 @@ public class OidcLoginAttemptOperations {
         // edit to the config mid-flight can't change the outcome of an attempt already in progress.
         attempt.setSuccessRedirectUrl(config.getSuccessRedirectUrl());
         attempt.setErrorRedirectUrl(config.getErrorRedirectUrl());
+
+        if (linkingUser != null) {
+            attempt.setLinkedUserId(linkingUser.getId());
+        }
 
         getOidcLoginAttemptDao().create(attempt);
 
@@ -144,7 +179,7 @@ public class OidcLoginAttemptOperations {
                     idToken, scheme, config.getClientId(), attempt.getNonce());
 
             final var sessionCreation = getOidcAuthServiceOperations().createOrUpdateUserWithVerifiedToken(
-                    decodedJWT, scheme, getAnonOidcAuthService()::apply);
+                    decodedJWT, scheme, userMapperFor(attempt));
 
             final var completed = getOidcLoginAttemptDao().markComplete(state, serializeSession(sessionCreation));
 
@@ -165,6 +200,19 @@ public class OidcLoginAttemptOperations {
             getOidcLoginAttemptDao().markFailed(state, "Login failed");
             return OidcLoginAttemptCallbackResult.failure(errorRedirectUrl);
         }
+
+    }
+
+    private BiFunction<DecodedJWT, OidcAuthScheme, User> userMapperFor(final OidcLoginAttempt attempt) {
+
+        final var linkedUserId = attempt.getLinkedUserId();
+
+        if (linkedUserId == null) {
+            return getAnonOidcAuthService()::apply;
+        }
+
+        final var linkedUser = getUserDao().getUser(linkedUserId);
+        return (jwt, scheme) -> getUserOidcAuthService().apply(linkedUser, jwt, scheme);
 
     }
 
@@ -318,6 +366,24 @@ public class OidcLoginAttemptOperations {
     @Inject
     public void setAnonOidcAuthService(AnonOidcAuthService anonOidcAuthService) {
         this.anonOidcAuthService = anonOidcAuthService;
+    }
+
+    public UserOidcAuthService getUserOidcAuthService() {
+        return userOidcAuthService;
+    }
+
+    @Inject
+    public void setUserOidcAuthService(UserOidcAuthService userOidcAuthService) {
+        this.userOidcAuthService = userOidcAuthService;
+    }
+
+    public UserDao getUserDao() {
+        return userDao;
+    }
+
+    @Inject
+    public void setUserDao(UserDao userDao) {
+        this.userDao = userDao;
     }
 
     public Client getClient() {

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
@@ -132,6 +132,15 @@ public class OidcLoginAttemptOperations {
 
     }
 
+    /**
+     * Polls a pending attempt by id. Returns {@code COMPLETE} with the session exactly once, on the poll that
+     * first observes completion; every subsequent poll for the same id returns {@code EXPIRED}. A non-mutating
+     * peek: a linking attempt that has become link-ready is rejected outright, since finalizing it here would
+     * mean trusting whoever presents {@code id} alone with the account-link mutation — see {@link #confirmLink}.
+     *
+     * @param id the opaque poll id
+     * @return the current status of the attempt
+     */
     public OidcLoginAttemptStatusResponse poll(final String id) {
 
         final var claimed = getOidcLoginAttemptDao().claimCompleteById(id);
@@ -207,6 +216,23 @@ public class OidcLoginAttemptOperations {
 
     }
 
+    /**
+     * Handles the provider's redirect callback: looks up the pending attempt by state, exchanges the code for an
+     * id_token, and validates it. For an anonymous attempt, builds and stores the session directly, exactly as
+     * before. For a linking attempt, deliberately does <em>not</em> perform the account-link mutation — this
+     * callback is always hit by an unauthenticated provider redirect with no way to verify it's talking to the
+     * same party that called {@link #begin(String, User)} — and instead persists the validated claims and marks
+     * the attempt {@link OidcLoginAttemptStatus#LINK_READY}, deferring the mutation to {@link #confirmLink}. Fails
+     * closed (marks the attempt FAILED) on any missing/expired/mismatched state, nonce mismatch, or exchange or
+     * validation failure; never throws for an expected failure mode, so the REST layer stays a thin dispatcher
+     * over the returned result.
+     *
+     * @param provider the provider identifier from the callback path
+     * @param code the authorization code from the provider, or {@code null} if the provider reported an error
+     * @param state the state value from the provider, matched against the pending attempt
+     * @param error the provider's {@code error} query parameter, or {@code null} on a normal code-bearing callback
+     * @return the outcome, including the caller-configured redirect URL for that outcome, if any
+     */
     public OidcLoginAttemptCallbackResult handleCallback(final String provider, final String code,
                                                           final String state, final String error) {
 
@@ -279,7 +305,7 @@ public class OidcLoginAttemptOperations {
             // Never log the code, id_token, or attempt id — only enough context to debug which provider/attempt failed.
             // Every expected failure mode is caught here so the REST layer never has to interpret an exception —
             // it only sees a plain failure result.
-            logger.debug("OIDC callback failed for provider {}", provider, ex);
+            logger.error("OIDC callback failed for provider {}", provider, ex);
             getOidcLoginAttemptDao().markFailed(state, "Login failed");
             return OidcLoginAttemptCallbackResult.failure(errorRedirectUrl);
         }

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
@@ -1,11 +1,9 @@
 package dev.getelements.elements.service.auth.oidc;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.getelements.elements.sdk.dao.OidcLoginAttemptDao;
 import dev.getelements.elements.sdk.dao.OidcProviderConfigurationDao;
 import dev.getelements.elements.sdk.dao.UserDao;
-import dev.getelements.elements.sdk.model.auth.OidcAuthScheme;
 import dev.getelements.elements.sdk.model.auth.OidcLoginAttempt;
 import dev.getelements.elements.sdk.model.auth.OidcLoginAttemptStatus;
 import dev.getelements.elements.sdk.model.auth.OidcProviderConfiguration;
@@ -27,10 +25,9 @@ import jakarta.ws.rs.core.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.function.BiFunction;
-
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.util.Base64;
@@ -46,9 +43,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * the Elements session it eventually resolves to.
  *
  * <p>Supports both anonymous (first-time login) and account-linking attempts. Which behavior applies is decided
- * once, at {@link #begin(String, User)} time, when the caller's own session (if any) is known, and is carried on
- * the persisted {@link OidcLoginAttempt#getLinkedUserId()} field through to {@link #handleCallback}, since the
- * callback itself is always hit by an unauthenticated provider redirect with no session of its own.
+ * once, at {@link #begin(String, User)} time, when the caller's own session (if any) is known. For an anonymous
+ * attempt, {@link #handleCallback} builds and stores the session directly, exactly as before. For a linking
+ * attempt, {@link #handleCallback} — always hit by an unauthenticated provider redirect, with no session of its
+ * own and no way to verify it's talking to the same party that called {@code begin()} — deliberately does
+ * <em>not</em> perform the account-link mutation. It only validates the external identity and marks the attempt
+ * {@link OidcLoginAttemptStatus#LINK_READY}. Finalizing it requires {@link #confirmLink}, presenting the
+ * {@code confirmToken} returned only in the original {@code begin()} response — proof that the caller is the
+ * same party that started the attempt, without relying on Elements' own session/access-level machinery.
  */
 public class OidcLoginAttemptOperations {
 
@@ -102,6 +104,7 @@ public class OidcLoginAttemptOperations {
         final var id = randomToken();
         final var state = randomToken();
         final var nonce = randomToken();
+        final var confirmToken = randomToken();
         final var expiry = new Timestamp(currentTimeMillis() + (ttlSeconds * 1000));
 
         final var attempt = new OidcLoginAttempt();
@@ -109,6 +112,7 @@ public class OidcLoginAttemptOperations {
         attempt.setProvider(provider);
         attempt.setState(state);
         attempt.setNonce(nonce);
+        attempt.setConfirmToken(confirmToken);
         attempt.setStatus(OidcLoginAttemptStatus.PENDING);
         attempt.setExpiry(expiry);
         // Snapshotted from the provider config at begin() time, not read live at callback time, so an admin
@@ -124,7 +128,7 @@ public class OidcLoginAttemptOperations {
 
         final var authorizeUrl = buildAuthorizeUrl(config, discoveryDocument, state, nonce);
 
-        return new OidcLoginAttemptBegin(id, authorizeUrl, expiry.toInstant().getEpochSecond());
+        return new OidcLoginAttemptBegin(id, authorizeUrl, expiry.toInstant().getEpochSecond(), confirmToken);
 
     }
 
@@ -137,6 +141,13 @@ public class OidcLoginAttemptOperations {
             return OidcLoginAttemptStatusResponse.complete(sessionCreation);
         }
 
+        // A non-mutating peek: a linking attempt is never finalizable via plain poll, since doing so would mean
+        // trusting whoever presents `id` alone with the account-link mutation. Reject rather than silently
+        // returning PENDING forever, so the client learns it must call confirmLink() instead.
+        if (getOidcLoginAttemptDao().findLinkReadyById(id).isPresent()) {
+            throw new ForbiddenException("This login attempt requires confirmation via POST .../confirm.");
+        }
+
         return getOidcLoginAttemptDao()
                 .findPendingOrFailedById(id)
                 .map(attempt -> attempt.getStatus() == OidcLoginAttemptStatus.FAILED
@@ -145,6 +156,54 @@ public class OidcLoginAttemptOperations {
                 // Unknown id, already claimed, or TTL-purged are all indistinguishable to the caller, and
                 // all correctly reported as EXPIRED per the API contract.
                 .orElseGet(OidcLoginAttemptStatusResponse::expired);
+
+    }
+
+    /**
+     * Finalizes a linking attempt by presenting the {@code confirmToken} returned only in the original
+     * {@code begin()} response — the sole proof that the caller is the same party that started the attempt.
+     * Performs the actual account-link mutation (deferred out of {@link #handleCallback}, which cannot make this
+     * determination itself) and mints the resulting session.
+     *
+     * @param id the opaque poll id
+     * @param confirmToken the secret returned in the original {@code begin()} response for this attempt
+     * @return the completed session, or {@link OidcLoginAttemptStatusResponse#expired()} if the attempt is
+     *         unknown, not link-ready, already claimed, or expired
+     */
+    public OidcLoginAttemptStatusResponse confirmLink(final String id, final String confirmToken) {
+
+        final var attemptOptional = getOidcLoginAttemptDao().findLinkReadyById(id);
+
+        if (attemptOptional.isEmpty()) {
+            return OidcLoginAttemptStatusResponse.expired();
+        }
+
+        final var attempt = attemptOptional.get();
+
+        if (confirmToken == null || !constantTimeEquals(confirmToken, attempt.getConfirmToken())) {
+            // Deliberately does not consume the attempt: a wrong/missing token might just be a client bug, and
+            // the legitimate holder of the real confirmToken must still be able to retry.
+            throw new ForbiddenException("Invalid confirmation token.");
+        }
+
+        // Only claim (and thus consume) the attempt once the token has already been verified to match.
+        final var claimed = getOidcLoginAttemptDao().claimLinkReadyById(id);
+
+        if (claimed.isEmpty()) {
+            // Lost a race to a concurrent confirm for the same id.
+            return OidcLoginAttemptStatusResponse.expired();
+        }
+
+        final var claims = deserializeLinkClaims(claimed.get().getLinkClaimsJson());
+        final var targetUser = getUserDao().getUser(claimed.get().getLinkedUserId());
+
+        final var linkedUser = getUserOidcAuthService().apply(
+                targetUser, claims.getSchemeName(), claims.getExternalUserId(), claims.getEmail(),
+                claims.getProfileClaims());
+
+        final var sessionCreation = getOidcAuthServiceOperations().createSessionForResolvedUser(linkedUser);
+
+        return OidcLoginAttemptStatusResponse.complete(sessionCreation);
 
     }
 
@@ -178,8 +237,32 @@ public class OidcLoginAttemptOperations {
             final var decodedJWT = getOidcAuthServiceOperations().decodeAndVerify(
                     idToken, scheme, config.getClientId(), attempt.getNonce());
 
+            if (attempt.getLinkedUserId() != null) {
+
+                // Linking attempt: the account-link mutation is deliberately deferred to confirmLink(), which
+                // this (always-unauthenticated) callback cannot itself gate correctly -- it has no way to verify
+                // it's talking to the same party that called begin(). Only the validated external identity is
+                // persisted here.
+                final var claims = new OidcLinkClaims();
+                claims.setSchemeName(scheme.getName());
+                claims.setExternalUserId(OidcAuthServiceOperations.claimAsString(
+                        decodedJWT, OidcAuthServiceOperations.Claim.USER_ID.value));
+                claims.setEmail(OidcAuthServiceOperations.claimAsString(
+                        decodedJWT, OidcAuthServiceOperations.Claim.EMAIL.value));
+                claims.setProfileClaims(OidcAuthServiceOperations.extractProfileClaims(decodedJWT));
+
+                final var linkReady = getOidcLoginAttemptDao().markLinkReady(state, serializeLinkClaims(claims));
+
+                if (linkReady.isEmpty()) {
+                    return OidcLoginAttemptCallbackResult.failure(errorRedirectUrl);
+                }
+
+                return OidcLoginAttemptCallbackResult.success(successRedirectUrl);
+
+            }
+
             final var sessionCreation = getOidcAuthServiceOperations().createOrUpdateUserWithVerifiedToken(
-                    decodedJWT, scheme, userMapperFor(attempt));
+                    decodedJWT, scheme, getAnonOidcAuthService()::apply);
 
             final var completed = getOidcLoginAttemptDao().markComplete(state, serializeSession(sessionCreation));
 
@@ -200,19 +283,6 @@ public class OidcLoginAttemptOperations {
             getOidcLoginAttemptDao().markFailed(state, "Login failed");
             return OidcLoginAttemptCallbackResult.failure(errorRedirectUrl);
         }
-
-    }
-
-    private BiFunction<DecodedJWT, OidcAuthScheme, User> userMapperFor(final OidcLoginAttempt attempt) {
-
-        final var linkedUserId = attempt.getLinkedUserId();
-
-        if (linkedUserId == null) {
-            return getAnonOidcAuthService()::apply;
-        }
-
-        final var linkedUser = getUserDao().getUser(linkedUserId);
-        return (jwt, scheme) -> getUserOidcAuthService().apply(linkedUser, jwt, scheme);
 
     }
 
@@ -321,6 +391,30 @@ public class OidcLoginAttemptOperations {
         } catch (final Exception ex) {
             throw new InternalException(ex);
         }
+    }
+
+    private static String serializeLinkClaims(final OidcLinkClaims claims) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(claims);
+        } catch (final Exception ex) {
+            throw new InternalException(ex);
+        }
+    }
+
+    private static OidcLinkClaims deserializeLinkClaims(final String json) {
+        try {
+            return OBJECT_MAPPER.readValue(json, OidcLinkClaims.class);
+        } catch (final Exception ex) {
+            throw new InternalException(ex);
+        }
+    }
+
+    /**
+     * A real secret comparison (unlike the other lookups in this class, which are keyed by unguessable random
+     * tokens anyway) — compared in constant time to avoid leaking match-length information via timing.
+     */
+    private static boolean constantTimeEquals(final String a, final String b) {
+        return MessageDigest.isEqual(a.getBytes(UTF_8), b.getBytes(UTF_8));
     }
 
     public OidcProviderConfigurationDao getOidcProviderConfigurationDao() {

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptServiceProvider.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptServiceProvider.java
@@ -1,29 +1,59 @@
 package dev.getelements.elements.service.auth.oidc;
 
+import dev.getelements.elements.sdk.model.user.User;
 import dev.getelements.elements.sdk.service.auth.OidcLoginAttemptService;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 
 /**
- * Always anonymous, mirroring {@link OidcAuthServiceProvider} — a caller has no Elements session yet when
- * starting or polling a browser-redirect login attempt, by definition, so there is no per-user-level dispatch.
+ * Dispatches on the caller's access level, mirroring {@link OidcLinkServiceProvider} — an already-authenticated
+ * caller (USER/SUPERUSER) gets an account-linking attempt via {@link UserOidcLoginAttemptService}; anyone else
+ * gets the anonymous, first-time-login attempt via {@link AnonOidcLoginAttemptService}.
  */
 public class OidcLoginAttemptServiceProvider implements Provider<OidcLoginAttemptService> {
 
-    private Provider<StandardOidcLoginAttemptService> standardOidcLoginAttemptServiceProvider;
+    private User user;
+
+    private Provider<AnonOidcLoginAttemptService> anonOidcLoginAttemptServiceProvider;
+
+    private Provider<UserOidcLoginAttemptService> userOidcLoginAttemptServiceProvider;
 
     @Override
     public OidcLoginAttemptService get() {
-        return getStandardOidcLoginAttemptServiceProvider().get();
+        switch (getUser().getLevel()) {
+            case USER:
+            case SUPERUSER:
+                return getUserOidcLoginAttemptServiceProvider().get();
+            default:
+                return getAnonOidcLoginAttemptServiceProvider().get();
+        }
     }
 
-    public Provider<StandardOidcLoginAttemptService> getStandardOidcLoginAttemptServiceProvider() {
-        return standardOidcLoginAttemptServiceProvider;
+    public User getUser() {
+        return user;
     }
 
     @Inject
-    public void setStandardOidcLoginAttemptServiceProvider(Provider<StandardOidcLoginAttemptService> standardOidcLoginAttemptServiceProvider) {
-        this.standardOidcLoginAttemptServiceProvider = standardOidcLoginAttemptServiceProvider;
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Provider<AnonOidcLoginAttemptService> getAnonOidcLoginAttemptServiceProvider() {
+        return anonOidcLoginAttemptServiceProvider;
+    }
+
+    @Inject
+    public void setAnonOidcLoginAttemptServiceProvider(Provider<AnonOidcLoginAttemptService> anonOidcLoginAttemptServiceProvider) {
+        this.anonOidcLoginAttemptServiceProvider = anonOidcLoginAttemptServiceProvider;
+    }
+
+    public Provider<UserOidcLoginAttemptService> getUserOidcLoginAttemptServiceProvider() {
+        return userOidcLoginAttemptServiceProvider;
+    }
+
+    @Inject
+    public void setUserOidcLoginAttemptServiceProvider(Provider<UserOidcLoginAttemptService> userOidcLoginAttemptServiceProvider) {
+        this.userOidcLoginAttemptServiceProvider = userOidcLoginAttemptServiceProvider;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcProviderConfigurationOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcProviderConfigurationOperations.java
@@ -5,6 +5,8 @@ import dev.getelements.elements.sdk.model.auth.OidcAuthScheme;
 import dev.getelements.elements.sdk.model.auth.OidcProviderConfiguration;
 import jakarta.inject.Inject;
 
+import java.util.List;
+
 /**
  * Resolves an {@link OidcProviderConfiguration}'s discovery document and finds-or-creates the matching
  * {@link OidcAuthScheme} by issuer, so that registering a single provider configuration is enough to fully
@@ -54,6 +56,9 @@ public class OidcProviderConfigurationOperations {
         scheme.setName(config.getName());
         scheme.setIssuer(discoveryDocument.getIssuer());
         scheme.setKeysUrl(discoveryDocument.getJwksUri());
+        // keys is @NotNull and is read via scheme.getKeys().stream() before ever being fetched -- must start
+        // as an empty list, not null, so validation passes and the lazy cache-on-miss fetch has something to miss.
+        scheme.setKeys(List.of());
 
         return getOidcAuthSchemeDao().createAuthScheme(scheme);
 

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcAuthService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcAuthService.java
@@ -78,9 +78,30 @@ public class UserOidcAuthService implements OidcAuthService, OidcLinkService {
 
         final var uid = OidcAuthServiceOperations.claimAsString(jwt, OidcAuthServiceOperations.Claim.USER_ID.value);
         final var email = OidcAuthServiceOperations.claimAsString(jwt, OidcAuthServiceOperations.Claim.EMAIL.value);
+        final var profileClaims = OidcAuthServiceOperations.extractProfileClaims(jwt);
+
+        return apply(targetUser, scheme.getName(), uid, email, profileClaims);
+
+    }
+
+    /**
+     * Links the given already-authenticated user to an external OIDC identity described by plain values rather
+     * than a live token — used by the login-attempt confirm flow, where the identity was already validated by
+     * the callback and persisted (see {@code OidcLoginAttemptOperations}), and the original {@code DecodedJWT} is
+     * long gone by the time confirmation happens.
+     *
+     * @param targetUser the already-authenticated user to link the external identity to
+     * @param schemeName the scheme the identity was validated against
+     * @param externalUserId the external user id (the token's {@code sub} claim)
+     * @param email the token's {@code email} claim, or {@code null} if absent
+     * @param profileClaims the token's standard OIDC profile-scope claims, or empty if none
+     * @return {@code targetUser}
+     */
+    public User apply(final User targetUser, final String schemeName, final String externalUserId,
+                       final String email, final Map<String, String> profileClaims) {
 
         // Check if this OIDC sub is already mapped to any user
-        final var existingOidcUid = userUidDao.findUserUid(uid, scheme.getName());
+        final var existingOidcUid = userUidDao.findUserUid(externalUserId, schemeName);
 
         if (existingOidcUid.isPresent()) {
             final var linkedUserId = existingOidcUid.get().getUserId();
@@ -89,7 +110,7 @@ public class UserOidcAuthService implements OidcAuthService, OidcLinkService {
             }
             // Already linked to current user — idempotent, fall through
         } else {
-            createNewUserUid(uid, scheme.getName(), targetUser.getId());
+            createNewUserUid(externalUserId, schemeName, targetUser.getId());
         }
 
         // Trust any email claim returned by a configured provider as verified — see AnonOidcAuthService for
@@ -112,15 +133,13 @@ public class UserOidcAuthService implements OidcAuthService, OidcLinkService {
         // Tracking/audit snapshot of this scheme's reported profile claims — unlike email above, this isn't
         // identity-sensitive (no account-takeover concern), so it's safe to capture here too, unlike the flat
         // convenience fields on User which stay scoped to the anonymous login path (see AnonOidcAuthService).
-        final var profileClaims = OidcAuthServiceOperations.extractProfileClaims(jwt);
-
-        if (!profileClaims.isEmpty()) {
+        if (profileClaims != null && !profileClaims.isEmpty()) {
             var profiles = targetUser.getLinkedAccountProfiles();
             if (profiles == null) {
                 profiles = new HashMap<String, Map<String, String>>();
                 targetUser.setLinkedAccountProfiles(profiles);
             }
-            profiles.put(scheme.getName(), profileClaims);
+            profiles.put(schemeName, profileClaims);
 
             try {
                 getUserDao().updateUserStrict(targetUser);

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcAuthService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcAuthService.java
@@ -60,6 +60,21 @@ public class UserOidcAuthService implements OidcAuthService, OidcLinkService {
     }
 
     private User apply(final DecodedJWT jwt, final OidcAuthScheme scheme) {
+        return apply(user, jwt, scheme);
+    }
+
+    /**
+     * Links the given already-authenticated user to the external OIDC identity carried by the token, rather than
+     * the injected {@link #getUser() current user} — used by the browser-redirect login-attempt flow, where the
+     * user to link was resolved at {@code begin()} time (when the caller's own session was known) and the
+     * callback itself (hit by an unauthenticated provider redirect) has no session of its own.
+     *
+     * @param targetUser the already-authenticated user to link the external identity to
+     * @param jwt the validated id_token
+     * @param scheme the scheme the token was validated against
+     * @return {@code targetUser}
+     */
+    public User apply(final User targetUser, final DecodedJWT jwt, final OidcAuthScheme scheme) {
 
         final var uid = OidcAuthServiceOperations.claimAsString(jwt, OidcAuthServiceOperations.Claim.USER_ID.value);
         final var email = OidcAuthServiceOperations.claimAsString(jwt, OidcAuthServiceOperations.Claim.EMAIL.value);
@@ -69,12 +84,12 @@ public class UserOidcAuthService implements OidcAuthService, OidcLinkService {
 
         if (existingOidcUid.isPresent()) {
             final var linkedUserId = existingOidcUid.get().getUserId();
-            if (linkedUserId != null && !linkedUserId.equals(user.getId())) {
+            if (linkedUserId != null && !linkedUserId.equals(targetUser.getId())) {
                 throw new AuthValidationException("External OIDC identity is already linked to a different user.");
             }
             // Already linked to current user — idempotent, fall through
         } else {
-            createNewUserUid(uid, scheme.getName(), user.getId());
+            createNewUserUid(uid, scheme.getName(), targetUser.getId());
         }
 
         // Trust any email claim returned by a configured provider as verified — see AnonOidcAuthService for
@@ -83,10 +98,10 @@ public class UserOidcAuthService implements OidcAuthService, OidcLinkService {
             final var existingEmailUid = userUidDao.findUserUid(email, UserUidDao.SCHEME_EMAIL);
 
             if (existingEmailUid.isEmpty()) {
-                createNewUserUid(email, UserUidDao.SCHEME_EMAIL, user.getId());
+                createNewUserUid(email, UserUidDao.SCHEME_EMAIL, targetUser.getId());
             } else {
                 final var linkedUserId = existingEmailUid.get().getUserId();
-                if (linkedUserId != null && !linkedUserId.equals(user.getId())) {
+                if (linkedUserId != null && !linkedUserId.equals(targetUser.getId())) {
                     // Stale or foreign mapping — skip rather than block the link operation
                     logger.warn("Email UID {} is already linked to a different user; skipping email UID creation.", email);
                 }
@@ -100,24 +115,24 @@ public class UserOidcAuthService implements OidcAuthService, OidcLinkService {
         final var profileClaims = OidcAuthServiceOperations.extractProfileClaims(jwt);
 
         if (!profileClaims.isEmpty()) {
-            var profiles = user.getLinkedAccountProfiles();
+            var profiles = targetUser.getLinkedAccountProfiles();
             if (profiles == null) {
                 profiles = new HashMap<String, Map<String, String>>();
-                user.setLinkedAccountProfiles(profiles);
+                targetUser.setLinkedAccountProfiles(profiles);
             }
             profiles.put(scheme.getName(), profileClaims);
 
             try {
-                getUserDao().updateUserStrict(user);
+                getUserDao().updateUserStrict(targetUser);
             } catch (final Exception ex) {
                 // Best-effort: this is an opportunistic profile-data capture, not a critical part of linking
                 // the account. A pre-existing data issue on this user record must never block the link operation.
                 logger.warn("Failed to persist linked account profile for user {}; continuing without it.",
-                        user.getId(), ex);
+                        targetUser.getId(), ex);
             }
         }
 
-        return user;
+        return targetUser;
 
     }
 

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcLoginAttemptService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcLoginAttemptService.java
@@ -3,16 +3,28 @@ package dev.getelements.elements.service.auth.oidc;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptBegin;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptCallbackResult;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptStatusResponse;
+import dev.getelements.elements.sdk.model.user.User;
 import dev.getelements.elements.sdk.service.auth.OidcLoginAttemptService;
 import jakarta.inject.Inject;
 
-public class StandardOidcLoginAttemptService implements OidcLoginAttemptService {
+/**
+ * Account-linking browser-redirect OIDC attempt, dispatched by {@link OidcLoginAttemptServiceProvider} when the
+ * caller already has an Elements session. {@link #begin} stamps the pending attempt with the current user's id,
+ * so the outcome (link to this user, rather than create/find one by external id) is decided and persisted here,
+ * at the one point in the flow where the caller's session is actually known. The provider's callback request
+ * itself carries no {@code Authorization} header of its own — it's a bare redirect from the IdP, not a call from
+ * the original caller — so it relies entirely on that persisted decision rather than re-deriving it. {@code
+ * poll}/{@code handleCallback} therefore need no user-level branching of their own.
+ */
+public class UserOidcLoginAttemptService implements OidcLoginAttemptService {
+
+    private User user;
 
     private OidcLoginAttemptOperations oidcLoginAttemptOperations;
 
     @Override
     public OidcLoginAttemptBegin begin(final String provider) {
-        return getOidcLoginAttemptOperations().begin(provider);
+        return getOidcLoginAttemptOperations().begin(provider, getUser());
     }
 
     @Override
@@ -24,6 +36,15 @@ public class StandardOidcLoginAttemptService implements OidcLoginAttemptService 
     public OidcLoginAttemptCallbackResult handleCallback(final String provider, final String code,
                                                            final String state, final String error) {
         return getOidcLoginAttemptOperations().handleCallback(provider, code, state, error);
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Inject
+    public void setUser(User user) {
+        this.user = user;
     }
 
     public OidcLoginAttemptOperations getOidcLoginAttemptOperations() {

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcLoginAttemptService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcLoginAttemptService.java
@@ -13,8 +13,9 @@ import jakarta.inject.Inject;
  * so the outcome (link to this user, rather than create/find one by external id) is decided and persisted here,
  * at the one point in the flow where the caller's session is actually known. The provider's callback request
  * itself carries no {@code Authorization} header of its own — it's a bare redirect from the IdP, not a call from
- * the original caller — so it relies entirely on that persisted decision rather than re-deriving it. {@code
- * poll}/{@code handleCallback} therefore need no user-level branching of their own.
+ * the original caller — so it relies entirely on that persisted decision rather than re-deriving it. Finalizing
+ * the mutation is gated on presenting {@code confirmToken} (see {@link #confirmLink}), not on Elements session
+ * identity, so {@code poll}/{@code confirmLink}/{@code handleCallback} need no user-level branching of their own.
  */
 public class UserOidcLoginAttemptService implements OidcLoginAttemptService {
 
@@ -30,6 +31,11 @@ public class UserOidcLoginAttemptService implements OidcLoginAttemptService {
     @Override
     public OidcLoginAttemptStatusResponse poll(final String id) {
         return getOidcLoginAttemptOperations().poll(id);
+    }
+
+    @Override
+    public OidcLoginAttemptStatusResponse confirmLink(final String id, final String confirmToken) {
+        return getOidcLoginAttemptOperations().confirmLink(id, confirmToken);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes #38. The browser-redirect OIDC login-attempt flow (`POST/GET /oidc/session`, `GET /oidc/{provider}/callback`) only ever created/found a user by external id via a hardcoded `AnonOidcAuthService::apply` mapper — there was no equivalent to `UserOidcAuthService`/`OidcLinkServiceProvider` (used by the direct id_token flow) for linking an external OIDC identity to an already-authenticated caller's account.

### Linking support

- `OidcLoginAttemptServiceProvider` now dispatches on `User.getLevel()`, mirroring `OidcLinkServiceProvider`: USER/SUPERUSER get a new `UserOidcLoginAttemptService`; everyone else gets `AnonOidcLoginAttemptService` (renamed from `StandardOidcLoginAttemptService`).
- `UserOidcLoginAttemptService.begin()` passes the current user through to `OidcLoginAttemptOperations.begin(provider, user)`, which stamps a new `linkedUserId` field on the (DAO-level, not public-REST) `OidcLoginAttempt` record — the one point in the flow where the caller's own session is actually known.
- The existing JWT-`aud`-claim-driven auto-create path used elsewhere is untouched; this only affects the login-attempt flow.

### Security hardening (added after review)

The callback that validates the external identity is always hit by an unauthenticated provider redirect, with no way to verify it's talking to the same party that called `begin()`. Its bridge to `begin()` — the `state` value — necessarily transits the browser/IdP leg of the flow by design (visible in the browser address bar/history, exposed to IdP-side logging), unlike the `id` poll token, which never leaves the direct client↔server channel. If an attacker intercepted a leaked `state` and completed the OAuth exchange with **their own** IdP account first, their identity would get permanently linked to the **victim's** account — full account takeover from a single leaked `state`.

To close that: `begin()` now also returns a `confirmToken`, visible only to the original caller. `handleCallback()` still performs all token validation, but for a linking attempt it now only persists the validated external identity and marks the attempt `LINK_READY`, deferring the actual account-link mutation. A new `POST /oidc/session/{id}/confirm`, gated on presenting that `confirmToken`, performs the mutation and mints the session. Plain `GET /oidc/session/{id}` now rejects a link-ready attempt outright (rather than silently doing the wrong thing), directing the caller to the confirm endpoint. Anonymous attempts are completely unaffected by any of this.

## Test plan

- `service-test/OidcLoginAttemptOperationsTest`: `begin()` returns/stamps a `confirmToken`; `handleCallback` for a linking attempt marks `LINK_READY` without mutating anything; `poll()` on a link-ready attempt throws; `confirmLink()` with the correct token performs the link and mints a session, with the wrong/missing token throwing without consuming the attempt (so the legitimate caller can still retry), and losing a claim race or hitting an unknown id both return `expired()`.
- `mvn -pl sdk-model,sdk-service,sdk-dao,mongo-dao,service,service-guice,rest-api,service-test -am install -DskipTests` and the OIDC/OAuth2 test suite (`OidcLoginAttemptOperationsTest`, `UserOidcAuthServiceTest`, `AnonOidcAuthServiceTest`, `OidcAuthServiceOperationsValidationTest`, `OAuth2AuthServiceTest`) — 45/45 passing.
- Full `mvn clean install -DskipTests` across the whole repo succeeds.