### PR TITLE
Migrate to Maven CI-Friendly Versions (single <revision> property)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
+.flattened-pom.xml
 release.properties
 dependency-reduced-pom.xml
 buildNumber.properties

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,20 @@ docker:
 docker_hub:
 	make -C docker-config hub
 
+# patch/release compute the next version the normal Maven way (letting versions:set's own
+# nextSnapshot/removeSnapshot semver logic decide it), then discard the literal per-module rewrite
+# that versions:set always produces and re-apply just the computed value to the single <revision>
+# property via versions:set-property -- versions:set does not honor a property-based version even
+# with -DprocessAllModules=true, it always writes a literal version into every module.
 patch:
-	mvn versions:set -DprocessAllModules=true -DnextSnapshot=true
+	@NEXT=$$(mvn -q versions:set -DnextSnapshot=true > /dev/null && mvn -q help:evaluate -Dexpression=project.version -DforceStdout) && \
+	find . -path "*/target" -prune -o -name "pom.xml" -exec git checkout {} \; && \
+	mvn versions:set-property -Dproperty=revision -DnewVersion=$$NEXT
 
 release:
-	mvn versions:set -DprocessAllModules=true -DremoveSnapshot=true
+	@NEXT=$$(mvn -q versions:set -DremoveSnapshot=true > /dev/null && mvn -q help:evaluate -Dexpression=project.version -DforceStdout) && \
+	find . -path "*/target" -prune -o -name "pom.xml" -exec git checkout {} \; && \
+	mvn versions:set-property -Dproperty=revision -DnewVersion=$$NEXT
 
 version:
 
@@ -57,7 +66,7 @@ ifndef VERSION
 	$(error VERSION is not set)
 endif
 
