### PR TITLE
#43 Add javadoc copyright footer and brand CSS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1310,6 +1310,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${javadoc.plugin.version}</version>
+                <configuration>
+                    <bottom><![CDATA[Copyright &#169; {currentYear} Namazu Studios LLC. All rights reserved.]]></bottom>
+                    <additionalOptions>
+                        <additionalOption>-stylesheetfile ${maven.multiModuleProjectDirectory}/src/main/javadoc/stylesheet.css</additionalOption>
+                    </additionalOptions>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/javadoc/stylesheet.css
+++ b/src/main/javadoc/stylesheet.css
@@ -1,0 +1,46 @@
+/*
+ * Namazu Elements brand overrides for the standard javadoc stylesheet.
+ * Brand colors: hot pink #FF0099, navy #0D1335
+ */
+
+:root {
+    --namazu-hot-pink: #FF0099;
+    --namazu-navy: #0D1335;
+}
+
+.top-nav, .sub-nav, .bottom-nav {
+    background-color: var(--namazu-navy);
+    color: #fff;
+}
+
+.top-nav a:link, .top-nav a:visited,
+.sub-nav a:link, .sub-nav a:visited,
+.bottom-nav a:link, .bottom-nav a:visited {
+    color: var(--namazu-hot-pink);
+}
+
+.title, .sub-title {
+    color: var(--namazu-navy);
+}
+
+a:link, a:visited {
+    color: var(--namazu-hot-pink);
+}
+
+a:hover, a:focus {
+    color: var(--namazu-navy);
+}
+
+.package-hierarchy-label, caption a:link, caption a:visited {
+    background-color: var(--namazu-navy);
+}
+
+.table-tabs > button.active-table-tab {
+    background-color: var(--namazu-navy);
+    color: #fff;
+}
+
+.table-tabs > button.table-tab, .caption a[href]:hover {
+    background-color: var(--namazu-hot-pink);
+    color: #000;
+}


### PR DESCRIPTION
## Summary
- Javadoc previously had no copyright notice and used the plain default styling.
- Added a `bottom` footer to the root `maven-javadoc-plugin` config: "Copyright (c) {currentYear} Namazu Studios LLC. All rights reserved." (applies to every module since the plugin is configured once at the root).
- Added `src/main/javadoc/stylesheet.css` with brand colors (hot pink #FF0099, navy #0D1335) applied via the raw `-stylesheetfile` javadoc option (Maven's own `addStylesheets`/`stylesheetfile` parameters only resolve paths relative to each module's own `src/main/javadoc/`, which doesn't work for a single shared file across an 84-module reactor).
- Fixed a contrast issue found during review: non-link text in the nav bars (e.g. "Package", "Class" breadcrumb labels) and the active class-summary tab button were dark text on the new navy background. Explicit white text color added for nav bars and the active tab.

## Test plan
- [x] Generated javadoc for `sdk-model` locally (`mvn -pl sdk-model javadoc:javadoc`) and visually confirmed:
  - Copyright footer appears on every page
  - Brand CSS colors applied (navy nav bars, hot pink links/tabs)
  - Nav bar text and active-tab text are readable (white on navy) after the contrast fix

Closes #43
