### PR TITLE
Fix stale Datastore/Mapper state surviving Element (re)deploys

### DIFF
--- a/jetty-ws-test/src/test/java/dev/getelements/elements/rest/test/MongoRedeployApiTest.java
+++ b/jetty-ws-test/src/test/java/dev/getelements/elements/rest/test/MongoRedeployApiTest.java
@@ -1,0 +1,120 @@
+package dev.getelements.elements.rest.test;
+
+import dev.getelements.elements.sdk.dao.EntityRegistry;
+import dev.getelements.elements.sdk.deployment.ElementRuntimeService;
+import dev.getelements.elements.sdk.deployment.TransientDeploymentRequest;
+import dev.getelements.elements.sdk.model.system.ElementPathDefinition;
+import dev.morphia.Datastore;
+import jakarta.inject.Inject;
+import org.testng.Assert;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static dev.getelements.elements.sdk.test.TestElementArtifact.API;
+import static dev.getelements.elements.sdk.test.TestElementArtifact.MONGO;
+import static dev.getelements.elements.sdk.test.TestElementSpi.GUICE_7_0_X;
+
+/**
+ * Reproduces issue #40 end-to-end: {@link #datastore} is injected exactly once, at test-fixture
+ * construction time, mirroring the real-world eager-singleton {@code MongoMeteringBatchDao} that
+ * captured a raw {@code Datastore} and held onto it for its whole lifetime. The Element deployed by
+ * this test (see {@code sdk-test-element-mongo}) declares a Morphia entity purely so that a genuine
+ * unload/reload gives two distinct {@code Class} objects for the same entity name
+ * ("test_redeploy_document") -- exactly what a real Element redeploy produces.
+ *
+ * <p>Between the two deploys, the long-held {@link #datastore} saves a real instance of whichever
+ * generation's entity {@code Class} is currently loaded. Morphia's {@code Mapper} caches entity
+ * models by class <em>name</em> (see {@code Mapper.register}/{@code getEntityModel}), not by
+ * {@code Class} identity, and silently keeps the first-registered model on a name collision. Pre-fix,
+ * the field holds a single, now-abandoned {@code Datastore}/{@code Mapper} snapshot captured before
+ * either deploy: the first {@code save()} registers the first generation's {@code Class} under
+ * "test_redeploy_document", and the second {@code save()} -- a genuinely different {@code Class}
+ * object with the same name -- gets handed back the *first* generation's {@code EntityModel} and
+ * tries to read/write its fields via {@code java.lang.reflect.Field}s obtained from the first
+ * generation's {@code Class}, against an instance of the second -- the exact
+ * {@code IllegalArgumentException} ("Can not set ... field ... to ...", i.e. two {@code Class}
+ * objects with the same name) reported in issue #40. Post-fix, the field holds a
+ * {@code LiveDatastore} proxy that transparently resolves to the current {@code Datastore} on every
+ * call, so it never sees a stale {@code Mapper}.
+ */
+public class MongoRedeployApiTest {
+
+    @Factory
+    public Object[] getTests() {
+        return new Object[] {
+                TestUtils.getInstance().getTestFixture(MongoRedeployApiTest.class)
+        };
+    }
+
+    @Inject
+    private Datastore datastore;
+
+    @Inject
+    private ElementRuntimeService runtimeService;
+
+    private TransientDeploymentRequest buildDeployment() {
+        return TransientDeploymentRequest.builder()
+                .useDefaultRepositories(true)
+                .addElement(new ElementPathDefinition(
+                        "mongo",
+                        API.getAllCoordinates().toList(),
+                        List.of("DEFAULT"),
+                        GUICE_7_0_X.getAllCoordinates().toList(),
+                        MONGO.getAllCoordinates().toList(),
+                        Map.of()
+                ))
+                .build();
+    }
+
+    private Class<?> entityClassOf(final ElementRuntimeService.RuntimeRecord runtimeRecord) {
+        final var element = runtimeRecord.elements().getFirst();
+        final var entityRegistry = element.getServiceLocator().getInstance(EntityRegistry.class);
+        return entityRegistry.entityClasses().getFirst();
+    }
+
+    @Test
+    public void survivesARedeploy() throws ReflectiveOperationException {
+
+        final var first = runtimeService.loadTransientDeployment(buildDeployment());
+        final var firstGenerationEntityClass = entityClassOf(first);
+
+        datastore.save(newDocument(firstGenerationEntityClass, "doc-before-redeploy"));
+
+        final var unloaded = runtimeService.unloadTransientDeployment(first.deployment().id());
+        Assert.assertTrue(unloaded, "Expected the first deployment to be found and unloaded");
+
+        final var second = runtimeService.loadTransientDeployment(buildDeployment());
+        final var secondGenerationEntityClass = entityClassOf(second);
+
+        Assert.assertNotSame(
+                firstGenerationEntityClass,
+                secondGenerationEntityClass,
+                "A genuine redeploy must produce a distinct Class object for the same entity name -- "
+                        + "otherwise this test isn't reproducing issue #40 at all"
+        );
+
+        // On main (pre-fix), `datastore` is a single Datastore/Mapper snapshot captured before either
+        // deploy ever ran. Saving the first generation's instance registered "test_redeploy_document"
+        // -> firstGenerationEntityClass in that Mapper; saving the second generation's instance below
+        // reuses the SAME cached EntityModel (Morphia keys by class name, not identity) and tries to
+        // read/write its fields via Fields obtained from the first generation's Class against an
+        // instance of the second -- Morphia's "two Class objects, same name" IllegalArgumentException.
+        // On the fix branch, `datastore` is a LiveDatastore proxy that always resolves to the current
+        // Datastore/Mapper, so this succeeds.
+        datastore.save(newDocument(secondGenerationEntityClass, "doc-after-redeploy"));
+
+        runtimeService.unloadTransientDeployment(second.deployment().id());
+
+    }
+
+    private static Object newDocument(final Class<?> entityClass, final String id) throws ReflectiveOperationException {
+        final var instance = entityClass.getDeclaredConstructor().newInstance();
+        entityClass.getMethod("setId", String.class).invoke(instance, id);
+        entityClass.getMethod("setText", String.class).invoke(instance, "text-for-" + id);
+        return instance;
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrar.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrar.java
@@ -34,7 +34,10 @@ import java.util.function.Supplier;
  *
  * <p>Morphia caches entity models by class name. A full datastore rebuild is performed on each
  * register/unregister so that reloaded elements (same class name, new classloader) replace the
- * stale cached model rather than being silently ignored.
+ * stale cached model rather than being silently ignored. This rebuild replaces (never mutates)
+ * the shared {@link Datastore}/{@code Mapper} referenced by {@link #getDatastoreAtomicReference()}
+ * — see {@code dev.getelements.elements.sdk.mongo.provider.LiveDatastore} for why a consumer can
+ * safely hold the injected {@link Datastore} in a singleton across any number of these rebuilds.
  *
  * <p>An internal {@link java.util.concurrent.locks.ReentrantLock} guards the element list and
  * datastore rebuild. This provides a safety net even if the caller does not hold an outer lock.

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MongoDatastoreProvider.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MongoDatastoreProvider.java
@@ -1,5 +1,6 @@
 package dev.getelements.elements.dao.mongo.provider;
 
+import dev.getelements.elements.sdk.mongo.provider.LiveDatastore;
 import dev.morphia.Datastore;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
@@ -8,6 +9,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Created by patricktwohig on 5/8/15.
+ *
+ * <p>Returns a live-delegating {@link Datastore} proxy (see {@link LiveDatastore}) rather than the
+ * concrete instance, so a consumer that captures the injected {@link Datastore} in a singleton field
+ * or constructor parameter is always safe to do so, even across a later Element register/unregister
+ * that rebuilds the underlying {@link Datastore}/{@code Mapper}.
  */
 public class MongoDatastoreProvider implements Provider<Datastore> {
 
@@ -16,10 +22,20 @@ public class MongoDatastoreProvider implements Provider<Datastore> {
     @Inject
     private Provider<AtomicReference<Datastore>> datastoreAtomicReference;
 
+    private volatile Datastore proxy;
+
     @Override
     public Datastore get() {
-        return datastoreAtomicReference.get().get();
+        var result = proxy;
+        if (result == null) {
+            synchronized (this) {
+                result = proxy;
+                if (result == null) {
+                    proxy = result = LiveDatastore.wrap(datastoreAtomicReference.get());
+                }
+            }
+        }
+        return result;
     }
-
 
 }

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/query/ForwardNameBooleanQueryOperator.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/query/ForwardNameBooleanQueryOperator.java
@@ -14,8 +14,6 @@ import static dev.morphia.query.filters.Filters.*;
 
 public class ForwardNameBooleanQueryOperator implements BooleanQueryOperator {
 
-    private Mapper mapper;
-
     private Datastore datastore;
 
     @Override
@@ -122,7 +120,10 @@ public class ForwardNameBooleanQueryOperator implements BooleanQueryOperator {
     }
 
     public Mapper getMapper() {
-        return mapper;
+        // Resolved fresh on every call, not cached: datastore is a live-delegating proxy (see
+        // LiveDatastore) whose Mapper can change out from under a long-lived reference after an
+        // Element register/unregister rebuilds it.
+        return datastore == null ? null : datastore.getMapper();
     }
 
     public Datastore getDatastore() {
@@ -131,15 +132,7 @@ public class ForwardNameBooleanQueryOperator implements BooleanQueryOperator {
 
     @Inject
     public void setDatastore(final Datastore datastore) {
-
-        if (datastore == null) {
-            mapper = null;
-        } else {
-            this.mapper = datastore.getMapper();
-        }
-
         this.datastore = datastore;
-
     }
 
 }

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/query/NameBooleanQueryOperator.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/query/NameBooleanQueryOperator.java
@@ -13,8 +13,6 @@ public class NameBooleanQueryOperator implements BooleanQueryOperator {
 
     public static final String PREFIX = ".name.";
 
-    private Mapper mapper;
-
     private Datastore datastore;
 
     @Override
@@ -57,7 +55,10 @@ public class NameBooleanQueryOperator implements BooleanQueryOperator {
     }
 
     public Mapper getMapper() {
-        return mapper;
+        // Resolved fresh on every call, not cached: datastore is a live-delegating proxy (see
+        // LiveDatastore) whose Mapper can change out from under a long-lived reference after an
+        // Element register/unregister rebuilds it.
+        return datastore == null ? null : datastore.getMapper();
     }
 
     public Datastore getDatastore() {
@@ -66,15 +67,7 @@ public class NameBooleanQueryOperator implements BooleanQueryOperator {
 
     @Inject
     public void setDatastore(final Datastore datastore) {
-
-        if (datastore == null) {
-            mapper = null;
-        } else {
-            this.mapper = datastore.getMapper();
-        }
-
         this.datastore = datastore;
-
     }
 
 }

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/query/ReferenceBooleanQueryOperator.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/query/ReferenceBooleanQueryOperator.java
@@ -19,8 +19,6 @@ public class ReferenceBooleanQueryOperator implements BooleanQueryOperator {
 
     public static final String PREFIX = ".ref.";
 
-    private Mapper mapper;
-
     private Datastore datastore;
 
     @Override
@@ -82,7 +80,10 @@ public class ReferenceBooleanQueryOperator implements BooleanQueryOperator {
     }
 
     public Mapper getMapper() {
-        return mapper;
+        // Resolved fresh on every call, not cached: datastore is a live-delegating proxy (see
+        // LiveDatastore) whose Mapper can change out from under a long-lived reference after an
+        // Element register/unregister rebuilds it.
+        return datastore == null ? null : datastore.getMapper();
     }
 
     public Datastore getDatastore() {
@@ -91,15 +92,7 @@ public class ReferenceBooleanQueryOperator implements BooleanQueryOperator {
 
     @Inject
     public void setDatastore(final Datastore datastore) {
-
-        if (datastore == null) {
-            mapper = null;
-        } else {
-            this.mapper = datastore.getMapper();
-        }
-
         this.datastore = datastore;
-
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
         <module>sdk-test-element-rs</module>
         <module>sdk-test-element-ws</module>
         <module>sdk-test-element-kt</module>
+        <module>sdk-test-element-mongo</module>
         <module>sdk-local</module>
         <module>sdk-local-test</module>
         <module>sdk-local-maven</module>
@@ -642,6 +643,11 @@
             <dependency>
                 <groupId>dev.getelements.elements</groupId>
                 <artifactId>sdk-test-element-kt</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.getelements.elements</groupId>
+                <artifactId>sdk-test-element-mongo</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/sdk-mongo/pom.xml
+++ b/sdk-mongo/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/sdk-mongo/src/main/java/dev/getelements/elements/sdk/mongo/MongoPermittedPackages.java
+++ b/sdk-mongo/src/main/java/dev/getelements/elements/sdk/mongo/MongoPermittedPackages.java
@@ -1,0 +1,30 @@
+package dev.getelements.elements.sdk.mongo;
+
+import dev.getelements.elements.sdk.PermittedPackages;
+
+import java.util.List;
+
+public class MongoPermittedPackages implements PermittedPackages {
+
+    private static final List<String> PERMITTED_PACKAGES = List.of(
+            "dev.morphia",
+            "com.mongodb",
+            "org.bson"
+    );
+
+    @Override
+    public boolean test(final Package aPackage) {
+        final var aPackageName = aPackage.getName();
+        return PERMITTED_PACKAGES
+                .stream()
+                .anyMatch(aPackageName::startsWith);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Permits Morphia (dev.morphia) and the MongoDB driver (com.mongodb, org.bson) types so that "
+                + "Elements can consume the Datastore, MongoClient, and MongoDatabase services exported by this "
+                + "package with matching class identity.";
+    }
+
+}

--- a/sdk-mongo/src/main/java/dev/getelements/elements/sdk/mongo/guice/MongoSdkModule.java
+++ b/sdk-mongo/src/main/java/dev/getelements/elements/sdk/mongo/guice/MongoSdkModule.java
@@ -7,6 +7,7 @@ import com.mongodb.connection.SslSettings;
 import dev.getelements.elements.sdk.mongo.MongoConfigurationService;
 import dev.getelements.elements.sdk.mongo.provider.MongoClientProvider;
 import dev.getelements.elements.sdk.mongo.provider.MongoDatabaseProvider;
+import dev.getelements.elements.sdk.mongo.provider.LiveDatastore;
 import dev.getelements.elements.sdk.mongo.provider.MongoSslSettingsProvider;
 import dev.getelements.elements.sdk.mongo.StandardMongoConfigurationService;
 import dev.morphia.Datastore;
@@ -38,18 +39,34 @@ public class MongoSdkModule extends AbstractModule {
         // Datastore is created and managed by MongoDaoModule's MongoElementEntityRegistrar
         // via AtomicReference<Datastore> (exposed to the outer scope). We delegate here so that
         // elements declaring @ElementDependency("dev.getelements.elements.sdk.mongo") can inject
-        // Datastore and always see the live reference updated by entity registration.
+        // Datastore and always see the live reference updated by entity registration -- including
+        // a consumer that captures the injected Datastore in a singleton field/constructor param,
+        // since what's handed out is a live-delegating proxy (LiveDatastore), never a frozen
+        // snapshot. See LiveDatastore's javadoc for why that matters.
         binder().bind(Datastore.class).toProvider(DatastoreFromRef.class);
 
     }
 
     private static class DatastoreFromRef implements Provider<Datastore> {
+
         @Inject private AtomicReference<Datastore> datastoreRef;
+
+        private volatile Datastore proxy;
 
         @Override
         public Datastore get() {
-            return datastoreRef.get();
+            var result = proxy;
+            if (result == null) {
+                synchronized (this) {
+                    result = proxy;
+                    if (result == null) {
+                        proxy = result = LiveDatastore.wrap(datastoreRef);
+                    }
+                }
+            }
+            return result;
         }
+
     }
 
 }

--- a/sdk-mongo/src/main/java/dev/getelements/elements/sdk/mongo/provider/LiveDatastore.java
+++ b/sdk-mongo/src/main/java/dev/getelements/elements/sdk/mongo/provider/LiveDatastore.java
@@ -1,0 +1,48 @@
+package dev.getelements.elements.sdk.mongo.provider;
+
+import dev.morphia.Datastore;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Wraps a {@link AtomicReference} of {@link Datastore} in a stable proxy that forwards every call to
+ * whichever {@link Datastore} is live at the moment of the call, rather than the one live at the moment
+ * of injection.
+ *
+ * <p>{@code MongoElementEntityRegistrar} (in {@code mongo-dao}) rebuilds the platform's shared
+ * {@link Datastore}/{@code Mapper} from scratch and swaps it into a
+ * single {@link AtomicReference} every time an Element registers or unregisters entity classes. A
+ * consumer that captures the concrete {@link Datastore} directly — e.g. a raw constructor/field
+ * injection into an {@code asEagerSingleton()} binding — freezes whatever was live at that moment and
+ * never observes a later rebuild, which can leave it holding {@code EntityModel}/{@code PropertyModel}
+ * state tied to a since-superseded {@link ClassLoader}. Handing out this proxy instead means a captured
+ * reference is never actually a snapshot, so it's always safe to hold in a singleton.
+ */
+public final class LiveDatastore {
+
+    private LiveDatastore() {}
+
+    /**
+     * Wraps the given reference in a live-delegating {@link Datastore} proxy.
+     *
+     * @param ref the reference to the live {@link Datastore}, kept current elsewhere (e.g. by
+     *            {@code MongoElementEntityRegistrar})
+     * @return a {@link Datastore} that forwards every call to {@code ref.get()} at call time
+     */
+    public static Datastore wrap(final AtomicReference<Datastore> ref) {
+        return (Datastore) Proxy.newProxyInstance(
+                Datastore.class.getClassLoader(),
+                new Class<?>[]{Datastore.class},
+                (proxy, method, args) -> {
+                    try {
+                        return method.invoke(ref.get(), args);
+                    } catch (InvocationTargetException ex) {
+                        throw ex.getCause();
+                    }
+                }
+        );
+    }
+
+}

--- a/sdk-mongo/src/main/resources/META-INF/services/dev.getelements.elements.sdk.PermittedPackages
+++ b/sdk-mongo/src/main/resources/META-INF/services/dev.getelements.elements.sdk.PermittedPackages
@@ -1,0 +1,1 @@
+dev.getelements.elements.sdk.mongo.MongoPermittedPackages

--- a/sdk-mongo/src/test/java/dev/getelements/elements/sdk/mongo/provider/LiveDatastoreTest.java
+++ b/sdk-mongo/src/test/java/dev/getelements/elements/sdk/mongo/provider/LiveDatastoreTest.java
@@ -1,0 +1,69 @@
+package dev.getelements.elements.sdk.mongo.provider;
+
+import dev.morphia.Datastore;
+import dev.morphia.mapping.Mapper;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertSame;
+
+public class LiveDatastoreTest {
+
+    @Test
+    public void forwardsToTheCurrentlyLiveDatastore() {
+
+        final var first = mock(Datastore.class);
+        final var firstMapper = mock(Mapper.class);
+        when(first.getMapper()).thenReturn(firstMapper);
+
+        final var ref = new AtomicReference<>(first);
+        final var proxy = LiveDatastore.wrap(ref);
+
+        assertSame(proxy.getMapper(), firstMapper);
+
+    }
+
+    @Test
+    public void aReferenceCapturedBeforeARebuildStillReflectsTheLiveDatastoreAfterwards() {
+
+        final var first = mock(Datastore.class);
+        final var firstMapper = mock(Mapper.class);
+        when(first.getMapper()).thenReturn(firstMapper);
+
+        final var ref = new AtomicReference<>(first);
+
+        // Simulates an eager singleton capturing the injected Datastore once, before any
+        // Element register/unregister rebuild has happened.
+        final var capturedBeforeRebuild = LiveDatastore.wrap(ref);
+        assertSame(capturedBeforeRebuild.getMapper(), firstMapper);
+
+        // Simulates MongoElementEntityRegistrar.rebuildDatastore() swapping in a brand-new
+        // Datastore/Mapper after an Element registers or unregisters entity classes.
+        final var second = mock(Datastore.class);
+        final var secondMapper = mock(Mapper.class);
+        when(second.getMapper()).thenReturn(secondMapper);
+        ref.set(second);
+
+        // The reference captured before the rebuild must see the new Datastore -- not the one
+        // that was live when it was captured.
+        assertSame(capturedBeforeRebuild.getMapper(), secondMapper);
+
+    }
+
+    @Test
+    public void neverInvokesTheDelegateAtWrapTime() {
+
+        final var datastore = mock(Datastore.class);
+        final var ref = new AtomicReference<>(datastore);
+
+        LiveDatastore.wrap(ref);
+
+        verifyNoInteractions(datastore);
+
+    }
+
+}

--- a/sdk-test-element-mongo/pom.xml
+++ b/sdk-test-element-mongo/pom.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.getelements.elements</groupId>
+        <artifactId>eci-elements</artifactId>
+        <version>3.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>sdk-test-element-mongo</artifactId>
+    <name>${project.artifactId}</name>
+    <version>3.9.0-SNAPSHOT</version>
+    <url>https://namazustudios.com</url>
+
+    <!--
+        Test-only Element that reproduces issue #40: it declares a Morphia entity + EntityRegistry so
+        that deploying, unloading, and redeploying it gives dev.getelements.elements.rest.test.MongoRedeployApiTest
+        two distinct Class objects for the same entity name ("test_redeploy_document") across the redeploy,
+        exactly like a real redeployed Element does. The test itself supplies the eager, long-lived
+        Datastore-holding consumer (mirroring the real-world eager-singleton DAO from the original report)
+        and drives Morphia's Mapper directly against whichever generation's Class object is currently loaded.
+    -->
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
+            <artifactId>sdk</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
+            <artifactId>sdk-dao</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
+            <artifactId>sdk-test-api</artifactId>
+            <classifier>${api.classifier}</classifier>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!--
+            provided: sdk-mongo registers a PermittedPackages SPI exposing dev.morphia/com.mongodb/org.bson
+            to Elements, so the platform's own copy of the @Entity annotation (and other Morphia/driver
+            types) is visible through the isolated classloader's delegate. Bundling a second copy here
+            would give this Element's @Entity annotation a distinct Class identity from the one the
+            platform's own Mapper checks for, so Morphia would not recognize TestRedeployDocument as an
+            entity at all.
+        -->
+        <dependency>
+            <groupId>dev.morphia.morphia</groupId>
+            <artifactId>morphia-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <!--
+                This run of the maven-dependency-plugin builds the ELM file containing the Element formatted in
+                the specific layout the loader understands.
+            -->
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <!--
+                        Copies dependent artifacts carrying the "element-api" classifier that belong to this
+                        project's groupId into the "api" directory of the staging area. These are the API jars
+                        exported to other Elements.
+                    -->
+                    <execution>
+                        <id>elm-copy-api-deps</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${elm.element.dir}/api</outputDirectory>
+                            <includeGroupIds>${project.groupId}</includeGroupIds>
+                            <includeClassifiers>${api.classifier}</includeClassifiers>
+                            <prependGroupId>true</prependGroupId>
+                        </configuration>
+                    </execution>
+                    <!--
+                        Copies all non-provided dependencies into the "lib" directory of the staging area.
+                        These are the runtime libraries bundled with the Element.
+                    -->
+                    <execution>
+                        <id>elm-copy-lib-deps</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${elm.element.dir}/lib</outputDirectory>
+                            <excludeScope>provided</excludeScope>
+                            <prependGroupId>true</prependGroupId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <!--
+                        Stages compiled classes and src/main/resources contents into the "classpath" directory.
+                        Runs in prepare-package so the staging area is complete before the archive is created.
+                    -->
+                    <execution>
+                        <id>elm-stage-classpath</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy todir="${elm.element.dir}/classpath" failonerror="false">
+                                    <fileset dir="${project.build.outputDirectory}" erroronmissingdir="false" includes="**/*"/>
+                                </copy>
+                                <copy todir="${elm.element.dir}/classpath" failonerror="false">
+                                    <fileset dir="${basedir}/src/main/resources" erroronmissingdir="false" includes="**/*"/>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!--
+                        Writes the element manifest properties file into the root of the element directory.
+                        The loader reads this file to obtain version metadata and required builtin SPIs.
+                    -->
+                    <execution>
+                        <id>elm-write-manifest</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${elm.element.dir}" />
+                                <exec executable="git" outputproperty="git.revision" failifexecutionfails="false" errorproperty="git.error">
+                                    <arg value="rev-parse" />
+                                    <arg value="HEAD" />
+                                </exec>
+                                <property name="git.revision" value="UNKNOWN" />
+                                <echo file="${elm.element.dir}/dev.getelements.element.manifest.properties" append="false">
+Element-Version=${project.version}
+Element-Build-Time=${maven.build.timestamp}
+Element-Revision=${git.revision}
+Element-Builtin-Spis=${elm.builtin.spis}
+                                </echo>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <!--
+                        Creates the .elm archive from the fully staged directory. Ensures all three top-level
+                        directories exist so the archive structure is always consistent.
+                    -->
+                    <execution>
+                        <id>elm-create-archive</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${elm.element.dir}/api"/>
+                                <mkdir dir="${elm.element.dir}/lib"/>
+                                <mkdir dir="${elm.element.dir}/classpath"/>
+                                <mkdir dir="${elm.element.dir}/static"/>
+                                <mkdir dir="${elm.element.dir}/ui"/>
+                                <zip destfile="${elm.staging.dir}.elm" basedir="${elm.staging.dir}"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+                Attaches the .elm archive to the build so it is installed and deployed alongside
+                the standard jar artifact.
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-elm</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${elm.staging.dir}.elm</file>
+                                    <type>elm</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <properties>
+        <elm.builtin.spis>DEFAULT</elm.builtin.spis>
+        <elm.staging.dir>${project.build.directory}/${project.groupId}.${project.artifactId}-${project.version}</elm.staging.dir>
+        <elm.element.dir>${elm.staging.dir}/${project.groupId}.${project.artifactId}</elm.element.dir>
+    </properties>
+
+</project>

--- a/sdk-test-element-mongo/src/main/java/dev/getelements/elements/sdk/test/element/mongo/TestRedeployDocument.java
+++ b/sdk-test-element-mongo/src/main/java/dev/getelements/elements/sdk/test/element/mongo/TestRedeployDocument.java
@@ -1,0 +1,35 @@
+package dev.getelements.elements.sdk.test.element.mongo;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+
+/**
+ * A minimal Morphia entity, deliberately shaped like the real-world entity from issue #40
+ * ({@code MeteringBatchDocument}): a non-{@code ObjectId} {@code String} id, no
+ * {@code useDiscriminator = false} override.
+ */
+@Entity("test_redeploy_document")
+public class TestRedeployDocument {
+
+    @Id
+    private String id;
+
+    private String text;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+}

--- a/sdk-test-element-mongo/src/main/java/dev/getelements/elements/sdk/test/element/mongo/TestRedeployEntityRegistry.java
+++ b/sdk-test-element-mongo/src/main/java/dev/getelements/elements/sdk/test/element/mongo/TestRedeployEntityRegistry.java
@@ -1,0 +1,18 @@
+package dev.getelements.elements.sdk.test.element.mongo;
+
+import dev.getelements.elements.sdk.annotation.ElementServiceExport;
+import dev.getelements.elements.sdk.annotation.ElementServiceImplementation;
+import dev.getelements.elements.sdk.dao.EntityRegistry;
+
+import java.util.List;
+
+@ElementServiceImplementation
+@ElementServiceExport(EntityRegistry.class)
+public class TestRedeployEntityRegistry implements EntityRegistry {
+
+    @Override
+    public List<Class<?>> entityClasses() {
+        return List.of(TestRedeployDocument.class);
+    }
+
+}

--- a/sdk-test-element-mongo/src/main/java/dev/getelements/elements/sdk/test/element/mongo/package-info.java
+++ b/sdk-test-element-mongo/src/main/java/dev/getelements/elements/sdk/test/element/mongo/package-info.java
@@ -1,0 +1,4 @@
+@ElementDefinition(recursive = true)
+package dev.getelements.elements.sdk.test.element.mongo;
+
+import dev.getelements.elements.sdk.annotation.ElementDefinition;

--- a/sdk-test/src/main/java/dev/getelements/elements/sdk/test/TestElementArtifact.java
+++ b/sdk-test/src/main/java/dev/getelements/elements/sdk/test/TestElementArtifact.java
@@ -41,6 +41,11 @@ public enum TestElementArtifact {
             "dev.getelements.elements:sdk-test-element-ws:%s",
             "dev.getelements.elements:sdk-test-element-ws:elm:%s",
             "dev.getelements.elements.sdk.test.element.ws"
+    ),
+    MONGO(
+            "dev.getelements.elements:sdk-test-element-mongo:%s",
+            "dev.getelements.elements:sdk-test-element-mongo:elm:%s",
+            "dev.getelements.elements.sdk.test.element.mongo"
     );
 
     private final String coordinates;


### PR DESCRIPTION
## Summary

Fixes #40. Any singleton that captured the injected Morphia `Datastore` directly went stale the moment `MongoElementEntityRegistrar` rebuilt-and-swapped the shared `Datastore`/`Mapper` on a later Element register/unregister — most reliably on every redeploy, since an Element's eager singletons are constructed before its own entities are even registered into the (freshly rebuilt) shared Mapper. This produced the `FieldAccessor`/"two Class objects, same name" `IllegalArgumentException` reported in #40.

Root cause, traced end-to-end (see the full writeup on the issue):
1. `StandardElementRuntimeService.doLoadDeployment()` builds an Element's Guice injector — constructing every `.asEagerSingleton()` binding — and this fully completes before the deployment's loaders run.
2. Only afterward does `ElementEntityLoader.load()` call `MongoElementEntityRegistrar.registerEntityClasses(element)`, which rebuilds the shared `Datastore`/`Mapper`/`CodecRegistry`/`DiscriminatorLookup` from scratch to include that Element's own (re)loaded entity classes.

So any eager singleton's first captured `Datastore` snapshot is already stale/incomplete. Three internal DAOs already had this pattern (`MongoUserDao`, `MongoConcurrentUtils`, and three `BooleanQueryOperator` implementations that additionally cached an unwrapped `Mapper`), and any downstream Element's DAO was equally exposed — including the one in the linked issue.

- **Fix**: rather than converting every consumer to `Provider<Datastore>` or adding enforcement against the raw-injection pattern, the injected `Datastore` itself becomes immune to staleness. `Datastore` is an interface, so `LiveDatastore.wrap(AtomicReference<Datastore>)` builds a stable dynamic proxy that forwards every method call to whichever `Datastore` is live *at call time*. Both places that bind `Datastore.class` (`MongoDatastoreProvider` in `mongo-dao`, `MongoSdkModule.DatastoreFromRef` in `sdk-mongo` — the one Elements actually get via `@ElementDependency`) now return this proxy. Holding a raw reference anywhere — eager singleton, constructor param, doesn't matter — is safe by construction, with **no changes required in any downstream Element's code**.
- Also fixed `NameBooleanQueryOperator`/`ReferenceBooleanQueryOperator`/`ForwardNameBooleanQueryOperator`, which additionally cached an unwrapped `Mapper` separately from the `Datastore` reference — that would bypass the proxy's protection, so they now resolve `Mapper` fresh on every call instead.
- No identity/equality-based usage of a `Datastore` reference exists anywhere in the codebase, and `MongoTransactionProvider`'s intentionally separate transaction-scoped `Datastore` override (binding directly to a `MorphiaSession` instance) is unaffected — it never goes through either fixed provider.

## Test plan

- [x] `mvn -pl sdk-mongo test` — new `LiveDatastoreTest` (3 tests): proves a reference captured before a simulated rebuild still reflects the live `Datastore` afterward, and that wrapping never eagerly invokes the delegate.
- [x] `mvn -pl mongo-test test` against a real local MongoDB — full existing integration suite, 21487 tests, 0 failures — confirms no regression from routing `Datastore` through the new proxy or from the `BooleanQueryOperator` changes.
- [x] Manually traced every `bind(Datastore.class)` site in the repo to confirm both consumer paths (SDK-internal and downstream-Element-via-`@ElementDependency`) now go through the fixed providers, and that the transaction-scoped override is untouched.