-	mvn versions:set -DprocessAllModules=true -DnewVersion=$(VERSION)
+	mvn versions:set-property -Dproperty=revision -DnewVersion=$(VERSION)
 
 tag: MAVEN_VERSION=$(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 tag:

--- a/app-node/pom.xml
+++ b/app-node/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>app-node</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/cdn-serve-guice/pom.xml
+++ b/cdn-serve-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>cdn-serve-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/cdn-serve/pom.xml
+++ b/cdn-serve/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>cdn-serve</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/code-serve-guice/pom.xml
+++ b/code-serve-guice/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>code-serve-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/common-git/pom.xml
+++ b/common-git/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>common-git</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/common-jetty/pom.xml
+++ b/common-jetty/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>common-jetty</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/common-mapstruct/pom.xml
+++ b/common-mapstruct/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>common-mapstruct</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/common-servlet-guice/pom.xml
+++ b/common-servlet-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>common-servlet-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/common-servlet/pom.xml
+++ b/common-servlet/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>common-servlet</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/common-util/pom.xml
+++ b/common-util/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>common-util</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/deployment-jetty/pom.xml
+++ b/deployment-jetty/pom.xml
@@ -8,10 +8,10 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <artifactId>deployment-jetty</artifactId>
     <name>${project.artifactId}</name>
     <url>https://namazustudios.com</url>

--- a/doc-serve-jetty/pom.xml
+++ b/doc-serve-jetty/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>doc-serve-jetty</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/docker-config/elements-base/pom.xml
+++ b/docker-config/elements-base/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>docker-config</artifactId>
         <groupId>dev.getelements.elements</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -14,7 +14,7 @@
 
     <artifactId>elements-base</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
 </project>
 

--- a/docker-config/elements-jetty-ws/pom.xml
+++ b/docker-config/elements-jetty-ws/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>docker-config</artifactId>
         <groupId>dev.getelements.elements</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -15,7 +15,7 @@
     <groupId>dev.getelements.elements</groupId>
     <name>${project.artifactId}</name>
     <artifactId>elements-jetty-ws</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <profiles>
         <profile>

--- a/docker-config/pom.xml
+++ b/docker-config/pom.xml
@@ -7,14 +7,14 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>docker-config</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <modules>
         <module>elements-base</module>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/jetty-ws-test/pom.xml
+++ b/jetty-ws-test/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>jetty-ws-test</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/jetty-ws/pom.xml
+++ b/jetty-ws/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>jetty-ws</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/mongo-dao/pom.xml
+++ b/mongo-dao/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>mongo-dao</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/mongo-guice/pom.xml
+++ b/mongo-guice/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>mongo-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/mongo-test/pom.xml
+++ b/mongo-test/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>mongo-test</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>eci-elements</artifactId>
 
     <name>Namazu Elements</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <scm>
@@ -140,6 +140,7 @@
     </modules>
 
     <properties>
+        <revision>3.9.0-SNAPSHOT</revision>
         <test.suites>**/*UnitTestSuite.java</test.suites>
         <guice.version>7.0.0</guice.version>
         <guice.bridge.version>3.0.6</guice.bridge.version>
@@ -1212,6 +1213,32 @@
                 <configuration>
                     <generateBackupPoms>false</generateBackupPoms>
                 </configuration>
+            </plugin>
+            <!-- Resolves the ${revision} CI-friendly version placeholder into a concrete version in the
+                 POM that install/deploy actually publish, so external consumers never see the raw property. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- Surefire Plugin -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1215,13 +1215,20 @@
                 </configuration>
             </plugin>
             <!-- Resolves the ${revision} CI-friendly version placeholder into a concrete version in the
-                 POM that install/deploy actually publish, so external consumers never see the raw property. -->
+                 POM that install/deploy actually publish, so external consumers never see the raw property.
+                 updatePomFile is required, not just the default separate .flattened-pom.xml: for pom-packaging
+                 modules (sdk-bom, and this root aggregator itself), install/deploy read the pom file directly
+                 rather than through the attached-artifact mechanism flatten's setPomFile() trick relies on for
+                 jar packaging, so without this, sdk-bom's installed/published parent reference was left as the
+                 literal, unresolved "${revision}", breaking every external consumer that resolves it from a
+                 repository instead of building inside this reactor. -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
                 <version>1.6.0</version>
                 <configuration>
                     <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    <updatePomFile>true</updatePomFile>
                 </configuration>
                 <executions>
                     <execution>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rest-api</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rest-guice/pom.xml
+++ b/rest-guice/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rest-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rpc-api-guice/pom.xml
+++ b/rpc-api-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rpc-api-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rpc-api-jetty/pom.xml
+++ b/rpc-api-jetty/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rpc-api-jetty</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rpc-api/pom.xml
+++ b/rpc-api/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rpc-api</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-common/pom.xml
+++ b/rt-common/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <artifactId>eci-elements</artifactId>
         <groupId>dev.getelements.elements</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-common</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-fst-guice/pom.xml
+++ b/rt-fst-guice/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-fst-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-fst/pom.xml
+++ b/rt-fst/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-fst</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-jackson-guice/pom.xml
+++ b/rt-jackson-guice/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-jackson-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-jackson/pom.xml
+++ b/rt-jackson/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-jackson</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-jeromq-guice/pom.xml
+++ b/rt-jeromq-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-jeromq-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-jeromq/pom.xml
+++ b/rt-jeromq/pom.xml
@@ -8,13 +8,13 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <groupId>dev.getelements.elements</groupId>
     <artifactId>rt-jeromq</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <dependencies>
         <dependency>

--- a/rt-jersey-guice/pom.xml
+++ b/rt-jersey-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-jersey-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-jersey/pom.xml
+++ b/rt-jersey/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-jersey</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-kryo-guice/pom.xml
+++ b/rt-kryo-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-kryo-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-kryo/pom.xml
+++ b/rt-kryo/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-kryo</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-cluster-guice/pom.xml
+++ b/rt-server-cluster-guice/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <artifactId>eci-elements</artifactId>
         <groupId>dev.getelements.elements</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-cluster-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-cluster-jeromq-guice/pom.xml
+++ b/rt-server-cluster-jeromq-guice/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <artifactId>eci-elements</artifactId>
         <groupId>dev.getelements.elements</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-cluster-jeromq-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-cluster-jeromq/pom.xml
+++ b/rt-server-cluster-jeromq/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-cluster-jeromq</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-cluster-node-guice/pom.xml
+++ b/rt-server-cluster-node-guice/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-cluster-node-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-cluster-node-jeromq-guice/pom.xml
+++ b/rt-server-cluster-node-jeromq-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-cluster-node-jeromq-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-cluster-node-jeromq/pom.xml
+++ b/rt-server-cluster-node-jeromq/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-cluster-node-jeromq</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-cluster-node/pom.xml
+++ b/rt-server-cluster-node/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-cluster-node</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-cluster/pom.xml
+++ b/rt-server-cluster/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-cluster</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-git/pom.xml
+++ b/rt-server-git/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-git</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-guice/pom.xml
+++ b/rt-server-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-simple-guice/pom.xml
+++ b/rt-server-simple-guice/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-simple-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-simple/pom.xml
+++ b/rt-server-simple/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-simple</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-testkit/pom.xml
+++ b/rt-server-testkit/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-testkit</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-transact-guice/pom.xml
+++ b/rt-server-transact-guice/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-transact-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-transact-unixfs-guice/pom.xml
+++ b/rt-server-transact-unixfs-guice/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-transact-unixfs-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-transact-unixfs/pom.xml
+++ b/rt-server-transact-unixfs/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-transact-unixfs</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server-transact/pom.xml
+++ b/rt-server-transact/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>rt-server-transact</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/rt-server/pom.xml
+++ b/rt-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>eci-elements</artifactId>
         <groupId>dev.getelements.elements</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <artifactId>rt-server</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-bom/pom.xml
+++ b/sdk-bom/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-bom</artifactId>

--- a/sdk-cluster/pom.xml
+++ b/sdk-cluster/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-cluster</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-dao/pom.xml
+++ b/sdk-dao/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-dao</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-deployment/pom.xml
+++ b/sdk-deployment/pom.xml
@@ -8,11 +8,11 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-deployment</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>sdk-deployment</name>
     <url>https://namazustudios.com</url>
 

--- a/sdk-element-standard-kt/pom.xml
+++ b/sdk-element-standard-kt/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>dev.getelements.elements</groupId>
     <artifactId>eci-elements</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>sdk-element-standard-kt</artifactId>
-  <version>3.9.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>maven-archetype</packaging>
 
   <name>Standard Element Archetype (Kotlin Version)</name>

--- a/sdk-element-standard/pom.xml
+++ b/sdk-element-standard/pom.xml
@@ -8,11 +8,11 @@
   <parent>
     <groupId>dev.getelements.elements</groupId>
     <artifactId>eci-elements</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>sdk-element-standard</artifactId>
-  <version>3.9.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>maven-archetype</packaging>
 
   <name>Standard Element Archetype</name>

--- a/sdk-guice/pom.xml
+++ b/sdk-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-jakarta-rs/pom.xml
+++ b/sdk-jakarta-rs/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-jakarta-rs</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-local-maven/pom.xml
+++ b/sdk-local-maven/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-local-maven</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <dependencies>
 

--- a/sdk-local-test/pom.xml
+++ b/sdk-local-test/pom.xml
@@ -8,10 +8,10 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <artifactId>sdk-local-test</artifactId>
     <name>${project.artifactId}</name>
     <groupId>dev.getelements.elements</groupId>

--- a/sdk-local/pom.xml
+++ b/sdk-local/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-local</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-logback/pom.xml
+++ b/sdk-logback/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-logback</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <dependencies>
         <dependency>

--- a/sdk-model/pom.xml
+++ b/sdk-model/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-model</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-mongo-test/pom.xml
+++ b/sdk-mongo-test/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <groupId>dev.getelements.elements</groupId>
     <artifactId>sdk-mongo-test</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>sdk-mongo-test</name>
 
     <dependencies>

--- a/sdk-mongo/pom.xml
+++ b/sdk-mongo/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-mongo</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-service/pom.xml
+++ b/sdk-service/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-service</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-spi-guice/pom.xml
+++ b/sdk-spi-guice/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-spi-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-spi-shrinkwrap/pom.xml
+++ b/sdk-spi-shrinkwrap/pom.xml
@@ -8,11 +8,11 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-spi-shrinkwrap</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>sdk-spi-shrinkwrap</name>
 
     <dependencies>

--- a/sdk-spi/pom.xml
+++ b/sdk-spi/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-spi</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-test-api/pom.xml
+++ b/sdk-test-api/pom.xml
@@ -8,11 +8,11 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-test-api</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>sdk-test-api</name>
 
     <dependencies>

--- a/sdk-test-element-a/pom.xml
+++ b/sdk-test-element-a/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-test-element-a</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-test-element-b/pom.xml
+++ b/sdk-test-element-b/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-test-element-b</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-test-element-kt/pom.xml
+++ b/sdk-test-element-kt/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-test-element-kt</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-test-element-mongo/pom.xml
+++ b/sdk-test-element-mongo/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-test-element-mongo</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <!--

--- a/sdk-test-element-rs/pom.xml
+++ b/sdk-test-element-rs/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-test-element-rs</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-test-element-ws/pom.xml
+++ b/sdk-test-element-ws/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-test-element-ws</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-test-element/pom.xml
+++ b/sdk-test-element/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-test-element</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-test/pom.xml
+++ b/sdk-test/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-test</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk-util/pom.xml
+++ b/sdk-util/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk-util</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>sdk</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/service-guice/pom.xml
+++ b/service-guice/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>service-guice</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/service-test/pom.xml
+++ b/service-test/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>service-test</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>service</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>
@@ -17,7 +17,7 @@
 
     <artifactId>setup</artifactId>
     <name>${project.artifactId}</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <url>https://namazustudios.com</url>
 
     <dependencies>

--- a/web-ui-react-jetty/pom.xml
+++ b/web-ui-react-jetty/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.getelements.elements</groupId>
         <artifactId>eci-elements</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <name>${project.artifactId}</name>
     <artifactId>web-ui-react-jetty</artifactId>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <properties>
         <!-- Set true to skip the npm build (e.g. for a skipTests prepass that


### PR DESCRIPTION
## Summary
- Every module's own `<version>` and `<parent><version>` was a hardcoded literal string, kept in sync only by re-running `versions-maven-plugin` across every `pom.xml`. This just broke `release/3.9`: `sdk-test-element-mongo` was added on `main` and reached `release/3.9` only via `git merge`, so it carried the version it had on `main` -- which no longer matched `release/3.9`'s own version after that branch's RC bumps. `git merge` has no idea a Maven version-bump plugin exists, so the merged-in module was invisible to every historical bump and the reactor failed to resolve its parent POM.
- Switches every module to a single `<revision>` property (Maven's built-in "CI Friendly Versions" feature) -- a module merged in from any branch is now immune to this bug by construction, since it always resolves against whatever `<revision>` the destination branch's root `pom.xml` currently holds.
- Adds `flatten-maven-plugin` so `install`/`deploy` still publish a POM with a concrete resolved version -- required since this repo does real `mvn deploy` to Maven Central and GitHub Packages, and an unresolved `${revision}` baked into a published POM would break every external consumer (e.g. third-party Element authors depending on `sdk`/`sdk-bom`).
- Updates the `Makefile`'s `version`/`patch`/`release` targets to use `versions:set-property -Dproperty=revision` instead of `versions:set` -- empirically verified that `versions:set` does **not** honor a property-based version even with `-DprocessAllModules=true`, it always writes a literal version into every module, which would silently re-break this the next time those targets ran. `patch`/`release` let `versions:set`'s own `nextSnapshot`/`removeSnapshot` semver math compute the next value, then discard its literal per-module rewrite and re-apply just that value via `versions:set-property`.
- No changes to `.github/workflows/*`/`.github/actions/*`: every version-changing workflow step goes through `make version VERSION=...`, whose external interface is unchanged.

## Test plan
- [x] `mvn -q validate` across the full reactor
- [x] `mvn clean install -DskipTests` across the full reactor (two pre-existing failures in `sdk-element-standard`/`sdk-element-standard-kt`'s archetype-IT/Javadoc generation confirmed present on plain `main` too, unrelated to this change)
- [x] `make version VERSION=X`, `make patch`, `make release`, `make tag` each verified to touch only root `pom.xml` (and `make tag`/`help:evaluate` still resolve the correct concrete version)
- [x] Installed `sdk`/`sdk-model`/`sdk-bom` locally and confirmed the installed POM (what `deploy` would publish) contains a concrete resolved version, never the literal `${revision}` string