### PR TITLE
Thread applicationNameOrId through the OIDC browser-redirect login flow

### DIFF
--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcLoginAttempt.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcLoginAttempt.java
@@ -54,6 +54,9 @@ public class MongoOidcLoginAttempt {
     private String linkedUserId;
 
     @Property
+    private String applicationNameOrId;
+
+    @Property
     private String linkClaimsJson;
 
     @Property
@@ -147,6 +150,14 @@ public class MongoOidcLoginAttempt {
         this.linkedUserId = linkedUserId;
     }
 
+    public String getApplicationNameOrId() {
+        return applicationNameOrId;
+    }
+
+    public void setApplicationNameOrId(String applicationNameOrId) {
+        this.applicationNameOrId = applicationNameOrId;
+    }
+
     public String getLinkClaimsJson() {
         return linkClaimsJson;
     }
@@ -179,6 +190,7 @@ public class MongoOidcLoginAttempt {
                 && Objects.equals(getSuccessRedirectUrl(), that.getSuccessRedirectUrl())
                 && Objects.equals(getErrorRedirectUrl(), that.getErrorRedirectUrl())
                 && Objects.equals(getLinkedUserId(), that.getLinkedUserId())
+                && Objects.equals(getApplicationNameOrId(), that.getApplicationNameOrId())
                 && Objects.equals(getLinkClaimsJson(), that.getLinkClaimsJson())
                 && Objects.equals(getConfirmToken(), that.getConfirmToken());
     }
@@ -187,7 +199,7 @@ public class MongoOidcLoginAttempt {
     public int hashCode() {
         return Objects.hash(getId(), getProvider(), getState(), getNonce(), getStatus(),
                 getSessionToken(), getFailureReason(), getExpiry(), getSuccessRedirectUrl(), getErrorRedirectUrl(),
-                getLinkedUserId(), getLinkClaimsJson(), getConfirmToken());
+                getLinkedUserId(), getApplicationNameOrId(), getLinkClaimsJson(), getConfirmToken());
     }
 
 }

