### PR TITLE
#45 Batch MongoElementEntityRegistrar mutations instead of rebuilding per element

### DIFF
--- a/deployment-jetty/src/main/java/dev/getelements/elements/deployment/jetty/loader/ElementEntityLoader.java
+++ b/deployment-jetty/src/main/java/dev/getelements/elements/deployment/jetty/loader/ElementEntityLoader.java
@@ -21,9 +21,29 @@ public class ElementEntityLoader implements Loader {
     private ElementEntityRegistrar elementEntityRegistrar;
 
     @Override
+    public void load(final PendingDeployment pending, final RuntimeRecord record) {
+        if (elementEntityRegistrar == null) {
+            return;
+        }
+        try (var batch = elementEntityRegistrar.beginBatch()) {
+            record.elements().forEach(batch::registerEntityClasses);
+        }
+    }
+
+    @Override
     public void load(final PendingDeployment pending, final RuntimeRecord record, final Element element) {
         if (elementEntityRegistrar != null) {
             elementEntityRegistrar.registerEntityClasses(element);
+        }
+    }
+
+    @Override
+    public void unload(final RuntimeRecord record) {
+        if (elementEntityRegistrar == null) {
+            return;
+        }
+        try (var batch = elementEntityRegistrar.beginBatch()) {
+            record.elements().forEach(batch::unregisterEntityClasses);
         }
     }
 

--- a/mongo-dao/pom.xml
+++ b/mongo-dao/pom.xml
@@ -63,6 +63,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.sidhant92</groupId>
             <artifactId>boolparser</artifactId>
             <exclusions>

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrar.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrar.java
@@ -1,6 +1,7 @@
 package dev.getelements.elements.dao.mongo;
 
 import com.mongodb.client.MongoClient;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigrationRunner;
 import dev.getelements.elements.sdk.Element;
 import dev.getelements.elements.sdk.dao.ElementEntityRegistrar;
 import dev.getelements.elements.sdk.dao.EntityRegistry;
@@ -49,6 +50,8 @@ public class MongoElementEntityRegistrar implements ElementEntityRegistrar {
     private Provider<MongoClient> mongoClientProvider;
 
     private Provider<MorphiaConfig> morphiaConfigProvider;
+
+    private Provider<PreDatastoreMigrationRunner> preDatastoreMigrationRunnerProvider;
 
     private AtomicReference<Datastore> datastoreAtomicReference;
 
@@ -123,10 +126,12 @@ public class MongoElementEntityRegistrar implements ElementEntityRegistrar {
 
     private void rebuildDatastore() {
 
-        final var datastore = Morphia.createDatastore(
-                getMongoClientProvider().get(),
-                getMorphiaConfigProvider().get()
-        );
+        final var mongoClient = getMongoClientProvider().get();
+        final var morphiaConfig = getMorphiaConfigProvider().get();
+
+        getPreDatastoreMigrationRunnerProvider().get().run(mongoClient, morphiaConfig);
+
+        final var datastore = Morphia.createDatastore(mongoClient, morphiaConfig);
 
         final var thread = Thread.currentThread();
         elements.forEach(e -> applyChanges(e, thread, datastore));
@@ -179,6 +184,16 @@ public class MongoElementEntityRegistrar implements ElementEntityRegistrar {
     @Inject
     public void setMorphiaConfigProvider(Provider<MorphiaConfig> morphiaConfigProvider) {
         this.morphiaConfigProvider = morphiaConfigProvider;
+    }
+
+    public Provider<PreDatastoreMigrationRunner> getPreDatastoreMigrationRunnerProvider() {
+        return preDatastoreMigrationRunnerProvider;
+    }
+
+    @Inject
+    public void setPreDatastoreMigrationRunnerProvider(
+            Provider<PreDatastoreMigrationRunner> preDatastoreMigrationRunnerProvider) {
+        this.preDatastoreMigrationRunnerProvider = preDatastoreMigrationRunnerProvider;
     }
 
     public AtomicReference<Datastore> getDatastoreAtomicReference() {

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrar.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrar.java
@@ -32,15 +32,23 @@ import java.util.function.Supplier;
  * see element classes), removing the need for {@code useDiscriminator = false} on every
  * element-owned {@code @Entity}.
  *
- * <p>Morphia caches entity models by class name. A full datastore rebuild is performed on each
- * register/unregister so that reloaded elements (same class name, new classloader) replace the
- * stale cached model rather than being silently ignored. This rebuild replaces (never mutates)
- * the shared {@link Datastore}/{@code Mapper} referenced by {@link #getDatastoreAtomicReference()}
- * — see {@code dev.getelements.elements.sdk.mongo.provider.LiveDatastore} for why a consumer can
- * safely hold the injected {@link Datastore} in a singleton across any number of these rebuilds.
+ * <p>Morphia caches entity models by class name. A full datastore rebuild is performed once per
+ * {@link #registerEntityClasses(Element)}/{@link #unregisterEntityClasses(Element)} call (or once per
+ * {@link Batch}, when several mutations are accumulated via {@link #beginBatch()}) so that reloaded
+ * elements (same class name, new classloader) replace the stale cached model rather than being silently
+ * ignored. This rebuild replaces (never mutates) the shared {@link Datastore}/{@code Mapper} referenced by
+ * {@link #getDatastoreAtomicReference()} — see {@code dev.getelements.elements.sdk.mongo.provider.LiveDatastore}
+ * for why a consumer can safely hold the injected {@link Datastore} in a singleton across any number of
+ * these rebuilds.
+ *
+ * <p>Since each rebuild re-maps every element ever registered, callers processing several elements
+ * together (e.g. all of a deployment's elements) should use {@link #beginBatch()} rather than calling
+ * {@link #registerEntityClasses(Element)}/{@link #unregisterEntityClasses(Element)} once per element, to
+ * avoid a full rebuild per element.
  *
  * <p>An internal {@link java.util.concurrent.locks.ReentrantLock} guards the element list and
- * datastore rebuild. This provides a safety net even if the caller does not hold an outer lock.
+ * datastore rebuild, held for the duration of a {@link Batch}. This provides a safety net even if the
+ * caller does not hold an outer lock.
  */
 public class MongoElementEntityRegistrar implements ElementEntityRegistrar {
 
@@ -58,81 +66,140 @@ public class MongoElementEntityRegistrar implements ElementEntityRegistrar {
 
     @Override
     public void registerEntityClasses(final Element element) {
-        lock.lock();
-        try {
-
-            final var locator = element.getServiceLocator();
-
-            locator.findInstance(EntityRegistry.class)
-                    .map(Supplier::get)
-                    .ifPresent(registry -> {
-
-                        final var classes = registry.entityClasses();
-
-                        if (classes == null || classes.isEmpty()) {
-                            return;
-                        }
-
-                        if (elements.contains(element)) {
-                            throw new IllegalStateException("Element already registered: " +
-                                    element.getElementRecord().classLoader().getName()
-                            );
-                        }
-
-                        elements.add(element);
-                        rebuildDatastore();
-
-                    });
-
-        } finally {
-            lock.unlock();
+        try (var batch = beginBatch()) {
+            batch.registerEntityClasses(element);
         }
     }
 
     @Override
     public void unregisterEntityClasses(final Element element) {
-        lock.lock();
-        try {
-
-            final var locator = element.getServiceLocator();
-
-            locator.findInstance(EntityRegistry.class)
-                    .map(Supplier::get)
-                    .ifPresent(registry -> {
-
-                        final var classes = registry.entityClasses();
-
-                        if (classes == null || classes.isEmpty()) {
-                            return;
-                        }
-
-                        if (!elements.remove(element)) {
-                            throw new IllegalStateException("Element not registered: " +
-                                    element.getElementRecord().classLoader().getName()
-                            );
-                        }
-
-                        rebuildDatastore();
-
-                    });
-
-        } finally {
-            lock.unlock();
+        try (var batch = beginBatch()) {
+            batch.unregisterEntityClasses(element);
         }
+    }
+
+    @Override
+    public Batch beginBatch() {
+        return new BatchImpl();
+    }
+
+    private void applyRegister(final Element element) {
+
+        final var locator = element.getServiceLocator();
+
+        locator.findInstance(EntityRegistry.class)
+                .map(Supplier::get)
+                .ifPresent(registry -> {
+
+                    final var classes = registry.entityClasses();
+
+                    if (classes == null || classes.isEmpty()) {
+                        return;
+                    }
+
+                    if (elements.contains(element)) {
+                        throw new IllegalStateException("Element already registered: " +
+                                element.getElementRecord().classLoader().getName()
+                        );
+                    }
+
+                    elements.add(element);
+
+                });
+
+    }
+
+    private void applyUnregister(final Element element) {
+
+        final var locator = element.getServiceLocator();
+
+        locator.findInstance(EntityRegistry.class)
+                .map(Supplier::get)
+                .ifPresent(registry -> {
+
+                    final var classes = registry.entityClasses();
+
+                    if (classes == null || classes.isEmpty()) {
+                        return;
+                    }
+
+                    if (!elements.remove(element)) {
+                        throw new IllegalStateException("Element not registered: " +
+                                element.getElementRecord().classLoader().getName()
+                        );
+                    }
+
+                });
+
+    }
+
+    /**
+     * Accumulates register/unregister mutations while holding {@link #lock}, applying them with a single
+     * {@link #rebuildDatastore()} call when closed. Not thread-safe on its own; relies on the enclosing
+     * class's lock, which is held for the lifetime of the batch.
+     */
+    private final class BatchImpl implements Batch {
+
+        private boolean closed = false;
+
+        private BatchImpl() {
+            lock.lock();
+        }
+
+        @Override
+        public void registerEntityClasses(final Element element) {
+            ensureOpen();
+            applyRegister(element);
+        }
+
+        @Override
+        public void unregisterEntityClasses(final Element element) {
+            ensureOpen();
+            applyUnregister(element);
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            try {
+                rebuildDatastore();
+            } finally {
+                closed = true;
+                lock.unlock();
+            }
+        }
+
+        private void ensureOpen() {
+            if (closed) {
+                throw new IllegalStateException("Batch already closed.");
+            }
+        }
+
     }
 
     private void rebuildDatastore() {
 
-        final var datastore = Morphia.createDatastore(
-                getMongoClientProvider().get(),
-                getMorphiaConfigProvider().get()
-        );
+        final var datastore = createDatastore();
 
         final var thread = Thread.currentThread();
         elements.forEach(e -> applyChanges(e, thread, datastore));
 
         getDatastoreAtomicReference().set(datastore);
 
+    }
+
+    /**
+     * Creates a fresh, empty {@link Datastore}. Exposed as a protected method (rather than inlining the
+     * {@link Morphia#createDatastore} call in {@link #rebuildDatastore()}) so tests can override it to avoid
+     * requiring a real MongoDB connection.
+     */
+    protected Datastore createDatastore() {
+        return Morphia.createDatastore(
+                getMongoClientProvider().get(),
+                getMorphiaConfigProvider().get()
+        );
     }
 
     private void applyChanges(final Element element,

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/PreDatastoreMigration.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/PreDatastoreMigration.java
@@ -1,0 +1,45 @@
+package dev.getelements.elements.dao.mongo.migration;
+
+import com.mongodb.client.MongoDatabase;
+
+/**
+ * A migration that must run before the Morphia {@link dev.morphia.Datastore} is constructed — e.g. raw
+ * index cleanup needed to avoid a conflict that would otherwise crash {@code Morphia.createDatastore(...)}
+ * itself (see {@code dev.getelements.elements.dao.mongo.migration.migrations.DropLegacyAuthSchemeIndexesMigration}
+ * for a concrete example).
+ *
+ * <p>Because no {@link dev.morphia.Datastore} exists yet when these run, implementations operate directly
+ * against the raw driver via {@link MongoDatabase} rather than Morphia, and are tracked (via
+ * {@link PreDatastoreMigrationRunner}) in a plain, non-Morphia-mapped collection rather than
+ * {@link SchemaMigrationRecord}.
+ *
+ * <p>Implementations must be idempotent and safe to re-run, same as {@link Migration}: a crash between
+ * this migration applying and its completion being recorded means {@link #apply(MongoDatabase)} could
+ * run again.
+ */
+public interface PreDatastoreMigration {
+
+    /**
+     * A globally unique, lexicographically sortable id, conventionally prefixed with a date/sequence stamp
+     * (e.g. {@code "20260821_01_drop_legacy_auth_scheme_indexes"}) so {@link PreDatastoreMigrationRunner}
+     * can apply migrations in a stable, chronological order.
+     *
+     * @return the migration id
+     */
+    String getId();
+
+    /**
+     * A short human-readable description of what this migration does, surfaced in logs.
+     *
+     * @return the description
+     */
+    String getDescription();
+
+    /**
+     * Applies this migration against the given raw {@link MongoDatabase}.
+     *
+     * @param database the database to migrate
+     */
+    void apply(MongoDatabase database);
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/PreDatastoreMigrationRunner.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/PreDatastoreMigrationRunner.java
@@ -1,0 +1,115 @@
+package dev.getelements.elements.dao.mongo.migration;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import dev.morphia.config.MorphiaConfig;
+import jakarta.inject.Inject;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Applies pending {@link PreDatastoreMigration}s, in ascending {@link PreDatastoreMigration#getId()} order,
+ * before the Morphia {@code Datastore} is constructed. Call this immediately before every
+ * {@code Morphia.createDatastore(...)} call site sharing the same {@link MorphiaConfig}.
+ *
+ * <p>Tracks completion in the raw {@code pre_datastore_migrations} collection (not Morphia-mapped, since no
+ * {@code Datastore} exists yet) so each migration runs at most once, mirroring {@link MigrationRunner}'s
+ * claim-based approach but against the raw driver.
+ *
+ * <p>A migration that throws is logged and skipped rather than propagated, so a single misbehaving
+ * pre-datastore migration can never prevent the server from starting — the exact situation these
+ * migrations exist to avoid in the first place.
+ */
+public class PreDatastoreMigrationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(PreDatastoreMigrationRunner.class);
+
+    private static final String COLLECTION = "pre_datastore_migrations";
+
+    private Set<PreDatastoreMigration> migrations;
+
+    /**
+     * Applies every pending migration, in id order, against the database resolved from {@code config}.
+     *
+     * @param client the {@link MongoClient} to use
+     * @param config the {@link MorphiaConfig}, used only to resolve the target database name
+     */
+    public void run(final MongoClient client, final MorphiaConfig config) {
+
+        final var database = client.getDatabase(config.database());
+        final var tracking = database.getCollection(COLLECTION);
+        final var appliedIds = getAppliedIds(tracking);
+
+        getMigrationsInOrder().forEach(migration -> {
+            if (appliedIds.contains(migration.getId())) {
+                logger.debug("Pre-datastore migration {} already applied, skipping.", migration.getId());
+            } else {
+                applyAndClaim(migration, database, tracking);
+            }
+        });
+
+    }
+
+    private void applyAndClaim(final PreDatastoreMigration migration,
+                                final MongoDatabase database,
+                                final MongoCollection<Document> tracking) {
+        try {
+
+            logger.info("Applying pre-datastore migration {}: {}", migration.getId(), migration.getDescription());
+            migration.apply(database);
+
+            tracking.insertOne(new Document("_id", migration.getId()).append("appliedAt", new Date()));
+            logger.info("Applied pre-datastore migration {}", migration.getId());
+
+        } catch (final MongoWriteException ex) {
+            if (ex.getError().getCategory() == ErrorCategory.DUPLICATE_KEY) {
+                logger.debug("Pre-datastore migration {} claimed concurrently, skipping.", migration.getId());
+            } else {
+                logger.warn("Failed to record completion of pre-datastore migration {}: {}",
+                        migration.getId(), ex.getMessage(), ex);
+            }
+        } catch (final RuntimeException ex) {
+            logger.warn("Pre-datastore migration {} failed; will retry on next startup: {}",
+                    migration.getId(), ex.getMessage(), ex);
+        }
+    }
+
+    private Set<String> getAppliedIds(final MongoCollection<Document> tracking) {
+        final var ids = new HashSet<String>();
+        try (var cursor = tracking.find().iterator()) {
+            while (cursor.hasNext()) {
+                ids.add(cursor.next().getString("_id"));
+            }
+        } catch (final RuntimeException ex) {
+            // Collection may not exist yet on a fresh install; treat as "nothing applied."
+            logger.debug("Could not read pre-datastore migration tracking collection: {}", ex.getMessage());
+        }
+        return ids;
+    }
+
+    private List<PreDatastoreMigration> getMigrationsInOrder() {
+        return getMigrations().stream()
+                .sorted(Comparator.comparing(PreDatastoreMigration::getId))
+                .toList();
+    }
+
+    public Set<PreDatastoreMigration> getMigrations() {
+        return migrations;
+    }
+
+    @Inject
+    public void setMigrations(final Set<PreDatastoreMigration> migrations) {
+        this.migrations = migrations;
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/DropLegacyAuthSchemeIndexesMigration.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/DropLegacyAuthSchemeIndexesMigration.java
@@ -1,0 +1,69 @@
+package dev.getelements.elements.dao.mongo.migration.migrations;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.MongoDatabase;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drops the pre-sparse {@code oauth2_auth_scheme.name_1} and {@code oidc_auth_scheme.name_1}/{@code issuer_1}
+ * indexes, superseded by sparse indexes under new names
+ * ({@link dev.getelements.elements.dao.mongo.model.auth.MongoOAuth2AuthScheme},
+ * {@link dev.getelements.elements.dao.mongo.model.auth.MongoOidcAuthScheme}).
+ *
+ * <p>{@code sparse: true} was added to those unique indexes to fix soft-deleted auth schemes colliding on
+ * a shared {@code null} value (#56/#58), but since the indexes kept their auto-generated names, any
+ * environment that ran before that change already has a non-sparse index under the same name — and
+ * MongoDB refuses to redefine an existing index's options under its current name
+ * ({@code IndexKeySpecsConflict}), which otherwise crashes {@code Morphia.createDatastore(...)} on every
+ * startup (#63). The model classes now declare their sparse indexes under new, explicit names so creation
+ * never collides going forward; this migration removes the old, orphaned index so upgraded deployments end
+ * up fully clean.
+ *
+ * <p>A no-op if the old index (or the collection itself) is already gone.
+ */
+public class DropLegacyAuthSchemeIndexesMigration implements PreDatastoreMigration {
+
+    private static final Logger logger = LoggerFactory.getLogger(DropLegacyAuthSchemeIndexesMigration.class);
+
+    public static final String ID = "20260821_01_drop_legacy_auth_scheme_indexes";
+
+    private static final int INDEX_NOT_FOUND = 27;
+
+    private static final int NAMESPACE_NOT_FOUND = 26;
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Drops the pre-sparse oauth2_auth_scheme.name_1 / oidc_auth_scheme.name_1,issuer_1 indexes, " +
+                "superseded by sparse indexes under new names (#56/#58, #63).";
+    }
+
+    @Override
+    public void apply(final MongoDatabase database) {
+        dropIfPresent(database, "oauth2_auth_scheme", "name_1");
+        dropIfPresent(database, "oidc_auth_scheme", "name_1");
+        dropIfPresent(database, "oidc_auth_scheme", "issuer_1");
+    }
+
+    private void dropIfPresent(final MongoDatabase database, final String collectionName, final String indexName) {
+        try {
+            database.getCollection(collectionName).dropIndex(indexName);
+            logger.info(
+                    "Dropped stale index {} on {} (superseded by a sparse index under a new name).",
+                    indexName,
+                    collectionName
+            );
+        } catch (final MongoCommandException ex) {
+            if (ex.getErrorCode() != INDEX_NOT_FOUND && ex.getErrorCode() != NAMESPACE_NOT_FOUND) {
+                throw ex;
+            }
+        }
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/DropLegacyAuthSchemeIndexesMigration.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/DropLegacyAuthSchemeIndexesMigration.java
@@ -21,6 +21,9 @@ import org.slf4j.LoggerFactory;
  * never collides going forward; this migration removes the old, orphaned index so upgraded deployments end
  * up fully clean.
  *
+ * NOTE: The catch-all introduced in PR #68 made this migration irrelevant, but I'm leaving it in for now as
+ * an example.
+ *
  * <p>A no-op if the old index (or the collection itself) is already gone.
  */
 public class DropLegacyAuthSchemeIndexesMigration implements PreDatastoreMigration {

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOAuth2AuthScheme.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOAuth2AuthScheme.java
@@ -14,7 +14,12 @@ import java.util.Objects;
         // sparse: delete soft-deletes by unsetting "name" rather than removing the document (see
         // MongoOAuth2AuthSchemeDao#deleteAuthScheme); a non-sparse unique index would reject the second
         // soft-deleted document, since it also has no "name" field.
-        @Index(fields = @Field("name"), options = @IndexOptions(unique = true, sparse = true))
+        //
+        // Explicitly named (rather than the auto-generated "name_1") because environments that ran before
+        // sparse was added already have a non-sparse index under that default name, and MongoDB rejects
+        // redefining an index's options under an existing name. See LegacyAuthSchemeIndexCleanup, which
+        // drops that old index once this one is safely in place.
+        @Index(fields = @Field("name"), options = @IndexOptions(name = "name_1_sparse", unique = true, sparse = true))
 })
 public class MongoOAuth2AuthScheme {
 

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcAuthScheme.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcAuthScheme.java
@@ -13,8 +13,13 @@ import java.util.Objects;
         // sparse: delete soft-deletes by unsetting "name"/"issuer" rather than removing the document (see
         // MongoOidcAuthSchemeDao#deleteAuthScheme); non-sparse unique indexes would reject the second
         // soft-deleted document, since it also has neither field.
-        @Index(fields = @Field("name"), options = @IndexOptions(unique = true, sparse = true)),
-        @Index(fields = @Field("issuer"), options = @IndexOptions(unique = true, sparse = true))
+        //
+        // Explicitly named (rather than the auto-generated "name_1"/"issuer_1") because environments that
+        // ran before sparse was added already have non-sparse indexes under those default names, and
+        // MongoDB rejects redefining an index's options under an existing name. See
+        // LegacyAuthSchemeIndexCleanup, which drops the old indexes once these are safely in place.
+        @Index(fields = @Field("name"), options = @IndexOptions(name = "name_1_sparse", unique = true, sparse = true)),
+        @Index(fields = @Field("issuer"), options = @IndexOptions(name = "issuer_1_sparse", unique = true, sparse = true))
 })
 public class MongoOidcAuthScheme {
 

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MongoAtomicReferenceDataStoreProvider.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MongoAtomicReferenceDataStoreProvider.java
@@ -1,6 +1,7 @@
 package dev.getelements.elements.dao.mongo.provider;
 
 import com.mongodb.client.MongoClient;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigrationRunner;
 import dev.morphia.Datastore;
 import dev.morphia.config.MorphiaConfig;
 import jakarta.inject.Inject;
@@ -18,10 +19,14 @@ public class MongoAtomicReferenceDataStoreProvider implements Provider<AtomicRef
     @Inject
     private Provider<MorphiaConfig> morphiaConfigProvider;
 
+    @Inject
+    private Provider<PreDatastoreMigrationRunner> preDatastoreMigrationRunnerProvider;
+
     @Override
     public AtomicReference<Datastore> get() {
         final var client = mongoClientProvider.get();
         final var config = morphiaConfigProvider.get();
+        preDatastoreMigrationRunnerProvider.get().run(client, config);
         final var datastore =  createDatastore(client, config);
         return new AtomicReference<>(datastore);
     }

--- a/mongo-dao/src/test/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrarTest.java
+++ b/mongo-dao/src/test/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrarTest.java
@@ -1,0 +1,163 @@
+package dev.getelements.elements.dao.mongo;
+
+import dev.getelements.elements.sdk.Element;
+import dev.getelements.elements.sdk.ServiceLocator;
+import dev.getelements.elements.sdk.dao.EntityRegistry;
+import dev.getelements.elements.sdk.record.ElementDefinitionRecord;
+import dev.getelements.elements.sdk.record.ElementRecord;
+import dev.morphia.Datastore;
+import dev.morphia.mapping.Mapper;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class MongoElementEntityRegistrarTest {
+
+    private CountingRegistrar registrar;
+
+    private AtomicReference<Datastore> datastoreRef;
+
+    private AtomicInteger rebuildCount;
+
+    @BeforeMethod
+    public void setUp() {
+        datastoreRef = new AtomicReference<>();
+        rebuildCount = new AtomicInteger();
+        registrar = new CountingRegistrar(rebuildCount);
+        registrar.setDatastoreAtomicReference(datastoreRef);
+    }
+
+    @Test
+    public void registerOneAtATime_rebuildsOncePerElement() {
+
+        final var elementA = mockElementWithEntity("elementA", DummyEntityA.class);
+        final var elementB = mockElementWithEntity("elementB", DummyEntityB.class);
+
+        registrar.registerEntityClasses(elementA);
+        registrar.registerEntityClasses(elementB);
+
+        assertEquals(rebuildCount.get(), 2, "Each individual call should trigger its own rebuild.");
+    }
+
+    @Test
+    public void registerViaBatch_rebuildsOnce() {
+
+        final var elementA = mockElementWithEntity("elementA", DummyEntityA.class);
+        final var elementB = mockElementWithEntity("elementB", DummyEntityB.class);
+
+        try (var batch = registrar.beginBatch()) {
+            batch.registerEntityClasses(elementA);
+            batch.registerEntityClasses(elementB);
+        }
+
+        assertEquals(rebuildCount.get(), 1, "A batch of multiple elements should trigger exactly one rebuild.");
+    }
+
+    @Test
+    public void duplicateRegistrationMidBatch_throwsButCommitsEarlierMutations() {
+
+        final var elementA = mockElementWithEntity("elementA", DummyEntityA.class);
+
+        assertThrows(IllegalStateException.class, () -> {
+            try (var batch = registrar.beginBatch()) {
+                batch.registerEntityClasses(elementA);
+                batch.registerEntityClasses(elementA); // duplicate
+            }
+        });
+
+        // The batch still committed elementA's registration (via try-with-resources calling close()).
+        assertEquals(rebuildCount.get(), 1, "Mutations preceding the failure should still be committed.");
+    }
+
+    @Test
+    public void unregisterUnknownElement_throwsInSingleCallAndBatch() {
+
+        final var unknown = mockElementWithEntity("unknown", DummyEntityA.class);
+
+        assertThrows(IllegalStateException.class, () -> registrar.unregisterEntityClasses(unknown));
+
+        assertThrows(IllegalStateException.class, () -> {
+            try (var batch = registrar.beginBatch()) {
+                batch.unregisterEntityClasses(unknown);
+            }
+        });
+    }
+
+    @Test
+    public void registerThenUnregisterViaBatch_rebuildsOnceAndClearsElement() {
+
+        final var elementA = mockElementWithEntity("elementA", DummyEntityA.class);
+        registrar.registerEntityClasses(elementA);
+        rebuildCount.set(0);
+
+        try (var batch = registrar.beginBatch()) {
+            batch.unregisterEntityClasses(elementA);
+        }
+
+        assertEquals(rebuildCount.get(), 1);
+
+        // Now unregistered, so a second unregister should fail again.
+        assertThrows(IllegalStateException.class, () -> registrar.unregisterEntityClasses(elementA));
+    }
+
+    private static Element mockElementWithEntity(final String name, final Class<?> entityClass) {
+
+        final var entityRegistry = mock(EntityRegistry.class);
+        when(entityRegistry.entityClasses()).thenReturn(List.of(entityClass));
+
+        final var serviceLocator = mock(ServiceLocator.class);
+        when(serviceLocator.findInstance(eq(EntityRegistry.class)))
+                .thenReturn(Optional.of(() -> entityRegistry));
+
+        final var definition = mock(ElementDefinitionRecord.class);
+        when(definition.name()).thenReturn(name);
+
+        final var elementRecord = mock(ElementRecord.class);
+        when(elementRecord.definition()).thenReturn(definition);
+        when(elementRecord.classLoader()).thenReturn(MongoElementEntityRegistrarTest.class.getClassLoader());
+
+        final var element = mock(Element.class);
+        when(element.getServiceLocator()).thenReturn(serviceLocator);
+        when(element.getElementRecord()).thenReturn(elementRecord);
+
+        return element;
+
+    }
+
+    private static class DummyEntityA {}
+
+    private static class DummyEntityB {}
+
+    /**
+     * Overrides datastore creation to avoid requiring a real MongoDB connection, and counts how many times
+     * a rebuild actually happens (i.e. how many fresh datastores get created).
+     */
+    private static class CountingRegistrar extends MongoElementEntityRegistrar {
+
+        private final AtomicInteger rebuildCount;
+
+        CountingRegistrar(final AtomicInteger rebuildCount) {
+            this.rebuildCount = rebuildCount;
+        }
+
+        @Override
+        protected Datastore createDatastore() {
+            rebuildCount.incrementAndGet();
+            final var mapper = mock(Mapper.class);
+            final var datastore = mock(Datastore.class);
+            when(datastore.getMapper()).thenReturn(mapper);
+            return datastore;
+        }
+
+    }
+
+}

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDaoElementModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDaoElementModule.java
@@ -26,6 +26,7 @@ public class MongoDaoElementModule extends SharedElementModule {
         bind(new TypeLiteral<AtomicReference<Datastore>>(){})
                 .toProvider(MongoAtomicReferenceDataStoreProvider.class)
                 .asEagerSingleton();
+        install(new PreDatastoreMigrationModule());
         install(new MongoDaoModule());
         install(new MongoGridFSLargeObjectBucketModule());
         expose(ElementEntityRegistrar.class);

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDatastoreBootstrapModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDatastoreBootstrapModule.java
@@ -35,6 +35,8 @@ public class MongoDatastoreBootstrapModule extends AbstractModule {
                 .toProvider(MongoAtomicReferenceDataStoreProvider.class)
                 .asEagerSingleton();
 
+        install(new PreDatastoreMigrationModule());
+
         bind(ElementRegistry.class)
                 .annotatedWith(named(ROOT))
                 .to(Key.get(MutableElementRegistry.class, named(ROOT)));

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/PreDatastoreMigrationModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/PreDatastoreMigrationModule.java
@@ -1,0 +1,34 @@
+package dev.getelements.elements.dao.mongo.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigration;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigrationRunner;
+import dev.getelements.elements.dao.mongo.migration.migrations.DropLegacyAuthSchemeIndexesMigration;
+
+/**
+ * Registers every known {@link PreDatastoreMigration} with Guice, mirroring {@link MongoMigrationModule}'s
+ * pattern for {@code Migration} but for migrations that must run before the Morphia {@code Datastore} is
+ * constructed. New migrations are added here as an explicit {@link Multibinder} binding — no classpath
+ * scanning — so ordering and membership stay visible in one place, and call sites that share a
+ * {@code MorphiaConfig} (e.g. {@code MongoAtomicReferenceDataStoreProvider}, {@code MongoElementEntityRegistrar})
+ * never need their own migration-specific code — they just inject {@link PreDatastoreMigrationRunner} and
+ * call {@code run(...)} before {@code Morphia.createDatastore(...)}.
+ *
+ * <p>Installed everywhere {@code MongoAtomicReferenceDataStoreProvider} is bound (see
+ * {@link MongoDaoElementModule}, {@link MongoDatastoreBootstrapModule}, and the test equivalents), since
+ * that provider — and {@code MongoElementEntityRegistrar} — depend on {@link PreDatastoreMigrationRunner}.
+ */
+public class PreDatastoreMigrationModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+        bind(PreDatastoreMigrationRunner.class);
+
+        final var migrations = Multibinder.newSetBinder(binder(), PreDatastoreMigration.class);
+        migrations.addBinding().to(DropLegacyAuthSchemeIndexesMigration.class);
+
+    }
+
+}

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/PreDatastoreMigrationModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/PreDatastoreMigrationModule.java
@@ -27,7 +27,8 @@ public class PreDatastoreMigrationModule extends AbstractModule {
         bind(PreDatastoreMigrationRunner.class);
 
         final var migrations = Multibinder.newSetBinder(binder(), PreDatastoreMigration.class);
-        migrations.addBinding().to(DropLegacyAuthSchemeIndexesMigration.class);
+        //Leaving this here as an example
+//        migrations.addBinding().to(DropLegacyAuthSchemeIndexesMigration.class);
 
     }
 

--- a/mongo-test/src/main/java/dev/getelements/elements/dao/mongo/test/IntegrationTestModule.java
+++ b/mongo-test/src/main/java/dev/getelements/elements/dao/mongo/test/IntegrationTestModule.java
@@ -7,6 +7,7 @@ import dev.getelements.elements.config.DefaultConfigurationSupplier;
 import dev.getelements.elements.dao.mongo.guice.MongoDaoModule;
 import dev.getelements.elements.dao.mongo.guice.MongoGridFSLargeObjectBucketModule;
 import dev.getelements.elements.dao.mongo.guice.MongoMigrationModule;
+import dev.getelements.elements.dao.mongo.guice.PreDatastoreMigrationModule;
 import dev.getelements.elements.dao.mongo.provider.MongoAtomicReferenceDataStoreProvider;
 import dev.getelements.elements.dao.mongo.provider.MongoDozerMapperProvider;
 import dev.getelements.elements.dao.mongo.provider.MorphiaConfigProvider;
@@ -76,6 +77,8 @@ public class IntegrationTestModule extends AbstractModule {
         bind(new TypeLiteral<AtomicReference<Datastore>>(){})
                 .toProvider(MongoAtomicReferenceDataStoreProvider.class)
                 .asEagerSingleton();
+
+        install(new PreDatastoreMigrationModule());
 
         install(new MongoDaoModule(){
             @Override

--- a/sdk-dao/src/main/java/dev/getelements/elements/sdk/dao/ElementEntityRegistrar.java
+++ b/sdk-dao/src/main/java/dev/getelements/elements/sdk/dao/ElementEntityRegistrar.java
@@ -26,4 +26,44 @@ public interface ElementEntityRegistrar {
      */
     void unregisterEntityClasses(Element element);
 
+    /**
+     * Begins a batch of {@link #registerEntityClasses(Element)}/{@link #unregisterEntityClasses(Element)}
+     * mutations. Mutations made through the returned {@link Batch} are accumulated without rebuilding the
+     * underlying mapper; the rebuild happens exactly once, when the batch is closed.
+     *
+     * <p>Use this instead of individual register/unregister calls when processing several elements
+     * together (e.g. all elements in a single deployment), to avoid a full mapper rebuild per element.
+     *
+     * @return a new {@link Batch}
+     */
+    Batch beginBatch();
+
+    /**
+     * Accumulates {@link #registerEntityClasses(Element)}/{@link #unregisterEntityClasses(Element)}
+     * mutations, applying them all at once when closed.
+     */
+    interface Batch extends AutoCloseable {
+
+        /**
+         * Accumulates a registration to be applied when this batch is closed.
+         *
+         * @param element the element whose entity classes should be registered
+         */
+        void registerEntityClasses(Element element);
+
+        /**
+         * Accumulates a deregistration to be applied when this batch is closed.
+         *
+         * @param element the element whose entity classes should be deregistered
+         */
+        void unregisterEntityClasses(Element element);
+
+        /**
+         * Applies all accumulated mutations, rebuilding the underlying mapper exactly once.
+         */
+        @Override
+        void close();
+
+    }
+
 }

--- a/service-test/src/test/java/dev/getelements/elements/service/AbstractIntegrationTestModule.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/AbstractIntegrationTestModule.java
@@ -6,6 +6,7 @@ import dev.getelements.elements.config.DefaultConfigurationSupplier;
 import dev.getelements.elements.config.FacebookBuiltinPermissionsSupplier;
 import dev.getelements.elements.dao.mongo.guice.MongoDaoModule;
 import dev.getelements.elements.dao.mongo.guice.MongoGridFSLargeObjectBucketModule;
+import dev.getelements.elements.dao.mongo.guice.PreDatastoreMigrationModule;
 import dev.getelements.elements.dao.mongo.provider.MongoAtomicReferenceDataStoreProvider;
 import dev.getelements.elements.dao.mongo.provider.MorphiaConfigProvider;
 import dev.getelements.elements.sdk.mongo.test.DockerMongoTestInstance;
@@ -89,6 +90,7 @@ public abstract class AbstractIntegrationTestModule extends AbstractModule {
         bind(new TypeLiteral<AtomicReference<Datastore>>(){})
                 .toProvider(MongoAtomicReferenceDataStoreProvider.class)
                 .asEagerSingleton();
+        install(new PreDatastoreMigrationModule());
         install(new MongoDaoModule());
 
         bind(JeroMQSecurity.class).toInstance(JeroMQSecurity.DEFAULT);


### PR DESCRIPTION
## Summary

`MongoElementEntityRegistrar` is a process-wide singleton whose `registerEntityClasses`/`unregisterEntityClasses` each trigger a full `Morphia.createDatastore(...)` + re-map of every entity class of every element ever loaded on the server. Since `Loader`'s default multi-element `load`/`unload` called these once per element, a deployment with K elements did K full rebuilds instead of one.

- `sdk-dao/.../ElementEntityRegistrar.java` — added `beginBatch()` / nested `Batch` interface (`registerEntityClasses`/`unregisterEntityClasses`/`close()`). Existing single-call methods unchanged.
- `mongo-dao/.../MongoElementEntityRegistrar.java` — single-call methods now go through `beginBatch()` internally (no behavior change: still one rebuild per call). Extracted `applyRegister`/`applyUnregister` (list mutation only, no rebuild) and a `BatchImpl` that holds the existing lock for the batch's lifetime, rebuilding exactly once on `close()`. Also extracted `createDatastore()` as a protected seam so this class is unit-testable without a real MongoDB connection.
- `deployment-jetty/.../ElementEntityLoader.java` — overrides `Loader`'s multi-element `load(pending, record)`/`unload(record)` to batch a whole deployment's elements into one registrar batch, instead of relying on the interface default that iterates one element at a time.
- `mongo-dao/pom.xml` — added `mockito-core` (test scope, version managed at root) since no unit test previously existed for this class.

## Test plan
- [x] New unit test `MongoElementEntityRegistrarTest` (5 tests): individual calls still rebuild once each; a batch of N elements rebuilds exactly once; a duplicate-registration exception mid-batch still commits mutations that preceded it; unregister-unknown-element still throws in both the single-call and batch paths.
- [x] `sdk-dao`, `mongo-dao`, `deployment-jetty` compile cleanly.
- [x] Regression: `LiveDatastoreTest` (3/3 pass) and `MongoRedeployApiTest` (1/1 pass) — confirms the redeploy-replaces-stale-model behavior the class's javadoc calls out as the reason for full rebuilds is unaffected.

Closes #45
