### PR TITLE
Fix OIDC/OAuth2 admin UI bugs: JWK escaping, table render, soft-delete (#56)

### DIFF
--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/auth/MongoOAuth2AuthSchemeDao.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/auth/MongoOAuth2AuthSchemeDao.java
@@ -40,6 +40,8 @@ public class MongoOAuth2AuthSchemeDao implements OAuth2AuthSchemeDao {
 
         final var mongoQuery = getDatastore().find(MongoOAuth2AuthScheme.class);
 
+        mongoQuery.filter(exists("name"));
+
         if (tags != null && !tags.isEmpty()) {
             mongoQuery.filter(in("tags", tags));
         }
@@ -53,8 +55,14 @@ public class MongoOAuth2AuthSchemeDao implements OAuth2AuthSchemeDao {
 
         final var query = getMongoDBUtils()
                 .parse(authSchemeNameOrId)
-                .map(objectId -> getDatastore().find(MongoOAuth2AuthScheme.class).filter(eq("_id", objectId)))
-                .orElseGet(() -> getDatastore().find(MongoOAuth2AuthScheme.class).filter(eq("name", authSchemeNameOrId)));
+                .map(objectId -> getDatastore()
+                        .find(MongoOAuth2AuthScheme.class)
+                        .filter(exists("name"))
+                        .filter(eq("_id", objectId)))
+                .orElseGet(() -> getDatastore()
+                        .find(MongoOAuth2AuthScheme.class)
+                        .filter(exists("name"))
+                        .filter(eq("name", authSchemeNameOrId)));
 
         return Optional.ofNullable(query.first()).map(this::transform);
     }
@@ -107,6 +115,7 @@ public class MongoOAuth2AuthSchemeDao implements OAuth2AuthSchemeDao {
         final var objectId = getMongoDBUtils().parseOrThrow(authSchemeId, AuthSchemeNotFoundException::new);
 
         final var query = getDatastore().find(MongoOAuth2AuthScheme.class);
+        query.filter(exists("name"));
         query.filter(eq("_id", objectId));
 
         final var builder = new UpdateBuilder();

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/auth/MongoOidcAuthSchemeDao.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/auth/MongoOidcAuthSchemeDao.java
@@ -120,6 +120,7 @@ public class MongoOidcAuthSchemeDao implements OidcAuthSchemeDao {
         final var objectId = getMongoDBUtils().parseOrThrow(authSchemeId, AuthSchemeNotFoundException::new);
 
         final var query = getDatastore().find(MongoOidcAuthScheme.class);
+        query.filter(exists("issuer"));
         query.filter(eq("_id", objectId));
 
         final var builder = new UpdateBuilder();

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOAuth2AuthScheme.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOAuth2AuthScheme.java
@@ -11,7 +11,10 @@ import java.util.Objects;
 
 @Entity(value = "oauth2_auth_scheme", useDiscriminator = false)
 @Indexes({
-        @Index(fields = @Field("name"), options = @IndexOptions(unique = true))
+        // sparse: delete soft-deletes by unsetting "name" rather than removing the document (see
+        // MongoOAuth2AuthSchemeDao#deleteAuthScheme); a non-sparse unique index would reject the second
+        // soft-deleted document, since it also has no "name" field.
+        @Index(fields = @Field("name"), options = @IndexOptions(unique = true, sparse = true))
 })
 public class MongoOAuth2AuthScheme {
 

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcAuthScheme.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcAuthScheme.java
@@ -10,8 +10,11 @@ import java.util.Objects;
 
 @Entity(value = "oidc_auth_scheme", useDiscriminator = false)
 @Indexes({
-        @Index(fields = @Field("name"), options = @IndexOptions(unique = true)),
-        @Index(fields = @Field("issuer"), options = @IndexOptions(unique = true))
+        // sparse: delete soft-deletes by unsetting "name"/"issuer" rather than removing the document (see
+        // MongoOidcAuthSchemeDao#deleteAuthScheme); non-sparse unique indexes would reject the second
+        // soft-deleted document, since it also has neither field.
+        @Index(fields = @Field("name"), options = @IndexOptions(unique = true, sparse = true)),
+        @Index(fields = @Field("issuer"), options = @IndexOptions(unique = true, sparse = true))
 })
 public class MongoOidcAuthScheme {
 

--- a/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MongoOAuth2AuthSchemeDaoTest.java
+++ b/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MongoOAuth2AuthSchemeDaoTest.java
@@ -1,0 +1,140 @@
+package dev.getelements.elements.dao.mongo.test;
+
+import dev.getelements.elements.sdk.dao.OAuth2AuthSchemeDao;
+import dev.getelements.elements.sdk.model.auth.HttpMethod;
+import dev.getelements.elements.sdk.model.auth.OAuth2AuthScheme;
+import dev.getelements.elements.sdk.model.exception.auth.AuthSchemeNotFoundException;
+import org.bson.types.ObjectId;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import jakarta.inject.Inject;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+import static java.lang.String.format;
+import static org.testng.Assert.*;
+
+@Guice(modules = IntegrationTestModule.class)
+public class MongoOAuth2AuthSchemeDaoTest {
+
+    private static final String TEST_NAME = "test_oauth2_scheme";
+
+    private OAuth2AuthSchemeDao oAuth2AuthSchemeDao;
+
+    private final Map<String, OAuth2AuthScheme> intermediateAuthSchemes = new ConcurrentHashMap<>();
+
+    private void updateIntermediate(final OAuth2AuthScheme authScheme) {
+        intermediateAuthSchemes.put(authScheme.getId(), authScheme);
+    }
+
+    @DataProvider
+    public Object[][] getAuthSchemeIteration() {
+        return IntStream
+            .range(0, 10)
+            .mapToObj(i -> new Object[]{i})
+            .toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "getAuthSchemeIteration")
+    public void testCreateAuthScheme(final int iteration) {
+
+        final var toCreate = new OAuth2AuthScheme();
+        toCreate.setName(format("%s_%d", TEST_NAME, iteration));
+        toCreate.setValidationUrl(format("https://example.com/validate/%d", iteration));
+        toCreate.setMethod(HttpMethod.GET);
+
+        final var created = getOAuth2AuthSchemeDao().createAuthScheme(toCreate);
+        assertNotNull(created.getId());
+        assertEquals(toCreate.getName(), created.getName());
+        assertEquals(toCreate.getValidationUrl(), created.getValidationUrl());
+        assertEquals(toCreate.getMethod(), created.getMethod());
+
+        updateIntermediate(created);
+
+    }
+
+    @DataProvider
+    public Object[][] getIntermediates() {
+        return intermediateAuthSchemes
+            .entrySet()
+            .stream()
+            .map(e -> new Object[]{e.getKey(), e.getValue()})
+            .toArray(Object[][]::new);
+    }
+
+    @Test(dependsOnMethods = "testCreateAuthScheme", dataProvider = "getIntermediates")
+    public void testFindIndividualAuthScheme(final String authSchemeId, final OAuth2AuthScheme existing) {
+        final var fetched = getOAuth2AuthSchemeDao().findAuthScheme(authSchemeId);
+        assertEquals(authSchemeId, fetched.get().getId());
+    }
+
+    @Test(dependsOnMethods = "testCreateAuthScheme")
+    public void testFindIndividualAuthSchemeFail() {
+        final var fetched = getOAuth2AuthSchemeDao().findAuthScheme(new ObjectId().toHexString());
+        assertTrue(fetched.isEmpty());
+    }
+
+    @Test(dependsOnMethods = "testFindIndividualAuthScheme")
+    public void testGetAllAuthSchemes() {
+
+        final var fetched = getOAuth2AuthSchemeDao().getAuthSchemes(0, 100, null);
+        assertEquals(intermediateAuthSchemes.size(), fetched.getTotal());
+
+        for (var scheme : fetched.getObjects()) {
+            assertTrue(intermediateAuthSchemes.containsKey(scheme.getId()));
+        }
+
+    }
+
+    @Test(dependsOnMethods = "testGetAllAuthSchemes", dataProvider = "getIntermediates")
+    public void updateAuthScheme(final String authSchemeId, final OAuth2AuthScheme existing) {
+
+        final var toUpdate = new OAuth2AuthScheme();
+        toUpdate.setId(authSchemeId);
+        toUpdate.setName(format("%s_updated", existing.getName()));
+        toUpdate.setValidationUrl(format("%s_updated", existing.getValidationUrl()));
+        toUpdate.setMethod(HttpMethod.POST);
+
+        final var updated = getOAuth2AuthSchemeDao().updateAuthScheme(toUpdate);
+
+        assertEquals(toUpdate.getId(), updated.getId());
+        assertEquals(toUpdate.getName(), updated.getName());
+        assertEquals(toUpdate.getValidationUrl(), updated.getValidationUrl());
+        assertEquals(toUpdate.getMethod(), updated.getMethod());
+
+        updateIntermediate(updated);
+
+    }
+
+    @Test(dependsOnMethods = "updateAuthScheme", dataProvider = "getIntermediates")
+    public void testDeleteAuthScheme(final String authSchemeId, final OAuth2AuthScheme authScheme) {
+        getOAuth2AuthSchemeDao().deleteAuthScheme(authSchemeId);
+        assertTrue(getOAuth2AuthSchemeDao().findAuthScheme(authSchemeId).isEmpty());
+    }
+
+    @Test(dependsOnMethods = "testDeleteAuthScheme", dataProvider = "getIntermediates",
+          expectedExceptions = AuthSchemeNotFoundException.class)
+    public void testDeleteAuthSchemeTwiceFails(final String authSchemeId, final OAuth2AuthScheme authScheme) {
+        getOAuth2AuthSchemeDao().deleteAuthScheme(authSchemeId);
+    }
+
+    @Test(dependsOnMethods = "testDeleteAuthSchemeTwiceFails")
+    public void testAllAreDeleted() {
+        final var fetched = getOAuth2AuthSchemeDao().getAuthSchemes(0, 100, null);
+        assertEquals(fetched.getTotal(), 0);
+        assertEquals(fetched.getObjects().size(), 0);
+    }
+
+    public OAuth2AuthSchemeDao getOAuth2AuthSchemeDao() {
+        return oAuth2AuthSchemeDao;
+    }
+
+    @Inject
+    public void setOAuth2AuthSchemeDao(OAuth2AuthSchemeDao oAuth2AuthSchemeDao) {
+        this.oAuth2AuthSchemeDao = oAuth2AuthSchemeDao;
+    }
+
+}

--- a/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MongoOidcAuthSchemeDaoTest.java
+++ b/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MongoOidcAuthSchemeDaoTest.java
@@ -1,0 +1,151 @@
+package dev.getelements.elements.dao.mongo.test;
+
+import dev.getelements.elements.sdk.dao.OidcAuthSchemeDao;
+import dev.getelements.elements.sdk.model.auth.JWK;
+import dev.getelements.elements.sdk.model.auth.OidcAuthScheme;
+import dev.getelements.elements.sdk.model.exception.auth.AuthSchemeNotFoundException;
+import org.bson.types.ObjectId;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+import static java.lang.String.format;
+import static org.testng.Assert.*;
+
+@Guice(modules = IntegrationTestModule.class)
+public class MongoOidcAuthSchemeDaoTest {
+
+    private static final String TEST_ISSUER = "test_oidc_issuer";
+
+    private OidcAuthSchemeDao oidcAuthSchemeDao;
+
+    private final Map<String, OidcAuthScheme> intermediateAuthSchemes = new ConcurrentHashMap<>();
+
+    private void updateIntermediate(final OidcAuthScheme authScheme) {
+        intermediateAuthSchemes.put(authScheme.getId(), authScheme);
+    }
+
+    private JWK testKey(final int iteration) {
+        final var jwk = new JWK();
+        jwk.setAlg("RS256");
+        jwk.setKid(format("kid_%d", iteration));
+        jwk.setKty("RSA");
+        jwk.setUse("sig");
+        jwk.setE("AQAB");
+        jwk.setN(format("modulus_%d", iteration));
+        return jwk;
+    }
+
+    @DataProvider
+    public Object[][] getAuthSchemeIteration() {
+        return IntStream
+            .range(0, 10)
+            .mapToObj(i -> new Object[]{i})
+            .toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "getAuthSchemeIteration")
+    public void testCreateAuthScheme(final int iteration) {
+
+        final var toCreate = new OidcAuthScheme();
+        toCreate.setName(format("%s_%d", TEST_ISSUER, iteration));
+        toCreate.setIssuer(format("https://example.com/issuer/%d", iteration));
+        toCreate.setKeys(List.of(testKey(iteration)));
+
+        final var created = getOidcAuthSchemeDao().createAuthScheme(toCreate);
+        assertNotNull(created.getId());
+        assertEquals(toCreate.getName(), created.getName());
+        assertEquals(toCreate.getIssuer(), created.getIssuer());
+        assertEquals(toCreate.getKeys(), created.getKeys());
+
+        updateIntermediate(created);
+
+    }
+
+    @DataProvider
+    public Object[][] getIntermediates() {
+        return intermediateAuthSchemes
+            .entrySet()
+            .stream()
+            .map(e -> new Object[]{e.getKey(), e.getValue()})
+            .toArray(Object[][]::new);
+    }
+
+    @Test(dependsOnMethods = "testCreateAuthScheme", dataProvider = "getIntermediates")
+    public void testFindIndividualAuthScheme(final String authSchemeId, final OidcAuthScheme existing) {
+        final var fetched = getOidcAuthSchemeDao().findAuthScheme(authSchemeId);
+        assertEquals(authSchemeId, fetched.get().getId());
+    }
+
+    @Test(dependsOnMethods = "testCreateAuthScheme")
+    public void testFindIndividualAuthSchemeFail() {
+        final var fetched = getOidcAuthSchemeDao().findAuthScheme(new ObjectId().toHexString());
+        assertTrue(fetched.isEmpty());
+    }
+
+    @Test(dependsOnMethods = "testFindIndividualAuthScheme")
+    public void testGetAllAuthSchemes() {
+
+        final var fetched = getOidcAuthSchemeDao().getAuthSchemes(0, 100, null);
+        assertEquals(intermediateAuthSchemes.size(), fetched.getTotal());
+
+        for (var scheme : fetched.getObjects()) {
+            assertTrue(intermediateAuthSchemes.containsKey(scheme.getId()));
+        }
+
+    }
+
+    @Test(dependsOnMethods = "testGetAllAuthSchemes", dataProvider = "getIntermediates")
+    public void updateAuthScheme(final String authSchemeId, final OidcAuthScheme existing) {
+
+        final var toUpdate = new OidcAuthScheme();
+        toUpdate.setId(authSchemeId);
+        toUpdate.setName(format("%s_updated", existing.getName()));
+        toUpdate.setIssuer(format("%s_updated", existing.getIssuer()));
+        toUpdate.setKeys(existing.getKeys());
+
+        final var updated = getOidcAuthSchemeDao().updateAuthScheme(toUpdate);
+
+        assertEquals(toUpdate.getId(), updated.getId());
+        assertEquals(toUpdate.getName(), updated.getName());
+        assertEquals(toUpdate.getIssuer(), updated.getIssuer());
+
+        updateIntermediate(updated);
+
+    }
+
+    @Test(dependsOnMethods = "updateAuthScheme", dataProvider = "getIntermediates")
+    public void testDeleteAuthScheme(final String authSchemeId, final OidcAuthScheme authScheme) {
+        getOidcAuthSchemeDao().deleteAuthScheme(authSchemeId);
+        assertTrue(getOidcAuthSchemeDao().findAuthScheme(authSchemeId).isEmpty());
+    }
+
+    @Test(dependsOnMethods = "testDeleteAuthScheme", dataProvider = "getIntermediates",
+          expectedExceptions = AuthSchemeNotFoundException.class)
+    public void testDeleteAuthSchemeTwiceFails(final String authSchemeId, final OidcAuthScheme authScheme) {
+        getOidcAuthSchemeDao().deleteAuthScheme(authSchemeId);
+    }
+
+    @Test(dependsOnMethods = "testDeleteAuthSchemeTwiceFails")
+    public void testAllAreDeleted() {
+        final var fetched = getOidcAuthSchemeDao().getAuthSchemes(0, 100, null);
+        assertEquals(fetched.getTotal(), 0);
+        assertEquals(fetched.getObjects().size(), 0);
+    }
+
+    public OidcAuthSchemeDao getOidcAuthSchemeDao() {
+        return oidcAuthSchemeDao;
+    }
+
+    @Inject
+    public void setOidcAuthSchemeDao(OidcAuthSchemeDao oidcAuthSchemeDao) {
+        this.oidcAuthSchemeDao = oidcAuthSchemeDao;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
         <jetty.version>12.0.12</jetty.version>
         <flapdoodle.mongo.version>3.0.0</flapdoodle.mongo.version>
         <auth0.java.jwt.version>3.10.3</auth0.java.jwt.version>
+        <nimbus.jose.jwt.version>9.37.3</nimbus.jose.jwt.version>
         <spotify.dns.version>3.2.2</spotify.dns.version>
         <annotations.version>2.11.3</annotations.version>
         <neow3j.version>3.14.0</neow3j.version>
@@ -852,6 +853,11 @@
                 <groupId>com.auth0</groupId>
                 <artifactId>java-jwt</artifactId>
                 <version>${auth0.java.jwt.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus.jose.jwt.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.neow3j</groupId>

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/JWK.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/JWK.java
@@ -20,17 +20,26 @@ public class JWK implements Serializable {
     @Schema(description = "The intended use (e.g. sig)")
     private String use;
 
-    @Schema(description = "Base64url encoded exponent")
+    @Schema(description = "Base64url encoded exponent (RSA keys only)")
     private String e;
 
-    @Schema(description = "Pub key modulus")
+    @Schema(description = "Pub key modulus (RSA keys only)")
     private String n;
+
+    @Schema(description = "Curve name, e.g. P-256, P-384, P-521 (EC keys only)")
+    private String crv;
+
+    @Schema(description = "Base64url encoded x coordinate (EC keys only)")
+    private String x;
+
+    @Schema(description = "Base64url encoded y coordinate (EC keys only)")
+    private String y;
 
     /** Creates a new empty instance. */
     public JWK() {}
 
     /**
-     * Creates a new instance with all fields.
+     * Creates a new instance with the RSA public key fields.
      *
      * @param alg the algorithm
      * @param kid the key ID
@@ -156,6 +165,60 @@ public class JWK implements Serializable {
         this.n = n;
     }
 
+    /**
+     * Returns the curve name (e.g. P-256).
+     *
+     * @return the curve name
+     */
+    public String getCrv() {
+        return crv;
+    }
+
+    /**
+     * Sets the curve name (e.g. P-256).
+     *
+     * @param crv the curve name
+     */
+    public void setCrv(String crv) {
+        this.crv = crv;
+    }
+
+    /**
+     * Returns the base64url encoded x coordinate.
+     *
+     * @return the x coordinate
+     */
+    public String getX() {
+        return x;
+    }
+
+    /**
+     * Sets the base64url encoded x coordinate.
+     *
+     * @param x the x coordinate
+     */
+    public void setX(String x) {
+        this.x = x;
+    }
+
+    /**
+     * Returns the base64url encoded y coordinate.
+     *
+     * @return the y coordinate
+     */
+    public String getY() {
+        return y;
+    }
+
+    /**
+     * Sets the base64url encoded y coordinate.
+     *
+     * @param y the y coordinate
+     */
+    public void setY(String y) {
+        this.y = y;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -166,12 +229,15 @@ public class JWK implements Serializable {
                 Objects.equals(getKty(), key.getKty()) &&
                 Objects.equals(getUse(), key.getUse()) &&
                 Objects.equals(getE(), key.getE()) &&
-                Objects.equals(getN(), key.getN());
+                Objects.equals(getN(), key.getN()) &&
+                Objects.equals(getCrv(), key.getCrv()) &&
+                Objects.equals(getX(), key.getX()) &&
+                Objects.equals(getY(), key.getY());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getAlg(), getKid(), getKty(), getUse(), getE(), getN());
+        return Objects.hash(getAlg(), getKid(), getKty(), getUse(), getE(), getN(), getCrv(), getX(), getY());
     }
 
     @Override
@@ -183,6 +249,9 @@ public class JWK implements Serializable {
                 ", use='" + use + '\'' +
                 ", e='" + e + '\'' +
                 ", n='" + n + '\'' +
+                ", crv='" + crv + '\'' +
+                ", x='" + x + '\'' +
+                ", y='" + y + '\'' +
                 '}';
     }
 }

--- a/service-test/src/test/java/dev/getelements/elements/service/OidcAuthServiceOperationsTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OidcAuthServiceOperationsTest.java
@@ -1,0 +1,203 @@
+package dev.getelements.elements.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.RSAKey;
+import dev.getelements.elements.sdk.model.auth.JWK;
+import dev.getelements.elements.sdk.model.auth.OidcAuthScheme;
+import dev.getelements.elements.sdk.model.exception.ForbiddenException;
+import dev.getelements.elements.sdk.model.exception.InternalException;
+import dev.getelements.elements.service.auth.oidc.OidcAuthServiceOperations;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+/**
+ * Exercises {@link OidcAuthServiceOperations}'s JWK-to-PublicKey construction and signature-algorithm dispatch
+ * directly (no Guice, no DAOs) -- signature verification for the direct-key-match path only depends on the scheme's
+ * own {@code keys} list and the JWT itself, so a bare instance is enough.
+ */
+public class OidcAuthServiceOperationsTest {
+
+    private static final String ISSUER = "https://issuer.example.com";
+
+    private final OidcAuthServiceOperations operations = new OidcAuthServiceOperations();
+
+    private KeyPair generateRsaKeyPair() throws NoSuchAlgorithmException {
+        final var generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    private KeyPair generateEcKeyPair(final String curveName)
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        final var generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec(curveName));
+        return generator.generateKeyPair();
+    }
+
+    private JWK rsaJwk(final String alg, final String kid, final RSAPublicKey publicKey) {
+        final var nimbusKey = new RSAKey.Builder(publicKey).build();
+        final var jwk = new JWK();
+        jwk.setAlg(alg);
+        jwk.setKid(kid);
+        jwk.setKty(nimbusKey.getKeyType().getValue());
+        jwk.setUse("sig");
+        jwk.setN(nimbusKey.getModulus().toString());
+        jwk.setE(nimbusKey.getPublicExponent().toString());
+        return jwk;
+    }
+
+    private JWK ecJwk(final String alg, final String kid, final Curve curve, final ECPublicKey publicKey) {
+        final var nimbusKey = new ECKey.Builder(curve, publicKey).build();
+        final var jwk = new JWK();
+        jwk.setAlg(alg);
+        jwk.setKid(kid);
+        jwk.setKty(nimbusKey.getKeyType().getValue());
+        jwk.setUse("sig");
+        jwk.setCrv(curve.getName());
+        jwk.setX(nimbusKey.getX().toString());
+        jwk.setY(nimbusKey.getY().toString());
+        return jwk;
+    }
+
+    private OidcAuthScheme schemeWithKeys(final JWK... keys) {
+        final var scheme = new OidcAuthScheme();
+        scheme.setIssuer(ISSUER);
+        scheme.setKeys(List.of(keys));
+        return scheme;
+    }
+
+    private String signedToken(final Algorithm algorithm, final String kid) {
+        return JWT.create()
+                .withKeyId(kid)
+                .withIssuer(ISSUER)
+                .withExpiresAt(new Date(System.currentTimeMillis() + 60_000))
+                .sign(algorithm);
+    }
+
+    @DataProvider
+    public Object[][] rsaAlgorithms() {
+        return new Object[][]{
+                {"RS256"},
+                {"RS384"},
+                {"RS512"},
+        };
+    }
+
+    @Test(dataProvider = "rsaAlgorithms")
+    public void verifiesRsaTokenForEveryAlg(final String alg) throws Exception {
+
+        final var keyPair = generateRsaKeyPair();
+        final var publicKey = (RSAPublicKey) keyPair.getPublic();
+        final var kid = UUID.randomUUID().toString();
+        final var jwk = rsaJwk(alg, kid, publicKey);
+        final var scheme = schemeWithKeys(jwk);
+
+        final var algorithm = switch (alg) {
+            case "RS256" -> Algorithm.RSA256(publicKey, (java.security.interfaces.RSAPrivateKey) keyPair.getPrivate());
+            case "RS384" -> Algorithm.RSA384(publicKey, (java.security.interfaces.RSAPrivateKey) keyPair.getPrivate());
+            case "RS512" -> Algorithm.RSA512(publicKey, (java.security.interfaces.RSAPrivateKey) keyPair.getPrivate());
+            default -> throw new IllegalStateException(alg);
+        };
+
+        final var token = signedToken(algorithm, kid);
+        final var decoded = operations.decodeAndVerify(token, scheme, null, null);
+        assertNotNull(decoded);
+
+    }
+
+    @DataProvider
+    public Object[][] ecCurves() {
+        return new Object[][]{
+                {"ES256", Curve.P_256, "secp256r1"},
+                {"ES384", Curve.P_384, "secp384r1"},
+        };
+    }
+
+    @Test(dataProvider = "ecCurves")
+    public void verifiesEcTokenForEveryCurve(final String alg, final Curve curve, final String stdCurveName)
+            throws Exception {
+
+        final var keyPair = generateEcKeyPair(stdCurveName);
+        final var publicKey = (ECPublicKey) keyPair.getPublic();
+        final var kid = UUID.randomUUID().toString();
+        final var jwk = ecJwk(alg, kid, curve, publicKey);
+        final var scheme = schemeWithKeys(jwk);
+
+        final var algorithm = switch (alg) {
+            case "ES256" -> Algorithm.ECDSA256(publicKey, (java.security.interfaces.ECPrivateKey) keyPair.getPrivate());
+            case "ES384" -> Algorithm.ECDSA384(publicKey, (java.security.interfaces.ECPrivateKey) keyPair.getPrivate());
+            default -> throw new IllegalStateException(alg);
+        };
+
+        final var token = signedToken(algorithm, kid);
+        final var decoded = operations.decodeAndVerify(token, scheme, null, null);
+        assertNotNull(decoded);
+
+    }
+
+    @Test(expectedExceptions = InternalException.class)
+    public void rejectsUnsupportedAlg() throws Exception {
+
+        final var keyPair = generateRsaKeyPair();
+        final var publicKey = (RSAPublicKey) keyPair.getPublic();
+        final var kid = UUID.randomUUID().toString();
+        final var jwk = rsaJwk("RS999", kid, publicKey);
+        final var scheme = schemeWithKeys(jwk);
+
+        final var algorithm = Algorithm.RSA256(publicKey, (java.security.interfaces.RSAPrivateKey) keyPair.getPrivate());
+        final var token = signedToken(algorithm, kid);
+
+        operations.decodeAndVerify(token, scheme, null, null);
+
+    }
+
+    /**
+     * Regression test for a signature-verification bypass: the direct-key-match path used to discard
+     * {@code attemptVerify}'s return value, so a token whose "kid" header matched a cached key -- a public,
+     * non-secret value -- would pass verification even with a bad signature (e.g. signed by an attacker-controlled
+     * key rather than the real one on file for that kid).
+     */
+    @Test
+    public void rejectsTokenSignedWithWrongKeyEvenWhenKidMatches() throws Exception {
+
+        final var realKeyPair = generateRsaKeyPair();
+        final var forgedKeyPair = generateRsaKeyPair();
+
+        final var kid = UUID.randomUUID().toString();
+        final var jwk = rsaJwk("RS256", kid, (RSAPublicKey) realKeyPair.getPublic());
+        final var scheme = schemeWithKeys(jwk);
+
+        // Signed with a different key than the one on file for this kid.
+        final var forgedAlgorithm = Algorithm.RSA256(
+                (RSAPublicKey) forgedKeyPair.getPublic(),
+                (java.security.interfaces.RSAPrivateKey) forgedKeyPair.getPrivate()
+        );
+        final var forgedToken = signedToken(forgedAlgorithm, kid);
+
+        try {
+            operations.decodeAndVerify(forgedToken, scheme, null, null);
+            fail("Expected verification of a token signed with the wrong key to be rejected");
+        } catch (ForbiddenException expected) {
+            // expected
+        }
+
+    }
+
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -88,6 +88,10 @@
             <artifactId>java-jwt</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.paymennt</groupId>
             <artifactId>solanaj</artifactId>
         </dependency>

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
@@ -5,6 +5,11 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.util.Base64URL;
 import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.OidcAuthSchemeDao;
 import dev.getelements.elements.sdk.dao.ProfileDao;
@@ -29,13 +34,9 @@ import jakarta.ws.rs.client.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.BigInteger;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.RSAPublicKeySpec;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,9 @@ public class OidcAuthServiceOperations {
 
     private static final Logger logger = LoggerFactory.getLogger(OidcAuthServiceOperations.class);
 
-    private static final String RSA_ALGO = "RSA";
+    private static final String RSA_KTY = "RSA";
+
+    private static final String EC_KTY = "EC";
 
     private Client client;
 
@@ -260,7 +263,9 @@ public class OidcAuthServiceOperations {
         //no other source of truth, so its keys are always trusted as-is.
         if(jwk != null && !(scheme.getKeysUrl() != null && isKeysStale(scheme))) {
             final var algorithm = getAlgorithmFromJWK(jwk);
-            attemptVerify(jwt, algorithm);
+            if (attemptVerify(jwt, algorithm) == null) {
+                throw new ForbiddenException("Signature verification failed");
+            }
             return;
         }
 
@@ -327,22 +332,45 @@ public class OidcAuthServiceOperations {
                 .map(this::getAlgorithmFromJWK);
     }
 
-    private Algorithm getAlgorithmFromJWK(JWK k) {
+    private Algorithm getAlgorithmFromJWK(final JWK k) {
 
-        final BigInteger n = new BigInteger(1, Base64.getUrlDecoder().decode(k.getN()));
-        final BigInteger e = new BigInteger(1, Base64.getUrlDecoder().decode(k.getE()));
-
-        final RSAPublicKey publicKey;
+        final PublicKey publicKey;
 
         try {
-            final RSAPublicKeySpec keySpec = new RSAPublicKeySpec(n, e);
-            publicKey = (RSAPublicKey) KeyFactory.getInstance(RSA_ALGO).generatePublic(keySpec);
-        } catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
+            if (RSA_KTY.equalsIgnoreCase(k.getKty())) {
+                publicKey = new RSAKey.Builder(Base64URL.from(k.getN()), Base64URL.from(k.getE()))
+                        .build()
+                        .toRSAPublicKey();
+            } else if (EC_KTY.equalsIgnoreCase(k.getKty())) {
+                final var curve = Curve.parse(k.getCrv());
+                publicKey = new ECKey.Builder(curve, Base64URL.from(k.getX()), Base64URL.from(k.getY()))
+                        .build()
+                        .toECPublicKey();
+            } else {
+                throw new InternalException("Unsupported JWK key type: " + k.getKty());
+            }
+        } catch (JOSEException ex) {
             throw new InternalException(ex);
         }
 
-        //TODO: Get algorithm type from JWK or JWT header
-        return Algorithm.RSA256(publicKey, null);
+        return algorithmFor(k.getAlg(), publicKey);
+
+    }
+
+    private Algorithm algorithmFor(final String alg, final PublicKey publicKey) {
+        if (alg == null) {
+            throw new InternalException("JWK is missing its 'alg' property");
+        }
+
+        return switch (alg) {
+            case "RS256" -> Algorithm.RSA256((RSAPublicKey) publicKey, null);
+            case "RS384" -> Algorithm.RSA384((RSAPublicKey) publicKey, null);
+            case "RS512" -> Algorithm.RSA512((RSAPublicKey) publicKey, null);
+            case "ES256" -> Algorithm.ECDSA256((ECPublicKey) publicKey, null);
+            case "ES384" -> Algorithm.ECDSA384((ECPublicKey) publicKey, null);
+            case "ES512" -> Algorithm.ECDSA512((ECPublicKey) publicKey, null);
+            default -> throw new InternalException("Unsupported JWK alg: " + alg);
+        };
     }
 
     private Profile map(final User user,

--- a/web-ui-react-jetty/elements-web-ui/client/src/components/DynamicResourceForm.tsx
+++ b/web-ui-react-jetty/elements-web-ui/client/src/components/DynamicResourceForm.tsx
@@ -278,6 +278,20 @@ export function DynamicResourceForm({
           fromClient: z.boolean(),
           userId: z.boolean().optional(),
         })).optional();
+      } else if (field.name === 'keys' && field.type === 'object' && field.isArray) {
+        // OIDC JWK keys - accept array of objects directly (RSA and EC fields both optional here;
+        // JwkListEditor only shows the fields valid for the selected kty)
+        fieldSchema = z.array(z.object({
+          alg: z.string().optional(),
+          kid: z.string().optional(),
+          kty: z.string(),
+          use: z.string().optional(),
+          e: z.string().optional(),
+          n: z.string().optional(),
+          crv: z.string().optional(),
+          x: z.string().optional(),
+          y: z.string().optional(),
+        })).min(1, 'At least one key is required');
       } else if (field.name === 'validStatusCodes' && field.type === 'integer' && field.isArray) {
         // Valid status codes - accept array of numbers directly
         fieldSchema = z.array(z.number()).optional();
@@ -392,6 +406,9 @@ export function DynamicResourceForm({
         } else if ((field.name === 'headers' || field.name === 'params' || field.name === 'body') && field.type === 'object' && field.isArray) {
           // OAuth2 headers, params, and body - keep as array of objects
           values[field.name] = Array.isArray(value) ? value : [];
+        } else if (field.name === 'keys' && field.type === 'object' && field.isArray) {
+          // OIDC JWK keys - keep as array of objects
+          values[field.name] = Array.isArray(value) ? value : [];
         } else if (field.name === 'validStatusCodes' && field.type === 'integer' && field.isArray) {
           // Valid status codes - keep as array of numbers
           values[field.name] = Array.isArray(value) ? value : [];
@@ -433,6 +450,9 @@ export function DynamicResourceForm({
         values[field.name] = [];
       } else if ((field.name === 'headers' || field.name === 'params' || field.name === 'body') && field.type === 'object' && field.isArray) {
         // OAuth2 headers, params, and body - initialize as empty array
+        values[field.name] = [];
+      } else if (field.name === 'keys' && field.type === 'object' && field.isArray) {
+        // OIDC JWK keys - initialize as empty array
         values[field.name] = [];
       } else if (field.name === 'validStatusCodes' && field.type === 'integer' && field.isArray) {
         // Valid status codes - initialize as empty array

--- a/web-ui-react-jetty/elements-web-ui/client/src/components/FormFieldGenerator.tsx
+++ b/web-ui-react-jetty/elements-web-ui/client/src/components/FormFieldGenerator.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Button } from '@/components/ui/button';
 import { TagsInput } from '@/components/TagsInput';
 import { OAuth2HeaderParamEditor } from '@/components/OAuth2HeaderParamEditor';
+import { JwkListEditor } from '@/components/JwkListEditor';
 import { type FieldSchema } from '@/lib/schema-parser';
 import { type UseFormReturn } from 'react-hook-form';
 import { Copy } from 'lucide-react';
@@ -179,6 +180,16 @@ function renderInput(
           form={form}
           fieldName={schema.name}
           value={formField.value}
+          onChange={formField.onChange}
+        />
+      );
+    }
+
+    // Special handling for OIDC's JWK "keys" field
+    if (schema.name === 'keys' && schema.type === 'object') {
+      return (
+        <JwkListEditor
+          value={Array.isArray(formField.value) ? formField.value : []}
           onChange={formField.onChange}
         />
       );

--- a/web-ui-react-jetty/elements-web-ui/client/src/components/JwkListEditor.tsx
+++ b/web-ui-react-jetty/elements-web-ui/client/src/components/JwkListEditor.tsx
@@ -1,0 +1,226 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Card } from '@/components/ui/card';
+import { Trash2, Plus } from 'lucide-react';
+
+const KEY_TYPES = ['RSA', 'EC'];
+
+const EC_CURVES = ['P-256', 'P-384', 'P-521'];
+
+interface JwkData {
+  alg?: string;
+  kid?: string;
+  kty: string;
+  use?: string;
+  e?: string;
+  n?: string;
+  crv?: string;
+  x?: string;
+  y?: string;
+}
+
+interface JwkListEditorProps {
+  value?: JwkData[];
+  onChange: (keys: JwkData[]) => void;
+}
+
+// A JWK's field set is fixed by RFC 7518, and differs by key type -- RSA uses "e"/"n", EC uses "crv"/"x"/"y".
+// Editing this as freeform key/value pairs would let a user type a field name the server's JWK model has no
+// setter for, which gets silently dropped -- so each card exposes exactly the fields valid for its own "kty".
+export function JwkListEditor({ value = [], onChange }: JwkListEditorProps) {
+  const [keys, setKeys] = useState<JwkData[]>(value);
+
+  useEffect(() => {
+    if (value && JSON.stringify(value) !== JSON.stringify(keys)) {
+      setKeys(value);
+    }
+  }, [value]);
+
+  useEffect(() => {
+    onChange(keys);
+  }, [keys]);
+
+  const addKey = () => {
+    setKeys([...keys, { kty: 'RSA', use: 'sig' }]);
+  };
+
+  const removeKey = (index: number) => {
+    setKeys(keys.filter((_, i) => i !== index));
+  };
+
+  const updateKey = (index: number, field: keyof JwkData, fieldValue: string) => {
+    const updated = [...keys];
+    const next = { ...updated[index], [field]: fieldValue };
+
+    // Switching key type clears the fields that don't apply to the new type, rather than leaving stale
+    // RSA values behind on an EC key (or vice versa).
+    if (field === 'kty') {
+      delete next.e;
+      delete next.n;
+      delete next.crv;
+      delete next.x;
+      delete next.y;
+    }
+
+    updated[index] = next;
+    setKeys(updated);
+  };
+
+  return (
+    <div className="space-y-3">
+      {keys.length === 0 ? (
+        <Card className="p-4 text-center text-muted-foreground text-sm">
+          No keys configured
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {keys.map((key, index) => (
+            <Card key={index} className="p-4">
+              <div className="space-y-3">
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                  <div>
+                    <Label className="text-xs text-muted-foreground">Key Type</Label>
+                    <Select
+                      value={key.kty}
+                      onValueChange={(v) => updateKey(index, 'kty', v)}
+                    >
+                      <SelectTrigger className="mt-1" data-testid={`select-jwk-kty-${index}`}>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {KEY_TYPES.map((kty) => (
+                          <SelectItem key={kty} value={kty}>{kty}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label className="text-xs text-muted-foreground">Algorithm</Label>
+                    <Input
+                      value={key.alg ?? ''}
+                      onChange={(e) => updateKey(index, 'alg', e.target.value)}
+                      placeholder={key.kty === 'EC' ? 'ES256' : 'RS256'}
+                      className="mt-1"
+                      data-testid={`input-jwk-alg-${index}`}
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs text-muted-foreground">Key ID</Label>
+                    <Input
+                      value={key.kid ?? ''}
+                      onChange={(e) => updateKey(index, 'kid', e.target.value)}
+                      placeholder="kid"
+                      className="mt-1"
+                      data-testid={`input-jwk-kid-${index}`}
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs text-muted-foreground">Use</Label>
+                    <Input
+                      value={key.use ?? ''}
+                      onChange={(e) => updateKey(index, 'use', e.target.value)}
+                      placeholder="sig"
+                      className="mt-1"
+                      data-testid={`input-jwk-use-${index}`}
+                    />
+                  </div>
+                </div>
+
+                {key.kty === 'EC' ? (
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+                    <div>
+                      <Label className="text-xs text-muted-foreground">Curve</Label>
+                      <Select
+                        value={key.crv ?? ''}
+                        onValueChange={(v) => updateKey(index, 'crv', v)}
+                      >
+                        <SelectTrigger className="mt-1" data-testid={`select-jwk-crv-${index}`}>
+                          <SelectValue placeholder="Select curve" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {EC_CURVES.map((crv) => (
+                            <SelectItem key={crv} value={crv}>{crv}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <Label className="text-xs text-muted-foreground">X Coordinate</Label>
+                      <Input
+                        value={key.x ?? ''}
+                        onChange={(e) => updateKey(index, 'x', e.target.value)}
+                        placeholder="Base64url encoded x"
+                        className="mt-1 font-mono text-sm"
+                        data-testid={`input-jwk-x-${index}`}
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-muted-foreground">Y Coordinate</Label>
+                      <Input
+                        value={key.y ?? ''}
+                        onChange={(e) => updateKey(index, 'y', e.target.value)}
+                        placeholder="Base64url encoded y"
+                        className="mt-1 font-mono text-sm"
+                        data-testid={`input-jwk-y-${index}`}
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                    <div>
+                      <Label className="text-xs text-muted-foreground">Modulus (n)</Label>
+                      <Input
+                        value={key.n ?? ''}
+                        onChange={(e) => updateKey(index, 'n', e.target.value)}
+                        placeholder="Base64url encoded modulus"
+                        className="mt-1 font-mono text-sm"
+                        data-testid={`input-jwk-n-${index}`}
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-muted-foreground">Exponent (e)</Label>
+                      <Input
+                        value={key.e ?? ''}
+                        onChange={(e) => updateKey(index, 'e', e.target.value)}
+                        placeholder="Base64url encoded exponent"
+                        className="mt-1 font-mono text-sm"
+                        data-testid={`input-jwk-e-${index}`}
+                      />
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeKey(index)}
+                    data-testid={`button-remove-jwk-${index}`}
+                  >
+                    <Trash2 className="w-4 h-4 mr-1" />
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        onClick={addKey}
+        className="w-full"
+        data-testid="button-add-jwk"
+      >
+        <Plus className="w-4 h-4 mr-2" />
+        Add Key
+      </Button>
+    </div>
+  );
+}

--- a/web-ui-react-jetty/elements-web-ui/client/src/pages/ResourceManager.tsx
+++ b/web-ui-react-jetty/elements-web-ui/client/src/pages/ResourceManager.tsx
@@ -659,9 +659,16 @@ export default function ResourceManager({ resourceName, endpoint }: ResourceMana
   // Memoize columns to prevent table remounting during refetch
   // MUST be before early returns to follow Rules of Hooks
   const columns = useMemo(() => {
-    if (!items || items.length === 0) return [];
-    
-    const keys = Object.keys(items[0]);
+    // Real items always win (avoids deriving columns from a draft's possibly-incomplete keys); fall back to
+    // the draft only while real items haven't loaded yet, so the table doesn't render zero data columns (which
+    // makes the sticky Actions cell appear to span the whole row) while a draft-only row is already showing.
+    const columnSource = items && items.length > 0
+      ? items
+      : (itemsWithDraft && itemsWithDraft.length > 0 ? itemsWithDraft : null);
+
+    if (!columnSource) return [];
+
+    const keys = Object.keys(columnSource[0]);
         
         // Custom column filtering and ordering for Profiles resource
         if (resourceName === 'Profiles') {
@@ -787,7 +794,7 @@ export default function ResourceManager({ resourceName, endpoint }: ResourceMana
         }
         
     return keys;
-  }, [items, resourceName]);
+  }, [items, itemsWithDraft, resourceName]);
 
   // Only show full-page loading on initial load (no cached data)
   if (isLoading && !items) {


### PR DESCRIPTION
## Summary
Fixes all three bugs filed in #56, plus one adjacent security fix and one adjacent data-integrity fix found while implementing them.

- **JWK JSON-escaping bug**: `keys` on an OIDC scheme fell through to a raw-JSON `<Textarea>` (the only structured-list field that hadn't gotten a proper editor, unlike OAuth2's headers/params/body). Replaced with `JwkListEditor`, a card-based editor. Scoped to what `JWK.java` actually supports today (RSA), but extended in the same change to add EC support (`crv`/`x`/`y`) with a kty-aware UI, since EC was a real near-term need, not speculative.
- **OIDC table renders wrong on first load**: table columns were derived only from real API items, so a local draft rendered with zero data columns (the sticky Actions cell appeared to swallow the row) until a refetch. Falls back to the draft's shape only when real items haven't loaded yet.
- **OAuth2 soft-delete leaves a null row**: `MongoOAuth2AuthSchemeDao` had no `exists()` filter (unlike the OIDC DAO), so a soft-deleted scheme stayed visible forever with null fields. Also made repeated delete on an already-deleted scheme 404 instead of silently no-oping, on both DAOs.

### Found along the way
- **Signature-verification bypass** (`OidcAuthServiceOperations.verify`): the direct-key-match path discarded `attemptVerify`'s return value, so a JWT whose `kid` matched a cached key passed verification even with an invalid signature. Fixed to check the result, matching the already-correct fetch-on-miss path.
- **Non-sparse unique indexes on soft-deleted fields**: both `MongoOAuth2AuthScheme`/`MongoOidcAuthScheme` had unique indexes on the exact fields their soft-delete unsets, so deleting a *second* scheme collided with the first's now-null value. Added `sparse: true`.
- Real EC verification also required replacing hardcoded RSA key construction / hardcoded `RSA256` dispatch in `getAlgorithmFromJWK` with real `kty`/`alg` dispatch, using Nimbus JOSE+JWT for JWK→PublicKey conversion (new dependency).

## Test plan
- [x] New DAO tests: `MongoOAuth2AuthSchemeDaoTest`, `MongoOidcAuthSchemeDaoTest` (create/list/find/update/delete + double-delete regression + the "all deleted" listing regression) — 106/106 passing
- [x] New service test: `OidcAuthServiceOperationsTest` (RSA RS256/384/512, EC ES256/384, unsupported-alg rejection, forged-signature-with-matching-kid regression) — all passing
- [x] Existing `OidcAuthServiceTest` still passing
- [x] `tsc` type-check clean (no new errors)
- [x] Full manual verification against a live running server (Mongo + jetty-ws + admin UI): created an OIDC scheme through the new JWK editor (confirmed clean structured payload over the wire, no JSON escaping), confirmed RSA↔EC field switching, reproduced and confirmed the fix for the table zero-column bug, created/deleted an OAuth2 scheme with no ghost row left behind, and confirmed a repeated delete now 404s