--- a/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcSessionResource.java
+++ b/rest-api/src/main/java/dev/getelements/elements/rest/auth/OidcSessionResource.java
@@ -69,6 +69,7 @@ public class OidcSessionResource {
 
             final var oidcSessionRequest = new OidcSessionRequest();
             oidcSessionRequest.setJwt(request.getIdToken());
+            oidcSessionRequest.setApplicationNameOrId(request.getApplicationNameOrId());
 
             final var sessionCreation = getOidcAuthService().createSession(oidcSessionRequest);
             final var body = OidcLoginAttemptResponse.complete(sessionCreation);
@@ -77,7 +78,7 @@ public class OidcSessionResource {
 
         }
 
-        final var begin = getOidcLoginAttemptService().begin(request.getProvider());
+        final var begin = getOidcLoginAttemptService().begin(request.getProvider(), request.getApplicationNameOrId());
         final var body = OidcLoginAttemptResponse.pending(
                 begin.getId(), begin.getAuthorizeUrl(), begin.getExpiresAt(), begin.getConfirmToken());
 

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/OidcLoginAttempt.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/auth/OidcLoginAttempt.java
@@ -53,6 +53,15 @@ public class OidcLoginAttempt {
     private String linkedUserId;
 
     /**
+     * The name or ID of the application whose primary profile should be attached to the resulting session, set
+     * at {@code begin()} time when the caller requested one. Snapshotted here (rather than read live) because
+     * {@code begin()} and the callback that later resolves this attempt are separate HTTP calls with no shared
+     * request body. {@code null} if the caller did not request one, in which case the legacy JWT
+     * {@code aud}-claim-driven, ungated resolution applies instead.
+     */
+    private String applicationNameOrId;
+
+    /**
      * Serialized external-identity claims (scheme name, external user id, email, profile claims) validated by
      * the callback for a linking attempt, set when transitioning to {@link OidcLoginAttemptStatus#LINK_READY}.
      * Consumed exactly once, by the authenticated poll that performs the deferred account-link mutation.
@@ -154,6 +163,14 @@ public class OidcLoginAttempt {
 
     public void setLinkedUserId(String linkedUserId) {
         this.linkedUserId = linkedUserId;
+    }
+
+    public String getApplicationNameOrId() {
+        return applicationNameOrId;
+    }
+
+    public void setApplicationNameOrId(String applicationNameOrId) {
+        this.applicationNameOrId = applicationNameOrId;
     }
 
     public String getLinkClaimsJson() {

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptRequest.java
@@ -24,6 +24,12 @@ public class OidcLoginAttemptRequest {
     @Schema(description = "An already-possessed id_token to validate directly, skipping the browser-redirect flow.")
     private String idToken;
 
+    @Schema(description = "The name or ID of an application whose primary profile should be attached to the " +
+            "session, auto-creating it (subject to the application's autoCreateProfile/maxProfiles settings) if " +
+            "it does not exist. If unspecified, the application encoded in the resulting id_token's own claims " +
+            "(if any) is used instead, without auto-create.")
+    private String applicationNameOrId;
+
     public String getProvider() {
         return provider;
     }
@@ -40,16 +46,25 @@ public class OidcLoginAttemptRequest {
         this.idToken = idToken;
     }
 
+    public String getApplicationNameOrId() {
+        return applicationNameOrId;
+    }
+
+    public void setApplicationNameOrId(String applicationNameOrId) {
+        this.applicationNameOrId = applicationNameOrId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof OidcLoginAttemptRequest that)) return false;
         return Objects.equals(provider, that.provider)
-                && Objects.equals(idToken, that.idToken);
+                && Objects.equals(idToken, that.idToken)
+                && Objects.equals(applicationNameOrId, that.applicationNameOrId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(provider, idToken);
+        return Objects.hash(provider, idToken, applicationNameOrId);
     }
 
     @Override

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptRequest.java
@@ -26,8 +26,9 @@ public class OidcLoginAttemptRequest {
 
     @Schema(description = "The name or ID of an application whose primary profile should be attached to the " +
             "session, auto-creating it (subject to the application's autoCreateProfile/maxProfiles settings) if " +
-            "it does not exist. If unspecified, the application encoded in the resulting id_token's own claims " +
-            "(if any) is used instead, without auto-create.")
+            "it does not exist. Only takes effect for an anonymous (non-linking) attempt. If unspecified, the " +
+            "application encoded in the resulting id_token's own 'aud' claim (if any) is used instead, via the " +
+            "legacy, ungated get-or-create profile behavior rather than the gated auto-create path above.")
     private String applicationNameOrId;
 
     public String getProvider() {

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/session/OidcLoginAttemptRequest.java
@@ -25,10 +25,11 @@ public class OidcLoginAttemptRequest {
     private String idToken;
 
     @Schema(description = "The name or ID of an application whose primary profile should be attached to the " +
-            "session, auto-creating it (subject to the application's autoCreateProfile/maxProfiles settings) if " +
-            "it does not exist. Only takes effect for an anonymous (non-linking) attempt. If unspecified, the " +
-            "application encoded in the resulting id_token's own 'aud' claim (if any) is used instead, via the " +
-            "legacy, ungated get-or-create profile behavior rather than the gated auto-create path above.")
+            "session, reusing an existing primary profile if one is already present, or else auto-creating it " +
+            "(subject to the application's autoCreateProfile/maxProfiles settings). Applies to both anonymous " +
+            "and account-linking attempts. If unspecified, the application encoded in the resulting id_token's " +
+            "own 'aud' claim (if any) is used instead, via the legacy, ungated get-or-create profile behavior " +
+            "rather than the gated auto-create path above.")
     private String applicationNameOrId;
 
     public String getProvider() {

--- a/sdk-service/src/main/java/dev/getelements/elements/sdk/service/auth/OidcLoginAttemptService.java
+++ b/sdk-service/src/main/java/dev/getelements/elements/sdk/service/auth/OidcLoginAttemptService.java
@@ -31,6 +31,19 @@ public interface OidcLoginAttemptService {
     OidcLoginAttemptBegin begin(String provider);
 
     /**
+     * Same as {@link #begin(String)}, additionally requesting that the given application's primary profile be
+     * attached to the resulting session (auto-creating it, subject to the application's autoCreateProfile/
+     * maxProfiles settings, if it does not exist) once the attempt resolves. Snapshotted onto the pending attempt
+     * at begin() time, since the callback that later resolves it shares no request body with this call.
+     *
+     * @param provider the provider identifier (e.g. "twitch")
+     * @param applicationNameOrId the name or ID of the application whose primary profile should be attached, or
+     *                             {@code null} for the legacy JWT aud-claim-driven, ungated behavior
+     * @return the pending attempt's id, authorize URL, and expiry
+     */
+    OidcLoginAttemptBegin begin(String provider, String applicationNameOrId);
+
+    /**
      * Polls a pending attempt by id. Returns COMPLETE with the session exactly once, on the poll that first
      * observes completion; every subsequent poll for the same id returns EXPIRED.
      *

--- a/service-test/src/test/java/dev/getelements/elements/service/OidcAuthServiceOperationsProfileTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OidcAuthServiceOperationsProfileTest.java
@@ -288,6 +288,110 @@ public class OidcAuthServiceOperationsProfileTest {
 
     }
 
+    // ── createSessionForResolvedUser(User, String, boolean) — account-linking confirm path ──────────────────
+
+    @Test
+    public void testCreateSessionForResolvedUserReusesExistingPrimaryProfileIfPresent() {
+
+        final var user = new User();
+        user.setId("user-6");
+
+        final var application = new Application();
+        application.setId("app-6");
+        application.setAutoCreateProfile(true);
+        application.setMaxProfiles(1);
+
+        final var existingProfile = new Profile();
+        existingProfile.setId("existing-profile-6");
+
+        when(applicationDao.findActiveApplication("app-6")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-6", "app-6")).thenReturn(Optional.of(existingProfile));
+
+        ops.createSessionForResolvedUser(user, "app-6", true);
+
+        verify(profileDao, never()).createSlottedProfile(any(), anyMap());
+        verify(profileDao, never()).createOrRefreshProfile(any());
+
+        final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertEquals(sessionCaptor.getValue().getProfile(), existingProfile);
+        assertEquals(sessionCaptor.getValue().getApplication(), application);
+
+    }
+
+    @Test
+    public void testCreateSessionForResolvedUserAutoCreatesWhenExplicitlyRequestedAndConfigured() {
+
+        final var user = new User();
+        user.setId("user-7");
+
+        final var application = new Application();
+        application.setId("app-7");
+        application.setAutoCreateProfile(true);
+        application.setMaxProfiles(1);
+
+        when(applicationDao.findActiveApplication("app-7")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-7", "app-7")).thenReturn(Optional.empty());
+
+        final var createdProfile = new Profile();
+        createdProfile.setId("profile-7");
+        when(profileDao.createSlottedProfile(any(Profile.class), anyMap())).thenReturn(createdProfile);
+
+        ops.createSessionForResolvedUser(user, "app-7", true);
+
+        verify(profileDao).createSlottedProfile(any(Profile.class), anyMap());
+        verify(profileDao, never()).createOrRefreshProfile(any());
+
+        final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertEquals(sessionCaptor.getValue().getProfile(), createdProfile);
+
+    }
+
+    @Test
+    public void testCreateSessionForResolvedUserUsesLegacyUngatedCreateWhenNotExplicitlyRequested() {
+
+        final var user = new User();
+        user.setId("user-8");
+
+        final var application = new Application();
+        application.setId("app-8");
+        application.setAutoCreateProfile(false); // deliberately not configured -- legacy path ignores this
+        application.setMaxProfiles(0);
+
+        when(applicationDao.findActiveApplication("app-8")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-8", "app-8")).thenReturn(Optional.empty());
+
+        final var legacyProfile = new Profile();
+        legacyProfile.setId("legacy-profile-8");
+        when(profileDao.createOrRefreshProfile(any(Profile.class))).thenReturn(legacyProfile);
+
+        // explicitlyRequested=false mirrors the aud-claim-driven fallback resolved earlier by the caller.
+        ops.createSessionForResolvedUser(user, "app-8", false);
+
+        verify(profileDao).createOrRefreshProfile(any(Profile.class));
+        verify(profileDao, never()).createSlottedProfile(any(), anyMap());
+
+    }
+
+    @Test
+    public void testCreateSessionForResolvedUserWithoutApplicationNameOrIdAttachesNothing() {
+
+        final var user = new User();
+        user.setId("user-9");
+
+        ops.createSessionForResolvedUser(user, null, false);
+
+        verifyNoInteractions(applicationDao);
+        verifyNoInteractions(profileDao);
+
+        final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertNull(sessionCaptor.getValue().getProfile());
+        assertNull(sessionCaptor.getValue().getApplication());
+
+    }
+
     private static class TestModule extends AbstractModule {
 
         @Override

--- a/service-test/src/test/java/dev/getelements/elements/service/OidcAuthServiceOperationsProfileTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OidcAuthServiceOperationsProfileTest.java
@@ -227,6 +227,67 @@ public class OidcAuthServiceOperationsProfileTest {
         assertEquals(sessionCaptor.getValue().getProfile(), createdProfile);
     }
 
+    @Test
+    public void testVerifiedTokenPathAutoCreatesPrimaryProfileWhenApplicationNameOrIdSuppliedAndConfigured() {
+
+        final var decodedJWT = JWT.decode(token(null));
+        final var scheme = scheme();
+
+        final var user = new User();
+        user.setId("user-4");
+
+        final var application = new Application();
+        application.setId("app-4");
+        application.setAutoCreateProfile(true);
+        application.setMaxProfiles(1);
+
+        when(applicationDao.findActiveApplication("app-4")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-4", "app-4")).thenReturn(Optional.empty());
+
+        final var createdProfile = new Profile();
+        createdProfile.setId("profile-4");
+        when(profileDao.createSlottedProfile(any(Profile.class), anyMap())).thenReturn(createdProfile);
+
+        ops.createOrUpdateUserWithVerifiedToken(decodedJWT, scheme, userMapper(user), "app-4");
+
+        verify(profileDao).createSlottedProfile(any(Profile.class), anyMap());
+        verify(profileDao, never()).createOrRefreshProfile(any());
+
+        final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
+        verify(sessionDao).create(sessionCaptor.capture());
+        assertEquals(sessionCaptor.getValue().getProfile(), createdProfile);
+        assertEquals(sessionCaptor.getValue().getApplication(), application);
+
+    }
+
+    @Test
+    public void testVerifiedTokenPathWithoutApplicationNameOrIdFallsBackToAudClaim() {
+
+        final var decodedJWT = JWT.decode(token("app-5"));
+        final var scheme = scheme();
+
+        final var user = new User();
+        user.setId("user-5");
+
+        final var application = new Application();
+        application.setId("app-5");
+        application.setAutoCreateProfile(false);
+        application.setMaxProfiles(0);
+
+        when(applicationDao.findActiveApplication("app-5")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-5", "app-5")).thenReturn(Optional.empty());
+
+        final var legacyProfile = new Profile();
+        legacyProfile.setId("legacy-profile-5");
+        when(profileDao.createOrRefreshProfile(any(Profile.class))).thenReturn(legacyProfile);
+
+        ops.createOrUpdateUserWithVerifiedToken(decodedJWT, scheme, userMapper(user));
+
+        verify(profileDao).createOrRefreshProfile(any(Profile.class));
+        verify(profileDao, never()).createSlottedProfile(any(), anyMap());
+
+    }
+
     private static class TestModule extends AbstractModule {
 
         @Override

--- a/service-test/src/test/java/dev/getelements/elements/service/OidcLoginAttemptOperationsTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OidcLoginAttemptOperationsTest.java
@@ -5,9 +5,11 @@ import com.auth0.jwt.algorithms.Algorithm;
 import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.OidcLoginAttemptDao;
 import dev.getelements.elements.sdk.dao.OidcProviderConfigurationDao;
+import dev.getelements.elements.sdk.dao.ProfileDao;
 import dev.getelements.elements.sdk.dao.SessionDao;
 import dev.getelements.elements.sdk.dao.UserDao;
 import dev.getelements.elements.sdk.dao.UserUidDao;
+import dev.getelements.elements.sdk.model.application.Application;
 import dev.getelements.elements.sdk.model.auth.JWK;
 import dev.getelements.elements.sdk.model.auth.OidcAuthScheme;
 import dev.getelements.elements.sdk.model.auth.OidcLoginAttempt;
@@ -16,10 +18,12 @@ import dev.getelements.elements.sdk.model.auth.OidcProviderConfiguration;
 import dev.getelements.elements.sdk.model.auth.TokenEndpointAuthMethod;
 import dev.getelements.elements.sdk.model.exception.ForbiddenException;
 import dev.getelements.elements.sdk.model.exception.InvalidDataException;
+import dev.getelements.elements.sdk.model.profile.Profile;
 import dev.getelements.elements.sdk.model.session.OidcLoginAttemptStatusResponse;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
 import dev.getelements.elements.sdk.model.user.User;
 import dev.getelements.elements.sdk.model.user.UserUid;
+import dev.getelements.elements.sdk.service.name.NameService;
 import dev.getelements.elements.service.auth.oidc.AnonOidcAuthService;
 import dev.getelements.elements.service.auth.oidc.OidcAuthServiceOperations;
 import dev.getelements.elements.service.auth.oidc.OidcDiscoveryDocument;
@@ -49,6 +53,7 @@ import java.util.Optional;
 import static java.lang.System.currentTimeMillis;
 import static java.util.List.of;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -73,6 +78,8 @@ public class OidcLoginAttemptOperationsTest {
     private UserOidcAuthService userOidcAuthService;
     private UserDao userDao;
     private Client client;
+    private ApplicationDao applicationDao;
+    private ProfileDao profileDao;
 
     private OidcLoginAttemptOperations operations;
 
@@ -108,7 +115,11 @@ public class OidcLoginAttemptOperationsTest {
         // than mocking it away. The token carries an 'aud' claim (needed for the audience check), which also
         // triggers buildSession's optional Application lookup, so ApplicationDao/SessionDao need mocking too.
         oidcAuthServiceOperations = new OidcAuthServiceOperations();
-        oidcAuthServiceOperations.setApplicationDao(mock(ApplicationDao.class));
+        applicationDao = mock(ApplicationDao.class);
+        oidcAuthServiceOperations.setApplicationDao(applicationDao);
+        profileDao = mock(ProfileDao.class);
+        oidcAuthServiceOperations.setProfileDao(profileDao);
+        oidcAuthServiceOperations.setNameService(mock(NameService.class));
         final var sessionDao = mock(SessionDao.class);
         when(sessionDao.create(any())).thenAnswer(invocation -> {
             final var sessionCreation = new SessionCreation();
@@ -267,6 +278,28 @@ public class OidcLoginAttemptOperationsTest {
 
     }
 
+    @Test
+    public void testBeginWithoutApplicationNameOrIdLeavesItNull() {
+
+        operations.begin(PROVIDER);
+
+        final var attemptCaptor = ArgumentCaptor.forClass(OidcLoginAttempt.class);
+        verify(oidcLoginAttemptDao).create(attemptCaptor.capture());
+        assertNull(attemptCaptor.getValue().getApplicationNameOrId());
+
+    }
+
+    @Test
+    public void testBeginWithApplicationNameOrIdPersistsIt() {
+
+        operations.begin(PROVIDER, null, "app-1");
+
+        final var attemptCaptor = ArgumentCaptor.forClass(OidcLoginAttempt.class);
+        verify(oidcLoginAttemptDao).create(attemptCaptor.capture());
+        assertEquals(attemptCaptor.getValue().getApplicationNameOrId(), "app-1");
+
+    }
+
     // ── handleCallback() ─────────────────────────────────────────────────────
 
     @Test
@@ -336,6 +369,98 @@ public class OidcLoginAttemptOperationsTest {
         assertNull(result.getRedirectUrl());
         verify(oidcLoginAttemptDao).markComplete(eq(state), anyString());
         verify(oidcLoginAttemptDao, never()).markFailed(eq(state), anyString());
+
+    }
+
+    @Test
+    public void testHandleCallbackAnonymousPathReachesGatedAutoCreateWhenApplicationNameOrIdSet() {
+
+        final var state = "matching-state";
+        final var nonce = "matching-nonce";
+        final var attempt = pendingAttempt(state, nonce);
+        attempt.setApplicationNameOrId("app-1");
+
+        when(oidcLoginAttemptDao.findPendingByState(PROVIDER, state)).thenReturn(Optional.of(attempt));
+        when(oidcLoginAttemptDao.markComplete(eq(state), anyString())).thenReturn(Optional.of(attempt));
+
+        final var idToken = JWT.create()
+                .withIssuer(ISSUER)
+                .withSubject("twitch-sub")
+                .withAudience(CLIENT_ID)
+                .withClaim("nonce", nonce)
+                .withKeyId(KID)
+                .withExpiresAt(new Date(currentTimeMillis() + 60_000))
+                .sign(algorithm);
+
+        stubTokenExchange(idToken);
+
+        final var user = new User();
+        user.setId("user-1");
+        when(anonOidcAuthService.apply(any(), any())).thenReturn(user);
+
+        final var application = new Application();
+        application.setId("app-1");
+        application.setAutoCreateProfile(true);
+        application.setMaxProfiles(1);
+
+        when(applicationDao.findActiveApplication("app-1")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-1", "app-1")).thenReturn(Optional.empty());
+
+        final var createdProfile = new Profile();
+        createdProfile.setId("profile-1");
+        when(profileDao.createSlottedProfile(any(Profile.class), anyMap())).thenReturn(createdProfile);
+
+        final var result = operations.handleCallback(PROVIDER, "auth-code", state, null);
+
+        assertTrue(result.isSuccess());
+        verify(profileDao).createSlottedProfile(any(Profile.class), anyMap());
+        verify(profileDao, never()).createOrRefreshProfile(any());
+
+    }
+
+    @Test
+    public void testHandleCallbackAnonymousPathWithoutApplicationNameOrIdKeepsLegacyUngatedBehavior() {
+
+        final var state = "matching-state";
+        final var nonce = "matching-nonce";
+        final var attempt = pendingAttempt(state, nonce);
+        // applicationNameOrId intentionally left unset -- legacy aud-claim-driven resolution applies.
+
+        when(oidcLoginAttemptDao.findPendingByState(PROVIDER, state)).thenReturn(Optional.of(attempt));
+        when(oidcLoginAttemptDao.markComplete(eq(state), anyString())).thenReturn(Optional.of(attempt));
+
+        final var idToken = JWT.create()
+                .withIssuer(ISSUER)
+                .withSubject("twitch-sub")
+                .withAudience(CLIENT_ID)
+                .withClaim("nonce", nonce)
+                .withKeyId(KID)
+                .withExpiresAt(new Date(currentTimeMillis() + 60_000))
+                .sign(algorithm);
+
+        stubTokenExchange(idToken);
+
+        final var user = new User();
+        user.setId("user-2");
+        when(anonOidcAuthService.apply(any(), any())).thenReturn(user);
+
+        final var application = new Application();
+        application.setId(CLIENT_ID);
+        application.setAutoCreateProfile(true);
+        application.setMaxProfiles(1);
+
+        when(applicationDao.findActiveApplication(CLIENT_ID)).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("user-2", CLIENT_ID)).thenReturn(Optional.empty());
+
+        final var legacyProfile = new Profile();
+        legacyProfile.setId("legacy-profile");
+        when(profileDao.createOrRefreshProfile(any(Profile.class))).thenReturn(legacyProfile);
+
+        final var result = operations.handleCallback(PROVIDER, "auth-code", state, null);
+
+        assertTrue(result.isSuccess());
+        verify(profileDao).createOrRefreshProfile(any(Profile.class));
+        verify(profileDao, never()).createSlottedProfile(any(), anyMap());
 
     }
 

--- a/service-test/src/test/java/dev/getelements/elements/service/OidcLoginAttemptOperationsTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OidcLoginAttemptOperationsTest.java
@@ -2,6 +2,7 @@ package dev.getelements.elements.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.getelements.elements.sdk.dao.ApplicationDao;
 import dev.getelements.elements.sdk.dao.OidcLoginAttemptDao;
 import dev.getelements.elements.sdk.dao.OidcProviderConfigurationDao;
@@ -27,6 +28,7 @@ import dev.getelements.elements.sdk.service.name.NameService;
 import dev.getelements.elements.service.auth.oidc.AnonOidcAuthService;
 import dev.getelements.elements.service.auth.oidc.OidcAuthServiceOperations;
 import dev.getelements.elements.service.auth.oidc.OidcDiscoveryDocument;
+import dev.getelements.elements.service.auth.oidc.OidcLinkClaims;
 import dev.getelements.elements.service.auth.oidc.OidcLoginAttemptOperations;
 import dev.getelements.elements.service.auth.oidc.OidcProviderConfigurationOperations;
 import dev.getelements.elements.service.auth.oidc.UserOidcAuthService;
@@ -530,6 +532,78 @@ public class OidcLoginAttemptOperationsTest {
 
     }
 
+    @Test
+    public void testHandleCallbackForLinkingAttemptWithApplicationNameOrIdPersistsItExplicitlyOntoClaims() {
+
+        final var state = "linking-state";
+        final var nonce = "linking-nonce";
+        final var attempt = pendingAttempt(state, nonce);
+        attempt.setLinkedUserId("current-user-id");
+        attempt.setApplicationNameOrId("app-1");
+
+        when(oidcLoginAttemptDao.findPendingByState(PROVIDER, state)).thenReturn(Optional.of(attempt));
+        when(oidcLoginAttemptDao.markLinkReady(eq(state), anyString())).thenReturn(Optional.of(attempt));
+
+        final var idToken = JWT.create()
+                .withIssuer(ISSUER)
+                .withSubject("twitch-sub")
+                .withAudience(CLIENT_ID)
+                .withClaim("nonce", nonce)
+                .withKeyId(KID)
+                .withExpiresAt(new Date(currentTimeMillis() + 60_000))
+                .sign(algorithm);
+
+        stubTokenExchange(idToken);
+
+        operations.handleCallback(PROVIDER, "auth-code", state, null);
+
+        final var claims = deserializeLinkClaims();
+        assertEquals(claims.getApplicationNameOrId(), "app-1");
+        assertTrue(claims.isApplicationExplicitlyRequested());
+
+    }
+
+    @Test
+    public void testHandleCallbackForLinkingAttemptWithoutApplicationNameOrIdFallsBackToAudClaim() {
+
+        final var state = "linking-state";
+        final var nonce = "linking-nonce";
+        final var attempt = pendingAttempt(state, nonce);
+        attempt.setLinkedUserId("current-user-id");
+        // applicationNameOrId intentionally left unset -- aud-claim fallback applies, same as the anonymous path.
+
+        when(oidcLoginAttemptDao.findPendingByState(PROVIDER, state)).thenReturn(Optional.of(attempt));
+        when(oidcLoginAttemptDao.markLinkReady(eq(state), anyString())).thenReturn(Optional.of(attempt));
+
+        final var idToken = JWT.create()
+                .withIssuer(ISSUER)
+                .withSubject("twitch-sub")
+                .withAudience(CLIENT_ID)
+                .withClaim("nonce", nonce)
+                .withKeyId(KID)
+                .withExpiresAt(new Date(currentTimeMillis() + 60_000))
+                .sign(algorithm);
+
+        stubTokenExchange(idToken);
+
+        operations.handleCallback(PROVIDER, "auth-code", state, null);
+
+        final var claims = deserializeLinkClaims();
+        assertEquals(claims.getApplicationNameOrId(), CLIENT_ID);
+        assertFalse(claims.isApplicationExplicitlyRequested());
+
+    }
+
+    private OidcLinkClaims deserializeLinkClaims() {
+        final var claimsCaptor = ArgumentCaptor.forClass(String.class);
+        verify(oidcLoginAttemptDao).markLinkReady(anyString(), claimsCaptor.capture());
+        try {
+            return new ObjectMapper().readValue(claimsCaptor.getValue(), OidcLinkClaims.class);
+        } catch (final Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
     // ── poll() ───────────────────────────────────────────────────────────────
 
     @Test(expectedExceptions = ForbiddenException.class)
@@ -609,6 +683,104 @@ public class OidcLoginAttemptOperationsTest {
 
     }
 
+    @Test
+    public void testConfirmLinkReusesExistingPrimaryProfileIfPresent() {
+
+        final var attempt = linkReadyAttemptWithApplication("app-1", true);
+        when(oidcLoginAttemptDao.findLinkReadyById("link-ready-id")).thenReturn(Optional.of(attempt));
+        when(oidcLoginAttemptDao.claimLinkReadyById("link-ready-id")).thenReturn(Optional.of(attempt));
+
+        final var linkedUser = new User();
+        linkedUser.setId("current-user-id");
+        when(userDao.getUser("current-user-id")).thenReturn(linkedUser);
+
+        final var application = new Application();
+        application.setId("app-1");
+        application.setAutoCreateProfile(true);
+        application.setMaxProfiles(1);
+
+        final var existingProfile = new Profile();
+        existingProfile.setId("existing-profile");
+
+        when(applicationDao.findActiveApplication("app-1")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("current-user-id", "app-1")).thenReturn(Optional.of(existingProfile));
+
+        final var result = operations.confirmLink("link-ready-id", "correct-token");
+
+        assertEquals(result.getStatus(), dev.getelements.elements.sdk.model.session.OidcLoginAttemptState.COMPLETE);
+        verify(profileDao, never()).createSlottedProfile(any(), anyMap());
+        verify(profileDao, never()).createOrRefreshProfile(any());
+        assertEquals(result.getSession().getSession().getProfile(), existingProfile);
+        assertEquals(result.getSession().getSession().getApplication(), application);
+
+    }
+
+    @Test
+    public void testConfirmLinkAutoCreatesGatedProfileWhenExplicitlyRequestedAndNoneExists() {
+
+        final var attempt = linkReadyAttemptWithApplication("app-2", true);
+        when(oidcLoginAttemptDao.findLinkReadyById("link-ready-id")).thenReturn(Optional.of(attempt));
+        when(oidcLoginAttemptDao.claimLinkReadyById("link-ready-id")).thenReturn(Optional.of(attempt));
+
+        final var linkedUser = new User();
+        linkedUser.setId("current-user-id");
+        when(userDao.getUser("current-user-id")).thenReturn(linkedUser);
+
+        final var application = new Application();
+        application.setId("app-2");
+        application.setAutoCreateProfile(true);
+        application.setMaxProfiles(1);
+
+        when(applicationDao.findActiveApplication("app-2")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("current-user-id", "app-2")).thenReturn(Optional.empty());
+
+        final var createdProfile = new Profile();
+        createdProfile.setId("created-profile");
+        when(profileDao.createSlottedProfile(any(Profile.class), anyMap())).thenReturn(createdProfile);
+
+        final var result = operations.confirmLink("link-ready-id", "correct-token");
+
+        assertEquals(result.getStatus(), dev.getelements.elements.sdk.model.session.OidcLoginAttemptState.COMPLETE);
+        verify(profileDao).createSlottedProfile(any(Profile.class), anyMap());
+        verify(profileDao, never()).createOrRefreshProfile(any());
+        assertEquals(result.getSession().getSession().getProfile(), createdProfile);
+
+    }
+
+    @Test
+    public void testConfirmLinkUsesLegacyUngatedCreateWhenApplicationCameFromAudClaimFallback() {
+
+        // explicitlyRequested=false mirrors what handleCallback persists when applicationNameOrId was never set
+        // on the attempt and the value came from the token's own aud claim instead.
+        final var attempt = linkReadyAttemptWithApplication("app-3", false);
+        when(oidcLoginAttemptDao.findLinkReadyById("link-ready-id")).thenReturn(Optional.of(attempt));
+        when(oidcLoginAttemptDao.claimLinkReadyById("link-ready-id")).thenReturn(Optional.of(attempt));
+
+        final var linkedUser = new User();
+        linkedUser.setId("current-user-id");
+        when(userDao.getUser("current-user-id")).thenReturn(linkedUser);
+
+        final var application = new Application();
+        application.setId("app-3");
+        application.setAutoCreateProfile(false); // deliberately not configured -- legacy path ignores this
+        application.setMaxProfiles(0);
+
+        when(applicationDao.findActiveApplication("app-3")).thenReturn(Optional.of(application));
+        when(profileDao.findPrimaryProfile("current-user-id", "app-3")).thenReturn(Optional.empty());
+
+        final var legacyProfile = new Profile();
+        legacyProfile.setId("legacy-profile");
+        when(profileDao.createOrRefreshProfile(any(Profile.class))).thenReturn(legacyProfile);
+
+        final var result = operations.confirmLink("link-ready-id", "correct-token");
+
+        assertEquals(result.getStatus(), dev.getelements.elements.sdk.model.session.OidcLoginAttemptState.COMPLETE);
+        verify(profileDao).createOrRefreshProfile(any(Profile.class));
+        verify(profileDao, never()).createSlottedProfile(any(), anyMap());
+        assertEquals(result.getSession().getSession().getProfile(), legacyProfile);
+
+    }
+
     private OidcLoginAttempt linkReadyAttempt() {
         final var attempt = pendingAttempt("linking-state", "linking-nonce");
         attempt.setId("link-ready-id");
@@ -617,6 +789,16 @@ public class OidcLoginAttemptOperationsTest {
         attempt.setConfirmToken("correct-token");
         attempt.setLinkClaimsJson(
                 "{\"schemeName\":\"twitch\",\"externalUserId\":\"twitch-sub\",\"email\":null,\"profileClaims\":{}}");
+        return attempt;
+    }
+
+    private OidcLoginAttempt linkReadyAttemptWithApplication(final String applicationNameOrId,
+                                                               final boolean explicitlyRequested) {
+        final var attempt = linkReadyAttempt();
+        attempt.setLinkClaimsJson(
+                "{\"schemeName\":\"twitch\",\"externalUserId\":\"twitch-sub\",\"email\":null,\"profileClaims\":{}," +
+                        "\"applicationNameOrId\":\"" + applicationNameOrId + "\"," +
+                        "\"applicationExplicitlyRequested\":" + explicitlyRequested + "}");
         return attempt;
     }
 

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/AnonOidcLoginAttemptService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/AnonOidcLoginAttemptService.java
@@ -21,6 +21,11 @@ public class AnonOidcLoginAttemptService implements OidcLoginAttemptService {
     }
 
     @Override
+    public OidcLoginAttemptBegin begin(final String provider, final String applicationNameOrId) {
+        return getOidcLoginAttemptOperations().begin(provider, null, applicationNameOrId);
+    }
+
+    @Override
     public OidcLoginAttemptStatusResponse poll(final String id) {
         return getOidcLoginAttemptOperations().poll(id);
     }

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
@@ -146,7 +146,24 @@ public class OidcAuthServiceOperations {
             final DecodedJWT decodedJWT,
             final OidcAuthScheme scheme,
             final BiFunction<DecodedJWT, OidcAuthScheme, User> userMapper) {
-        return buildSession(decodedJWT, scheme, userMapper, null);
+        return createOrUpdateUserWithVerifiedToken(decodedJWT, scheme, userMapper, null);
+    }
+
+    /**
+     * Same as {@link #createOrUpdateUserWithVerifiedToken(DecodedJWT, OidcAuthScheme, BiFunction)}, additionally
+     * requesting that the given application's primary profile be attached to the resulting session (gated
+     * auto-create), exactly as {@link #createOrUpdateUserWithToken} does via
+     * {@link OidcSessionRequest#getApplicationNameOrId()}.
+     *
+     * @param requestedApplicationNameOrId the application name/ID to attach, or {@code null} for the legacy
+     *                                      JWT aud-claim-driven, ungated behavior
+     */
+    public SessionCreation createOrUpdateUserWithVerifiedToken(
+            final DecodedJWT decodedJWT,
+            final OidcAuthScheme scheme,
+            final BiFunction<DecodedJWT, OidcAuthScheme, User> userMapper,
+            final String requestedApplicationNameOrId) {
+        return buildSession(decodedJWT, scheme, userMapper, requestedApplicationNameOrId);
     }
 
     /**

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcAuthServiceOperations.java
@@ -167,6 +167,33 @@ public class OidcAuthServiceOperations {
     }
 
     /**
+     * Same as {@link #createSessionForResolvedUser(User)}, additionally requesting that the given application's
+     * primary profile be attached to the resulting session, exactly as {@link #buildSession} does for a live
+     * token — reusing an existing primary profile if one is already present, otherwise gated auto-create
+     * (subject to the application's autoCreateProfile/maxProfiles settings) if {@code explicitlyRequested}, or
+     * the legacy, ungated get-or-create behavior otherwise. Used by the login-attempt confirm flow, where the
+     * user was resolved (and any account-link mutation already performed) from claims persisted by an earlier
+     * callback — including the application id/name resolved at that time from the request or the token's own
+     * {@code aud} claim — not a live JWT.
+     *
+     * @param user the already-resolved user
+     * @param applicationNameOrId the application name/ID to attach, or {@code null} for none
+     * @param explicitlyRequested whether {@code applicationNameOrId} came from an explicit request value (gated
+     *                            auto-create) as opposed to the token's {@code aud} claim (legacy, ungated)
+     * @return the created session
+     */
+    public SessionCreation createSessionForResolvedUser(final User user,
+                                                          final String applicationNameOrId,
+                                                          final boolean explicitlyRequested) {
+        final long expiry = MILLISECONDS.convert(getSessionTimeoutSeconds(), SECONDS) + currentTimeMillis();
+        final var session = new Session();
+        session.setUser(user);
+        session.setExpiry(expiry);
+        attachApplicationProfile(session, user, applicationNameOrId, explicitlyRequested);
+        return getSessionDao().create(session);
+    }
+
+    /**
      * Builds and persists a session for an already-resolved user, with no token of its own to run through
      * {@link #buildSession}. Used by the login-attempt confirm flow, where the user was resolved (and any
      * account-link mutation already performed) from claims persisted by an earlier callback, not a live JWT.
@@ -175,11 +202,7 @@ public class OidcAuthServiceOperations {
      * @return the created session
      */
     public SessionCreation createSessionForResolvedUser(final User user) {
-        final long expiry = MILLISECONDS.convert(getSessionTimeoutSeconds(), SECONDS) + currentTimeMillis();
-        final var session = new Session();
-        session.setUser(user);
-        session.setExpiry(expiry);
-        return getSessionDao().create(session);
+        return createSessionForResolvedUser(user, null, false);
     }
 
     private SessionCreation buildSession(final DecodedJWT decodedJWT,
@@ -202,30 +225,48 @@ public class OidcAuthServiceOperations {
         session.setUser(user);
         session.setExpiry(expiry);
 
-        if(applicationId != null) {
-
-            final var applicationOptional = getApplicationDao().findActiveApplication(applicationId);
-
-            if(applicationOptional.isPresent()) {
-
-                final var application = applicationOptional.get();
-                final var existingProfile = getProfileDao().findPrimaryProfile(user.getId(), application.getId());
-
-                final Profile profile = existingProfile.isPresent()
-                        ? existingProfile.get()
-                        : requestedApplicationNameOrId != null
-                                ? autoCreatePrimaryProfileIfConfigured(user, application)
-                                : getProfileDao().createOrRefreshProfile(map(user, application));
-
-                if (profile != null) {
-                    session.setProfile(profile);
-                    session.setApplication(application);
-                }
-
-            }
-        }
+        attachApplicationProfile(session, user, applicationId, requestedApplicationNameOrId != null);
 
         return getSessionDao().create(session);
+    }
+
+    /**
+     * Resolves the application to attach and, if found, attaches its existing primary profile for {@code user}
+     * if one is already present — otherwise gated auto-create (subject to autoCreateProfile/maxProfiles) if
+     * {@code gatedAutoCreate}, or the legacy, ungated get-or-create behavior otherwise. Shared by
+     * {@link #buildSession} (live token, {@code gatedAutoCreate} true iff the caller explicitly requested an
+     * application) and {@link #createSessionForResolvedUser(User, String, boolean)} (account-linking confirm,
+     * resolved earlier from either the request or the token's own {@code aud} claim).
+     */
+    private void attachApplicationProfile(final Session session,
+                                           final User user,
+                                           final String applicationId,
+                                           final boolean gatedAutoCreate) {
+
+        if (applicationId == null) {
+            return;
+        }
+
+        final var applicationOptional = getApplicationDao().findActiveApplication(applicationId);
+
+        if (applicationOptional.isEmpty()) {
+            return;
+        }
+
+        final var application = applicationOptional.get();
+        final var existingProfile = getProfileDao().findPrimaryProfile(user.getId(), application.getId());
+
+        final Profile profile = existingProfile.isPresent()
+                ? existingProfile.get()
+                : gatedAutoCreate
+                        ? autoCreatePrimaryProfileIfConfigured(user, application)
+                        : getProfileDao().createOrRefreshProfile(map(user, application));
+
+        if (profile != null) {
+            session.setProfile(profile);
+            session.setApplication(application);
+        }
+
     }
 
     private Profile autoCreatePrimaryProfileIfConfigured(final User user, final Application application) {

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLinkClaims.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLinkClaims.java
@@ -17,6 +17,10 @@ public class OidcLinkClaims {
 
     private Map<String, String> profileClaims;
 
+    private String applicationNameOrId;
+
+    private boolean applicationExplicitlyRequested;
+
     public String getSchemeName() {
         return schemeName;
     }
@@ -47,6 +51,22 @@ public class OidcLinkClaims {
 
     public void setProfileClaims(Map<String, String> profileClaims) {
         this.profileClaims = profileClaims;
+    }
+
+    public String getApplicationNameOrId() {
+        return applicationNameOrId;
+    }
+
+    public void setApplicationNameOrId(String applicationNameOrId) {
+        this.applicationNameOrId = applicationNameOrId;
+    }
+
+    public boolean isApplicationExplicitlyRequested() {
+        return applicationExplicitlyRequested;
+    }
+
+    public void setApplicationExplicitlyRequested(boolean applicationExplicitlyRequested) {
+        this.applicationExplicitlyRequested = applicationExplicitlyRequested;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
@@ -81,7 +81,7 @@ public class OidcLoginAttemptOperations {
     private long ttlSeconds;
 
     public OidcLoginAttemptBegin begin(final String provider) {
-        return begin(provider, null);
+        return begin(provider, null, null);
     }
 
     /**
@@ -97,6 +97,23 @@ public class OidcLoginAttemptOperations {
      * @return the pending attempt's id, authorize URL, and expiry
      */
     public OidcLoginAttemptBegin begin(final String provider, final User linkingUser) {
+        return begin(provider, linkingUser, null);
+    }
+
+    /**
+     * Same as {@link #begin(String, User)}, additionally snapshotting the requested application name/id onto the
+     * pending attempt, since the callback that later resolves it shares no request body with this call.
+     *
+     * @param provider the provider identifier
+     * @param linkingUser the already-authenticated user to link on success, or {@code null} for an anonymous
+     *                    (first-time login) attempt
+     * @param applicationNameOrId the name or ID of the application whose primary profile should be attached once
+     *                            the attempt resolves, or {@code null} for the legacy JWT aud-claim-driven,
+     *                            ungated behavior
+     * @return the pending attempt's id, authorize URL, and expiry
+     */
+    public OidcLoginAttemptBegin begin(final String provider, final User linkingUser,
+                                        final String applicationNameOrId) {
 
         final var config = findConfigOrThrow(provider);
         final var discoveryDocument = getOidcProviderConfigurationOperations().resolveDiscovery(config);
@@ -123,6 +140,8 @@ public class OidcLoginAttemptOperations {
         if (linkingUser != null) {
             attempt.setLinkedUserId(linkingUser.getId());
         }
+
+        attempt.setApplicationNameOrId(applicationNameOrId);
 
         getOidcLoginAttemptDao().create(attempt);
 
@@ -288,7 +307,7 @@ public class OidcLoginAttemptOperations {
             }
 
             final var sessionCreation = getOidcAuthServiceOperations().createOrUpdateUserWithVerifiedToken(
-                    decodedJWT, scheme, getAnonOidcAuthService()::apply);
+                    decodedJWT, scheme, getAnonOidcAuthService()::apply, attempt.getApplicationNameOrId());
 
             final var completed = getOidcLoginAttemptDao().markComplete(state, serializeSession(sessionCreation));
 

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/OidcLoginAttemptOperations.java
@@ -229,7 +229,8 @@ public class OidcLoginAttemptOperations {
                 targetUser, claims.getSchemeName(), claims.getExternalUserId(), claims.getEmail(),
                 claims.getProfileClaims());
 
-        final var sessionCreation = getOidcAuthServiceOperations().createSessionForResolvedUser(linkedUser);
+        final var sessionCreation = getOidcAuthServiceOperations().createSessionForResolvedUser(
+                linkedUser, claims.getApplicationNameOrId(), claims.isApplicationExplicitlyRequested());
 
         return OidcLoginAttemptStatusResponse.complete(sessionCreation);
 
@@ -288,6 +289,15 @@ public class OidcLoginAttemptOperations {
                 // this (always-unauthenticated) callback cannot itself gate correctly -- it has no way to verify
                 // it's talking to the same party that called begin(). Only the validated external identity is
                 // persisted here.
+                // Same precedence as the anonymous path (OidcAuthServiceOperations#buildSession): the
+                // request-supplied application, or else the token's own 'aud' claim. Resolved here, while the
+                // live token is still in hand, and snapshotted onto the persisted claims -- confirmLink() only
+                // has these claims, not the token, to work from.
+                final var applicationNameOrId = attempt.getApplicationNameOrId() != null
+                        ? attempt.getApplicationNameOrId()
+                        : OidcAuthServiceOperations.claimAsString(
+                                decodedJWT, OidcAuthServiceOperations.Claim.APPLICATION_ID.value);
+
                 final var claims = new OidcLinkClaims();
                 claims.setSchemeName(scheme.getName());
                 claims.setExternalUserId(OidcAuthServiceOperations.claimAsString(
@@ -295,6 +305,8 @@ public class OidcLoginAttemptOperations {
                 claims.setEmail(OidcAuthServiceOperations.claimAsString(
                         decodedJWT, OidcAuthServiceOperations.Claim.EMAIL.value));
                 claims.setProfileClaims(OidcAuthServiceOperations.extractProfileClaims(decodedJWT));
+                claims.setApplicationNameOrId(applicationNameOrId);
+                claims.setApplicationExplicitlyRequested(attempt.getApplicationNameOrId() != null);
 
                 final var linkReady = getOidcLoginAttemptDao().markLinkReady(state, serializeLinkClaims(claims));
 

--- a/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcLoginAttemptService.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oidc/UserOidcLoginAttemptService.java
@@ -29,6 +29,11 @@ public class UserOidcLoginAttemptService implements OidcLoginAttemptService {
     }
 
     @Override
+    public OidcLoginAttemptBegin begin(final String provider, final String applicationNameOrId) {
+        return getOidcLoginAttemptOperations().begin(provider, getUser(), applicationNameOrId);
+    }
+
+    @Override
     public OidcLoginAttemptStatusResponse poll(final String id) {
         return getOidcLoginAttemptOperations().poll(id);
     }


### PR DESCRIPTION
## Summary

Fixes #61. `OidcLoginAttemptOperations.handleCallback`'s anonymous branch always passed `null` for the requested application to `OidcAuthServiceOperations.buildSession`, so the browser-redirect OIDC flow (`POST /oidc/session` begin + IdP callback) could never reach the gated auto-create-profile path added in #37 for the direct id_token flow (`POST /auth/oidc`). Any consumer of the redirect-based login (e.g. a Twitch-style OAuth2/OIDC widget) was stuck on the legacy, deliberately ungated `createOrRefreshProfile` get-or-create behavior.

Since `begin()` and the IdP callback are separate HTTP calls with no shared body, `applicationNameOrId` is now snapshotted onto the persisted `OidcLoginAttempt` at `begin()` time and read back off it at callback time — mirroring the pattern #38 used for `linkedUserId`.

- `OidcLoginAttemptRequest`/`OidcLoginAttempt` gain an `applicationNameOrId` field.
- `OidcLoginAttemptService.begin` gets an additive `begin(provider, applicationNameOrId)` overload, threaded through `AnonOidcLoginAttemptService`/`UserOidcLoginAttemptService` → `OidcLoginAttemptOperations.begin`, which persists it onto the attempt.
- `OidcLoginAttemptOperations.handleCallback`'s anonymous branch reads `attempt.getApplicationNameOrId()` and passes it into a new `OidcAuthServiceOperations.createOrUpdateUserWithVerifiedToken(..., requestedApplicationNameOrId)` overload, reaching the same `buildSession` gating logic #37 already established.
- `OidcSessionResource`'s idToken shortcut branch now also copies `applicationNameOrId` onto the ad-hoc `OidcSessionRequest` it builds (previously dropped).
- `MongoOidcLoginAttempt` gains the corresponding persisted field (MapStruct mapper needs no change — field-name based).

The deprecated, ungated `ProfileDao.createOrRefreshProfile` is intentionally left as the sole fallback for the legacy JWT-`aud`-claim-only case (no request-level `applicationNameOrId`) — not touched or expanded by this change. New tests assert it is never invoked once `applicationNameOrId` is set.

Out of scope: the account-linking branch of `handleCallback` (`confirmLink` → `createSessionForResolvedUser`) does no profile/application attachment at all today; that's a separate, deeper gap not covered here.

## Test plan
- [x] `mvn -pl service-test -Dtest=OidcLoginAttemptOperationsTest,OidcAuthServiceOperationsProfileTest test` — 27/27 passing, including new cases covering `begin()` persistence and the gated-vs-legacy `handleCallback` branch.
- [x] `mvn -pl sdk-model,sdk-dao,sdk-service,mongo-dao,service,rest-api -am install -DskipTests` — compiles cleanly across all touched modules.
- [x] Full multi-module `mvn test` sweep (in progress).