### PR TITLE
Add operator-run DB migration framework with profile-slot backfill (#13)

### DIFF
--- a/docker-config/elements-jetty-ws/pom.xml
+++ b/docker-config/elements-jetty-ws/pom.xml
@@ -31,6 +31,10 @@
                     <artifactId>jetty-ws</artifactId>
                 </dependency>
                 <dependency>
+                    <groupId>dev.getelements.elements</groupId>
+                    <artifactId>migrate</artifactId>
+                </dependency>
+                <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                     <scope>compile</scope>

--- a/migrate/pom.xml
+++ b/migrate/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.getelements.elements</groupId>
+        <artifactId>eci-elements</artifactId>
+        <version>3.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>migrate</artifactId>
+    <name>${project.artifactId}</name>
+    <version>3.9.0-SNAPSHOT</version>
+    <url>https://namazustudios.com</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
+            <artifactId>mongo-dao</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
+            <artifactId>mongo-guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
+            <artifactId>sdk-mongo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ru.vyarus</groupId>
+            <artifactId>guice-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate.validator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.jopt-simple</groupId>
+            <artifactId>jopt-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/migrate/src/main/java/dev/getelements/elements/migrate/Migrate.java
+++ b/migrate/src/main/java/dev/getelements/elements/migrate/Migrate.java
@@ -1,0 +1,91 @@
+package dev.getelements.elements.migrate;
+
+import com.google.inject.Guice;
+import dev.getelements.elements.config.DefaultConfigurationSupplier;
+import dev.getelements.elements.dao.mongo.guice.MongoDaoModule;
+import dev.getelements.elements.dao.mongo.guice.MongoDatastoreBootstrapModule;
+import dev.getelements.elements.dao.mongo.guice.MongoMigrationModule;
+import dev.getelements.elements.dao.mongo.migration.MigrationRunner;
+import dev.getelements.elements.guice.ConfigurationModule;
+import dev.getelements.elements.sdk.SystemVersion;
+import dev.getelements.elements.sdk.mongo.guice.MongoSdkModule;
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import ru.vyarus.guice.validator.ValidationModule;
+
+/**
+ * Standalone entry point that applies pending {@link MigrationRunner} migrations (or reports their status)
+ * against the configured MongoDB instance. Deliberately wires only the Mongo/DAO Guice graph -- no web
+ * server, no cluster/JeroMQ wiring -- so it can run as a one-shot ops task, either as a second entry class
+ * alongside {@code jettyws} on the {@code elements-jetty-ws} Docker image, or standalone (e.g. from a
+ * {@code .deb}/systemd unit with no container to piggyback on).
+ */
+public class Migrate {
+
+    private static final OptionParser optionParser = new OptionParser();
+
+    private static final OptionSpec<Void> helpOptionSpec = optionParser
+            .accepts("help", "Prints Help.")
+            .forHelp();
+
+    private static final OptionSpec<Void> statusOptionSpec = optionParser
+            .accepts("status", "Lists applied and pending migrations without applying any of them.");
+
+    public static void main(final String[] args) throws Exception {
+        try {
+
+            final var options = optionParser.parse(args);
+
+            if (options.has(helpOptionSpec)) {
+                optionParser.printHelpOn(System.out);
+            } else {
+                run(options);
+            }
+
+        } catch (OptionException ex) {
+            System.out.println(ex.getMessage());
+            optionParser.printHelpOn(System.out);
+            System.exit(1);
+        }
+    }
+
+    private static void run(final OptionSet options) {
+
+        SystemVersion.CURRENT.logVersion();
+
+        final var defaultConfigurationSupplier = new DefaultConfigurationSupplier();
+
+        final var injector = Guice.createInjector(
+                new ConfigurationModule(defaultConfigurationSupplier::get, defaultConfigurationSupplier::getExplicitProperties),
+                new MongoDatastoreBootstrapModule(),
+                new MongoSdkModule(),
+                new MongoDaoModule(),
+                new MongoMigrationModule(),
+                new ValidationModule());
+
+        final var runner = injector.getInstance(MigrationRunner.class);
+
+        if (options.has(statusOptionSpec)) {
+            status(runner);
+        } else {
+            runner.run();
+        }
+
+    }
+
+    private static void status(final MigrationRunner runner) {
+
+        final var appliedIds = runner.getAppliedIds();
+        final var pending = runner.getPending();
+
+        System.out.println("Applied migrations:");
+        appliedIds.stream().sorted().forEach(id -> System.out.println("  " + id));
+
+        System.out.println("Pending migrations:");
+        pending.forEach(migration -> System.out.println("  " + migration.getId() + " - " + migration.getDescription()));
+
+    }
+
+}

--- a/migrate/src/main/java/migrate.java
+++ b/migrate/src/main/java/migrate.java
@@ -1,0 +1,7 @@
+import dev.getelements.elements.migrate.Migrate;
+
+public class migrate {
+    public static void main(final String[] args) throws Exception {
+        Migrate.main(args);
+    }
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/Migration.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/Migration.java
@@ -1,0 +1,40 @@
+package dev.getelements.elements.dao.mongo.migration;
+
+import dev.morphia.Datastore;
+
+/**
+ * A single operator-run database migration. Implementations back-fill or reshape existing MongoDB data
+ * when a schema-shaping feature ships, and are applied at most once (tracked via {@link SchemaMigrationRecord})
+ * by a {@link MigrationRunner}.
+ *
+ * Implementations must be idempotent and safe to re-run: {@link MigrationRunner} claims a migration's id in the
+ * tracking collection before invoking {@link #apply(Datastore)}, but a crash between the claim and completion
+ * (or two runners racing against the same database) means {@link #apply(Datastore)} could still observe partially
+ * applied state.
+ */
+public interface Migration {
+
+    /**
+     * A globally unique, lexicographically sortable id, conventionally prefixed with a date/sequence stamp
+     * (e.g. {@code "20260819_01_backfill_profile_slot_zero"}) so {@link MigrationRunner} can apply migrations
+     * in a stable, chronological order.
+     *
+     * @return the migration id
+     */
+    String getId();
+
+    /**
+     * A short human-readable description of what this migration does, surfaced in logs and CLI status output.
+     *
+     * @return the description
+     */
+    String getDescription();
+
+    /**
+     * Applies this migration against the given {@link Datastore}.
+     *
+     * @param datastore the datastore to migrate
+     */
+    void apply(Datastore datastore);
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/MigrationRunner.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/MigrationRunner.java
@@ -1,0 +1,122 @@
+package dev.getelements.elements.dao.mongo.migration;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import dev.morphia.Datastore;
+import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static dev.morphia.query.filters.Filters.eq;
+
+/**
+ * Applies pending {@link Migration}s, in ascending {@link Migration#getId()} order, tracking completion in the
+ * {@code schema_migrations} collection ({@link SchemaMigrationRecord}) so each migration runs at most once.
+ * <p>
+ * Race-safety mirrors {@code dev.getelements.elements.service.goods.ProductBundleMigration}: a migration is
+ * "claimed" by inserting its tracking record before it runs, relying on the {@code _id} uniqueness of
+ * {@link SchemaMigrationRecord} to reject a second, concurrent claim rather than any new locking machinery.
+ */
+public class MigrationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(MigrationRunner.class);
+
+    private Datastore datastore;
+
+    private Set<Migration> migrations;
+
+    /**
+     * Applies every pending migration, in id order. A migration whose claim record already exists is skipped.
+     */
+    public void run() {
+        getMigrationsInOrder().forEach(this::applyIfPending);
+    }
+
+    /**
+     * The migrations that have not yet been applied, in the order they would be applied.
+     *
+     * @return the pending migrations
+     */
+    public List<Migration> getPending() {
+        final var appliedIds = getAppliedIds();
+        return getMigrationsInOrder().stream()
+                .filter(migration -> !appliedIds.contains(migration.getId()))
+                .toList();
+    }
+
+    /**
+     * The ids of every migration that has already been applied.
+     *
+     * @return the applied migration ids
+     */
+    public Set<String> getAppliedIds() {
+        try (var iterator = getDatastore().find(SchemaMigrationRecord.class).iterator()) {
+            return iterator.toList()
+                    .stream()
+                    .map(SchemaMigrationRecord::getMigrationId)
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    private List<Migration> getMigrationsInOrder() {
+        return getMigrations().stream()
+                .sorted(Comparator.comparing(Migration::getId))
+                .toList();
+    }
+
+    private void applyIfPending(final Migration migration) {
+
+        final var record = new SchemaMigrationRecord();
+        record.setMigrationId(migration.getId());
+        record.setAppliedAt(new Date());
+
+        try {
+            getDatastore().insert(record);
+        } catch (MongoWriteException e) {
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
+                throw e;
+            }
+            logger.debug("Migration {} already applied, skipping.", migration.getId());
+            return;
+        }
+
+        logger.info("Applying migration {}: {}", migration.getId(), migration.getDescription());
+
+        try {
+            migration.apply(getDatastore());
+        } catch (final RuntimeException e) {
+            // Release the claim so a later run retries this migration instead of treating a failed
+            // attempt as permanently applied.
+            getDatastore().find(SchemaMigrationRecord.class).filter(eq("_id", migration.getId())).delete();
+            throw e;
+        }
+
+        logger.info("Applied migration {}", migration.getId());
+
+    }
+
+    public Datastore getDatastore() {
+        return datastore;
+    }
+
+    @Inject
+    public void setDatastore(Datastore datastore) {
+        this.datastore = datastore;
+    }
+
+    public Set<Migration> getMigrations() {
+        return migrations;
+    }
+
+    @Inject
+    public void setMigrations(Set<Migration> migrations) {
+        this.migrations = migrations;
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/SchemaMigrationRecord.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/SchemaMigrationRecord.java
@@ -1,0 +1,39 @@
+package dev.getelements.elements.dao.mongo.migration;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.annotations.Property;
+
+import java.util.Date;
+
+/**
+ * Tracks that a {@link Migration} with a given id has been applied. The {@code _id} is the migration's id itself,
+ * so inserting a record for an id already present fails with a duplicate-key error -- the mechanism
+ * {@link MigrationRunner} relies on to claim a migration exactly once, even across concurrent/racing runners.
+ */
+@Entity(value = "schema_migrations", useDiscriminator = false)
+public class SchemaMigrationRecord {
+
+    @Id
+    private String migrationId;
+
+    @Property
+    private Date appliedAt;
+
+    public String getMigrationId() {
+        return migrationId;
+    }
+
+    public void setMigrationId(String migrationId) {
+        this.migrationId = migrationId;
+    }
+
+    public Date getAppliedAt() {
+        return appliedAt;
+    }
+
+    public void setAppliedAt(Date appliedAt) {
+        this.appliedAt = appliedAt;
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/BackfillProfileSlotZeroMigration.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/BackfillProfileSlotZeroMigration.java
@@ -1,0 +1,74 @@
+package dev.getelements.elements.dao.mongo.migration.migrations;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import dev.getelements.elements.dao.mongo.migration.Migration;
+import dev.getelements.elements.dao.mongo.model.MongoProfile;
+import dev.getelements.elements.dao.mongo.model.profile.MongoProfileSlot;
+import dev.getelements.elements.dao.mongo.model.profile.MongoProfileSlotId;
+import dev.morphia.Datastore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static dev.morphia.query.filters.Filters.eq;
+
+/**
+ * Backfills a slot-{@code 0} {@link MongoProfileSlot} for every active {@link MongoProfile} that predates
+ * per-application profile slots (introduced by issue #11), so pre-existing accounts are correctly counted
+ * against {@code Application#getMaxProfiles()} and resolvable via {@code ProfileDao#findPrimaryProfile}.
+ */
+public class BackfillProfileSlotZeroMigration implements Migration {
+
+    private static final Logger logger = LoggerFactory.getLogger(BackfillProfileSlotZeroMigration.class);
+
+    public static final String ID = "20260819_01_backfill_profile_slot_zero";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Backfills a slot-0 MongoProfileSlot for every active Profile that predates per-application " +
+                "profile slots (#11), so maxProfiles counting is correct for pre-existing accounts.";
+    }
+
+    @Override
+    public void apply(final Datastore datastore) {
+
+        final var query = datastore.find(MongoProfile.class).filter(eq("active", true));
+
+        try (var iterator = query.iterator()) {
+            while (iterator.hasNext()) {
+                backfillSlotZero(datastore, iterator.next());
+            }
+        }
+
+    }
+
+    private void backfillSlotZero(final Datastore datastore, final MongoProfile profile) {
+
+        final var slotId = new MongoProfileSlotId(
+                profile.getUser().getObjectId(),
+                profile.getApplication().getObjectId(),
+                0);
+
+        final var slot = new MongoProfileSlot();
+        slot.setObjectId(slotId);
+        slot.setProfileId(profile.getObjectId());
+
+        try {
+            datastore.insert(slot);
+            logger.info("Backfilled profile slot 0 for profile {}", profile.getObjectId());
+        } catch (MongoWriteException e) {
+            if (e.getError().getCategory() != ErrorCategory.DUPLICATE_KEY) {
+                throw e;
+            }
+            logger.debug("Profile slot 0 already exists for user {} / application {}, skipping profile {}",
+                    profile.getUser().getObjectId(), profile.getApplication().getObjectId(), profile.getObjectId());
+        }
+
+    }
+
+}

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDatastoreBootstrapModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDatastoreBootstrapModule.java
@@ -1,0 +1,48 @@
+package dev.getelements.elements.dao.mongo.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import dev.getelements.elements.dao.mongo.provider.MongoAtomicReferenceDataStoreProvider;
+import dev.getelements.elements.dao.mongo.provider.MorphiaConfigProvider;
+import dev.getelements.elements.sdk.ElementRegistry;
+import dev.getelements.elements.sdk.MutableElementRegistry;
+import dev.morphia.Datastore;
+import dev.morphia.config.MorphiaConfig;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.inject.name.Names.named;
+import static dev.getelements.elements.sdk.ElementRegistry.ROOT;
+
+/**
+ * Binds the handful of things {@link MongoDaoModule} otherwise expects an Element-loading server (or
+ * {@link MongoDaoElementModule}) to provide -- {@link MorphiaConfig}, {@code AtomicReference<Datastore>}, and a
+ * root {@link ElementRegistry} -- so a bare non-Element context (a standalone CLI, a test) can install
+ * {@link MongoDaoModule} and {@code MongoSdkModule} directly. The root registry is an empty, unused
+ * {@link MutableElementRegistry}: nothing in this context loads Elements, but {@code MongoDaoModule}'s
+ * transaction/event-publishing wiring still needs a registry to be bound.
+ */
+public class MongoDatastoreBootstrapModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+        bind(MorphiaConfig.class)
+                .toProvider(MorphiaConfigProvider.class);
+
+        bind(new TypeLiteral<AtomicReference<Datastore>>(){})
+                .toProvider(MongoAtomicReferenceDataStoreProvider.class)
+                .asEagerSingleton();
+
+        bind(ElementRegistry.class)
+                .annotatedWith(named(ROOT))
+                .to(Key.get(MutableElementRegistry.class, named(ROOT)));
+
+        bind(MutableElementRegistry.class)
+                .annotatedWith(named(ROOT))
+                .toInstance(MutableElementRegistry.newDefaultInstance());
+
+    }
+
+}

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoMigrationModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoMigrationModule.java
@@ -1,0 +1,26 @@
+package dev.getelements.elements.dao.mongo.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import dev.getelements.elements.dao.mongo.migration.Migration;
+import dev.getelements.elements.dao.mongo.migration.MigrationRunner;
+import dev.getelements.elements.dao.mongo.migration.migrations.BackfillProfileSlotZeroMigration;
+
+/**
+ * Registers every known {@link Migration} with Guice so both the standalone {@code migrate} CLI and tests
+ * resolve the same set. New migrations are added here as an explicit {@link Multibinder} binding -- no
+ * classpath scanning -- so ordering and membership stay visible in one place.
+ */
+public class MongoMigrationModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+        bind(MigrationRunner.class);
+
+        final var migrations = Multibinder.newSetBinder(binder(), Migration.class);
+        migrations.addBinding().to(BackfillProfileSlotZeroMigration.class);
+
+    }
+
+}

--- a/mongo-test/src/main/java/dev/getelements/elements/dao/mongo/test/IntegrationTestModule.java
+++ b/mongo-test/src/main/java/dev/getelements/elements/dao/mongo/test/IntegrationTestModule.java
@@ -6,6 +6,7 @@ import com.google.inject.TypeLiteral;
 import dev.getelements.elements.config.DefaultConfigurationSupplier;
 import dev.getelements.elements.dao.mongo.guice.MongoDaoModule;
 import dev.getelements.elements.dao.mongo.guice.MongoGridFSLargeObjectBucketModule;
+import dev.getelements.elements.dao.mongo.guice.MongoMigrationModule;
 import dev.getelements.elements.dao.mongo.provider.MongoAtomicReferenceDataStoreProvider;
 import dev.getelements.elements.dao.mongo.provider.MongoDozerMapperProvider;
 import dev.getelements.elements.dao.mongo.provider.MorphiaConfigProvider;
@@ -106,6 +107,7 @@ public class IntegrationTestModule extends AbstractModule {
 
         install(new MongoSdkModule());
         install(new MongoGridFSLargeObjectBucketModule());
+        install(new MongoMigrationModule());
         install(new ValidationModule());
 
     }

--- a/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MigrationRunnerTest.java
+++ b/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MigrationRunnerTest.java
@@ -1,0 +1,164 @@
+package dev.getelements.elements.dao.mongo.test;
+
+import dev.getelements.elements.dao.mongo.migration.MigrationRunner;
+import dev.getelements.elements.dao.mongo.migration.migrations.BackfillProfileSlotZeroMigration;
+import dev.getelements.elements.dao.mongo.model.profile.MongoProfileSlot;
+import dev.getelements.elements.dao.mongo.model.profile.MongoProfileSlotId;
+import dev.getelements.elements.sdk.dao.ProfileDao;
+import dev.getelements.elements.sdk.model.application.Application;
+import dev.getelements.elements.sdk.model.profile.Profile;
+import dev.getelements.elements.sdk.model.user.User;
+import dev.morphia.Datastore;
+import org.bson.types.ObjectId;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import jakarta.inject.Inject;
+
+import static dev.morphia.query.filters.Filters.eq;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+@Guice(modules = IntegrationTestModule.class)
+public class MigrationRunnerTest {
+
+    private Datastore datastore;
+
+    private ProfileDao profileDao;
+
+    private MigrationRunner migrationRunner;
+
+    private UserTestFactory userTestFactory;
+
+    private ApplicationTestFactory applicationTestFactory;
+
+    private ProfileTestFactory profileTestFactory;
+
+    private User user;
+
+    private Application application;
+
+    private Profile legacyProfile;
+
+    @BeforeClass
+    public void setup() {
+
+        user = getUserTestFactory().createTestUser();
+
+        application = getApplicationTestFactory()
+                .createMockApplication("Application for MigrationRunnerTest");
+
+        // Simulates a pre-#11 profile: created without any MongoProfileSlot ever having been assigned.
+        legacyProfile = getProfileTestFactory().makeMockProfile(user, application);
+
+    }
+
+    @Test
+    public void testLegacyProfileHasNoSlotBeforeMigration() {
+        assertNull(findSlotZero());
+        assertFalse(getMigrationRunner().getAppliedIds().contains(BackfillProfileSlotZeroMigration.ID));
+        assertTrue(getMigrationRunner()
+                .getPending()
+                .stream()
+                .anyMatch(m -> BackfillProfileSlotZeroMigration.ID.equals(m.getId())));
+    }
+
+    @Test(dependsOnMethods = "testLegacyProfileHasNoSlotBeforeMigration")
+    public void testRunBackfillsSlotZero() {
+
+        getMigrationRunner().run();
+
+        final var slot = findSlotZero();
+        assertEquals(slot.getProfileId(), new ObjectId(legacyProfile.getId()));
+
+        final var primary = getProfileDao().findPrimaryProfile(user.getId(), application.getId());
+        assertTrue(primary.isPresent());
+        assertEquals(primary.get().getId(), legacyProfile.getId());
+
+        assertTrue(getMigrationRunner().getAppliedIds().contains(BackfillProfileSlotZeroMigration.ID));
+        assertFalse(getMigrationRunner()
+                .getPending()
+                .stream()
+                .anyMatch(m -> BackfillProfileSlotZeroMigration.ID.equals(m.getId())));
+
+    }
+
+    @Test(dependsOnMethods = "testRunBackfillsSlotZero")
+    public void testRerunIsNoOp() {
+        getMigrationRunner().run();
+        final var slot = findSlotZero();
+        assertEquals(slot.getProfileId(), new ObjectId(legacyProfile.getId()));
+    }
+
+    private MongoProfileSlot findSlotZero() {
+
+        final var slotId = new MongoProfileSlotId(
+                new ObjectId(user.getId()),
+                new ObjectId(application.getId()),
+                0);
+
+        return getDatastore()
+                .find(MongoProfileSlot.class)
+                .filter(eq("_id", slotId))
+                .first();
+
+    }
+
+    public Datastore getDatastore() {
+        return datastore;
+    }
+
+    @Inject
+    public void setDatastore(Datastore datastore) {
+        this.datastore = datastore;
+    }
+
+    public ProfileDao getProfileDao() {
+        return profileDao;
+    }
+
+    @Inject
+    public void setProfileDao(ProfileDao profileDao) {
+        this.profileDao = profileDao;
+    }
+
+    public MigrationRunner getMigrationRunner() {
+        return migrationRunner;
+    }
+
+    @Inject
+    public void setMigrationRunner(MigrationRunner migrationRunner) {
+        this.migrationRunner = migrationRunner;
+    }
+
+    public UserTestFactory getUserTestFactory() {
+        return userTestFactory;
+    }
+
+    @Inject
+    public void setUserTestFactory(UserTestFactory userTestFactory) {
+        this.userTestFactory = userTestFactory;
+    }
+
+    public ApplicationTestFactory getApplicationTestFactory() {
+        return applicationTestFactory;
+    }
+
+    @Inject
+    public void setApplicationTestFactory(ApplicationTestFactory applicationTestFactory) {
+        this.applicationTestFactory = applicationTestFactory;
+    }
+
+    public ProfileTestFactory getProfileTestFactory() {
+        return profileTestFactory;
+    }
+
+    @Inject
+    public void setProfileTestFactory(ProfileTestFactory profileTestFactory) {
+        this.profileTestFactory = profileTestFactory;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <module>rpc-api-guice</module>
         <module>rpc-api-jetty</module>
         <module>mongo-guice</module>
+        <module>migrate</module>
         <module>jetty-ws</module>
         <module>jetty-ws-test</module>
         <module>web-ui-react-jetty</module>
@@ -311,6 +312,11 @@
             <dependency>
                 <groupId>dev.getelements.elements</groupId>
                 <artifactId>mongo-guice</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.getelements.elements</groupId>
+                <artifactId>migrate</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- Adds a lightweight, tracked, idempotent migration mechanism: `Migration`/`SchemaMigrationRecord`/`MigrationRunner` in `mongo-dao`, with Guice wiring (`MongoMigrationModule`, `MongoDatastoreBootstrapModule`) in `mongo-guice`.
- Adds a standalone `migrate` CLI (jopt-simple `--status` / apply) packaged onto the existing `elements-jetty-ws` Docker image alongside `jettyws` — no second container — so it also stays runnable outside Docker for the future `.deb`/systemd path (#12).
- Ships the first real migration: backfills a slot-0 `MongoProfileSlot` for every active `Profile` that predates per-application profile slots (#11), so `maxProfiles` counting is correct for pre-existing accounts.

Closes #13.

## Test plan
- [x] `mvn -pl mongo-dao,mongo-guice,migrate -am compile`
- [x] `mvn -pl mongo-test -am test` — full suite (21,490 tests) passes, including new `MigrationRunnerTest` (pending → applied → idempotent rerun)
- [x] Manual: `java -cp ... dev.getelements.elements.migrate.Migrate --status` / `migrate` against local dev Mongo — correctly reports pending, applies, then reports applied/no-op on rerun
- [x] `mvn -pl docker-config/elements-jetty-ws -am -Pdocker package` — confirmed `migrate-*.jar` lands in `target/lib` alongside `jetty-ws-*.jar` with no Dockerfile changes, so `java migrate` and `java jettyws` both work off the same image/tag