### PR TITLE
#29 Fix Endpoints links hardcoded to localhost:8080

### DIFF
--- a/web-ui-react-jetty/elements-web-ui/client/src/pages/Containers.tsx
+++ b/web-ui-react-jetty/elements-web-ui/client/src/pages/Containers.tsx
@@ -8,6 +8,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Loader2, Container, RefreshCw, ExternalLink, ChevronDown, ChevronRight, ArrowLeft, AlertTriangle, AlertCircle } from 'lucide-react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { queryClient } from '@/lib/queryClient';
+import { fixElementUri } from '@/lib/openapi-utils';
 
 interface ElementServiceMetadata {
   implementation?: {
@@ -334,13 +335,16 @@ function ContainerDetail({ container }: { container: ElementContainerStatus }) {
               <div className="space-y-2">
                 <h3 className="text-sm font-medium">Endpoints</h3>
                 <div className="space-y-1">
-                  {container.uris.map((uri, i) => (
-                    <a key={i} href={uri} target="_blank" rel="noopener noreferrer"
-                      className="flex items-center gap-2 px-3 py-2 rounded-md border bg-muted/20 hover:bg-muted/50 hover:border-primary/50 transition-colors">
-                      <ExternalLink className="w-3 h-3 text-muted-foreground flex-shrink-0" />
-                      <span className="font-mono text-xs break-all" data-testid={`text-uri-${i}`}>{uri}</span>
-                    </a>
-                  ))}
+                  {container.uris.map((uri, i) => {
+                    const fixedUri = fixElementUri(uri);
+                    return (
+                      <a key={i} href={fixedUri} target="_blank" rel="noopener noreferrer"
+                        className="flex items-center gap-2 px-3 py-2 rounded-md border bg-muted/20 hover:bg-muted/50 hover:border-primary/50 transition-colors">
+                        <ExternalLink className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+                        <span className="font-mono text-xs break-all" data-testid={`text-uri-${i}`}>{fixedUri}</span>
+                      </a>
+                    );
+                  })}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
- The Admin UI's container Endpoints panel rendered every URL verbatim from the backend, which bakes in http://localhost:8080 via server-side config defaults (APP_OUTSIDE_URL etc.) that aren't set in this repo's deployment configs, so hosted deployments showed unusable localhost links.
- Applied the same fix already used for OpenAPI doc links elsewhere in this codebase (fixElementUri() in client/src/lib/openapi-utils.ts), which rewrites localhost URLs to the browser's actual origin, instead of introducing a new backend-side request-derived-host pattern.

## Test plan
- [x] tsc type-check passes (no new errors introduced)
- [x] Verified via Playwright that the app loads with zero console errors and the edited files resolve correctly through the Vite dev server
- [x] Verified the fix logic against the exact URLs from the bug report: http://localhost:8080/conductor/admin and http://localhost:8080/app/ui/dev.getelements.elements.stripe both correctly resolve to the simulated hosted origin
- [ ] Manual visual check against a real container's Endpoints panel (not possible in this environment without a full running Elements backend + deployed test element)

Closes #29
