### PR TITLE
#63 Fix OAuth2/OIDC auth-scheme index conflict via pre-datastore migration framework

### DIFF
--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrar.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/MongoElementEntityRegistrar.java
@@ -1,6 +1,7 @@
 package dev.getelements.elements.dao.mongo;
 
 import com.mongodb.client.MongoClient;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigrationRunner;
 import dev.getelements.elements.sdk.Element;
 import dev.getelements.elements.sdk.dao.ElementEntityRegistrar;
 import dev.getelements.elements.sdk.dao.EntityRegistry;
@@ -49,6 +50,8 @@ public class MongoElementEntityRegistrar implements ElementEntityRegistrar {
     private Provider<MongoClient> mongoClientProvider;
 
     private Provider<MorphiaConfig> morphiaConfigProvider;
+
+    private Provider<PreDatastoreMigrationRunner> preDatastoreMigrationRunnerProvider;
 
     private AtomicReference<Datastore> datastoreAtomicReference;
 
@@ -123,10 +126,12 @@ public class MongoElementEntityRegistrar implements ElementEntityRegistrar {
 
     private void rebuildDatastore() {
 
-        final var datastore = Morphia.createDatastore(
-                getMongoClientProvider().get(),
-                getMorphiaConfigProvider().get()
-        );
+        final var mongoClient = getMongoClientProvider().get();
+        final var morphiaConfig = getMorphiaConfigProvider().get();
+
+        getPreDatastoreMigrationRunnerProvider().get().run(mongoClient, morphiaConfig);
+
+        final var datastore = Morphia.createDatastore(mongoClient, morphiaConfig);
 
         final var thread = Thread.currentThread();
         elements.forEach(e -> applyChanges(e, thread, datastore));
@@ -179,6 +184,16 @@ public class MongoElementEntityRegistrar implements ElementEntityRegistrar {
     @Inject
     public void setMorphiaConfigProvider(Provider<MorphiaConfig> morphiaConfigProvider) {
         this.morphiaConfigProvider = morphiaConfigProvider;
+    }
+
+    public Provider<PreDatastoreMigrationRunner> getPreDatastoreMigrationRunnerProvider() {
+        return preDatastoreMigrationRunnerProvider;
+    }
+
+    @Inject
+    public void setPreDatastoreMigrationRunnerProvider(
+            Provider<PreDatastoreMigrationRunner> preDatastoreMigrationRunnerProvider) {
+        this.preDatastoreMigrationRunnerProvider = preDatastoreMigrationRunnerProvider;
     }
 
     public AtomicReference<Datastore> getDatastoreAtomicReference() {

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/PreDatastoreMigration.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/PreDatastoreMigration.java
@@ -1,0 +1,45 @@
+package dev.getelements.elements.dao.mongo.migration;
+
+import com.mongodb.client.MongoDatabase;
+
+/**
+ * A migration that must run before the Morphia {@link dev.morphia.Datastore} is constructed — e.g. raw
+ * index cleanup needed to avoid a conflict that would otherwise crash {@code Morphia.createDatastore(...)}
+ * itself (see {@code dev.getelements.elements.dao.mongo.migration.migrations.DropLegacyAuthSchemeIndexesMigration}
+ * for a concrete example).
+ *
+ * <p>Because no {@link dev.morphia.Datastore} exists yet when these run, implementations operate directly
+ * against the raw driver via {@link MongoDatabase} rather than Morphia, and are tracked (via
+ * {@link PreDatastoreMigrationRunner}) in a plain, non-Morphia-mapped collection rather than
+ * {@link SchemaMigrationRecord}.
+ *
+ * <p>Implementations must be idempotent and safe to re-run, same as {@link Migration}: a crash between
+ * this migration applying and its completion being recorded means {@link #apply(MongoDatabase)} could
+ * run again.
+ */
+public interface PreDatastoreMigration {
+
+    /**
+     * A globally unique, lexicographically sortable id, conventionally prefixed with a date/sequence stamp
+     * (e.g. {@code "20260821_01_drop_legacy_auth_scheme_indexes"}) so {@link PreDatastoreMigrationRunner}
+     * can apply migrations in a stable, chronological order.
+     *
+     * @return the migration id
+     */
+    String getId();
+
+    /**
+     * A short human-readable description of what this migration does, surfaced in logs.
+     *
+     * @return the description
+     */
+    String getDescription();
+
+    /**
+     * Applies this migration against the given raw {@link MongoDatabase}.
+     *
+     * @param database the database to migrate
+     */
+    void apply(MongoDatabase database);
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/PreDatastoreMigrationRunner.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/PreDatastoreMigrationRunner.java
@@ -1,0 +1,115 @@
+package dev.getelements.elements.dao.mongo.migration;
+
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import dev.morphia.config.MorphiaConfig;
+import jakarta.inject.Inject;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Applies pending {@link PreDatastoreMigration}s, in ascending {@link PreDatastoreMigration#getId()} order,
+ * before the Morphia {@code Datastore} is constructed. Call this immediately before every
+ * {@code Morphia.createDatastore(...)} call site sharing the same {@link MorphiaConfig}.
+ *
+ * <p>Tracks completion in the raw {@code pre_datastore_migrations} collection (not Morphia-mapped, since no
+ * {@code Datastore} exists yet) so each migration runs at most once, mirroring {@link MigrationRunner}'s
+ * claim-based approach but against the raw driver.
+ *
+ * <p>A migration that throws is logged and skipped rather than propagated, so a single misbehaving
+ * pre-datastore migration can never prevent the server from starting — the exact situation these
+ * migrations exist to avoid in the first place.
+ */
+public class PreDatastoreMigrationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(PreDatastoreMigrationRunner.class);
+
+    private static final String COLLECTION = "pre_datastore_migrations";
+
+    private Set<PreDatastoreMigration> migrations;
+
+    /**
+     * Applies every pending migration, in id order, against the database resolved from {@code config}.
+     *
+     * @param client the {@link MongoClient} to use
+     * @param config the {@link MorphiaConfig}, used only to resolve the target database name
+     */
+    public void run(final MongoClient client, final MorphiaConfig config) {
+
+        final var database = client.getDatabase(config.database());
+        final var tracking = database.getCollection(COLLECTION);
+        final var appliedIds = getAppliedIds(tracking);
+
+        getMigrationsInOrder().forEach(migration -> {
+            if (appliedIds.contains(migration.getId())) {
+                logger.debug("Pre-datastore migration {} already applied, skipping.", migration.getId());
+            } else {
+                applyAndClaim(migration, database, tracking);
+            }
+        });
+
+    }
+
+    private void applyAndClaim(final PreDatastoreMigration migration,
+                                final MongoDatabase database,
+                                final MongoCollection<Document> tracking) {
+        try {
+
+            logger.info("Applying pre-datastore migration {}: {}", migration.getId(), migration.getDescription());
+            migration.apply(database);
+
+            tracking.insertOne(new Document("_id", migration.getId()).append("appliedAt", new Date()));
+            logger.info("Applied pre-datastore migration {}", migration.getId());
+
+        } catch (final MongoWriteException ex) {
+            if (ex.getError().getCategory() == ErrorCategory.DUPLICATE_KEY) {
+                logger.debug("Pre-datastore migration {} claimed concurrently, skipping.", migration.getId());
+            } else {
+                logger.warn("Failed to record completion of pre-datastore migration {}: {}",
+                        migration.getId(), ex.getMessage(), ex);
+            }
+        } catch (final RuntimeException ex) {
+            logger.warn("Pre-datastore migration {} failed; will retry on next startup: {}",
+                    migration.getId(), ex.getMessage(), ex);
+        }
+    }
+
+    private Set<String> getAppliedIds(final MongoCollection<Document> tracking) {
+        final var ids = new HashSet<String>();
+        try (var cursor = tracking.find().iterator()) {
+            while (cursor.hasNext()) {
+                ids.add(cursor.next().getString("_id"));
+            }
+        } catch (final RuntimeException ex) {
+            // Collection may not exist yet on a fresh install; treat as "nothing applied."
+            logger.debug("Could not read pre-datastore migration tracking collection: {}", ex.getMessage());
+        }
+        return ids;
+    }
+
+    private List<PreDatastoreMigration> getMigrationsInOrder() {
+        return getMigrations().stream()
+                .sorted(Comparator.comparing(PreDatastoreMigration::getId))
+                .toList();
+    }
+
+    public Set<PreDatastoreMigration> getMigrations() {
+        return migrations;
+    }
+
+    @Inject
+    public void setMigrations(final Set<PreDatastoreMigration> migrations) {
+        this.migrations = migrations;
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/DropLegacyAuthSchemeIndexesMigration.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/DropLegacyAuthSchemeIndexesMigration.java
@@ -1,0 +1,69 @@
+package dev.getelements.elements.dao.mongo.migration.migrations;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.MongoDatabase;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drops the pre-sparse {@code oauth2_auth_scheme.name_1} and {@code oidc_auth_scheme.name_1}/{@code issuer_1}
+ * indexes, superseded by sparse indexes under new names
+ * ({@link dev.getelements.elements.dao.mongo.model.auth.MongoOAuth2AuthScheme},
+ * {@link dev.getelements.elements.dao.mongo.model.auth.MongoOidcAuthScheme}).
+ *
+ * <p>{@code sparse: true} was added to those unique indexes to fix soft-deleted auth schemes colliding on
+ * a shared {@code null} value (#56/#58), but since the indexes kept their auto-generated names, any
+ * environment that ran before that change already has a non-sparse index under the same name — and
+ * MongoDB refuses to redefine an existing index's options under its current name
+ * ({@code IndexKeySpecsConflict}), which otherwise crashes {@code Morphia.createDatastore(...)} on every
+ * startup (#63). The model classes now declare their sparse indexes under new, explicit names so creation
+ * never collides going forward; this migration removes the old, orphaned index so upgraded deployments end
+ * up fully clean.
+ *
+ * <p>A no-op if the old index (or the collection itself) is already gone.
+ */
+public class DropLegacyAuthSchemeIndexesMigration implements PreDatastoreMigration {
+
+    private static final Logger logger = LoggerFactory.getLogger(DropLegacyAuthSchemeIndexesMigration.class);
+
+    public static final String ID = "20260821_01_drop_legacy_auth_scheme_indexes";
+
+    private static final int INDEX_NOT_FOUND = 27;
+
+    private static final int NAMESPACE_NOT_FOUND = 26;
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Drops the pre-sparse oauth2_auth_scheme.name_1 / oidc_auth_scheme.name_1,issuer_1 indexes, " +
+                "superseded by sparse indexes under new names (#56/#58, #63).";
+    }
+
+    @Override
+    public void apply(final MongoDatabase database) {
+        dropIfPresent(database, "oauth2_auth_scheme", "name_1");
+        dropIfPresent(database, "oidc_auth_scheme", "name_1");
+        dropIfPresent(database, "oidc_auth_scheme", "issuer_1");
+    }
+
+    private void dropIfPresent(final MongoDatabase database, final String collectionName, final String indexName) {
+        try {
+            database.getCollection(collectionName).dropIndex(indexName);
+            logger.info(
+                    "Dropped stale index {} on {} (superseded by a sparse index under a new name).",
+                    indexName,
+                    collectionName
+            );
+        } catch (final MongoCommandException ex) {
+            if (ex.getErrorCode() != INDEX_NOT_FOUND && ex.getErrorCode() != NAMESPACE_NOT_FOUND) {
+                throw ex;
+            }
+        }
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/DropLegacyAuthSchemeIndexesMigration.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/migration/migrations/DropLegacyAuthSchemeIndexesMigration.java
@@ -21,6 +21,9 @@ import org.slf4j.LoggerFactory;
  * never collides going forward; this migration removes the old, orphaned index so upgraded deployments end
  * up fully clean.
  *
+ * NOTE: The catch-all introduced in PR #68 made this migration irrelevant, but I'm leaving it in for now as
+ * an example.
+ *
  * <p>A no-op if the old index (or the collection itself) is already gone.
  */
 public class DropLegacyAuthSchemeIndexesMigration implements PreDatastoreMigration {

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOAuth2AuthScheme.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOAuth2AuthScheme.java
@@ -14,7 +14,12 @@ import java.util.Objects;
         // sparse: delete soft-deletes by unsetting "name" rather than removing the document (see
         // MongoOAuth2AuthSchemeDao#deleteAuthScheme); a non-sparse unique index would reject the second
         // soft-deleted document, since it also has no "name" field.
-        @Index(fields = @Field("name"), options = @IndexOptions(unique = true, sparse = true))
+        //
+        // Explicitly named (rather than the auto-generated "name_1") because environments that ran before
+        // sparse was added already have a non-sparse index under that default name, and MongoDB rejects
+        // redefining an index's options under an existing name. See LegacyAuthSchemeIndexCleanup, which
+        // drops that old index once this one is safely in place.
+        @Index(fields = @Field("name"), options = @IndexOptions(name = "name_1_sparse", unique = true, sparse = true))
 })
 public class MongoOAuth2AuthScheme {
 

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcAuthScheme.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/auth/MongoOidcAuthScheme.java
@@ -13,8 +13,13 @@ import java.util.Objects;
         // sparse: delete soft-deletes by unsetting "name"/"issuer" rather than removing the document (see
         // MongoOidcAuthSchemeDao#deleteAuthScheme); non-sparse unique indexes would reject the second
         // soft-deleted document, since it also has neither field.
-        @Index(fields = @Field("name"), options = @IndexOptions(unique = true, sparse = true)),
-        @Index(fields = @Field("issuer"), options = @IndexOptions(unique = true, sparse = true))
+        //
+        // Explicitly named (rather than the auto-generated "name_1"/"issuer_1") because environments that
+        // ran before sparse was added already have non-sparse indexes under those default names, and
+        // MongoDB rejects redefining an index's options under an existing name. See
+        // LegacyAuthSchemeIndexCleanup, which drops the old indexes once these are safely in place.
+        @Index(fields = @Field("name"), options = @IndexOptions(name = "name_1_sparse", unique = true, sparse = true)),
+        @Index(fields = @Field("issuer"), options = @IndexOptions(name = "issuer_1_sparse", unique = true, sparse = true))
 })
 public class MongoOidcAuthScheme {
 

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MongoAtomicReferenceDataStoreProvider.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MongoAtomicReferenceDataStoreProvider.java
@@ -1,6 +1,7 @@
 package dev.getelements.elements.dao.mongo.provider;
 
 import com.mongodb.client.MongoClient;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigrationRunner;
 import dev.morphia.Datastore;
 import dev.morphia.config.MorphiaConfig;
 import jakarta.inject.Inject;
@@ -18,10 +19,14 @@ public class MongoAtomicReferenceDataStoreProvider implements Provider<AtomicRef
     @Inject
     private Provider<MorphiaConfig> morphiaConfigProvider;
 
+    @Inject
+    private Provider<PreDatastoreMigrationRunner> preDatastoreMigrationRunnerProvider;
+
     @Override
     public AtomicReference<Datastore> get() {
         final var client = mongoClientProvider.get();
         final var config = morphiaConfigProvider.get();
+        preDatastoreMigrationRunnerProvider.get().run(client, config);
         final var datastore =  createDatastore(client, config);
         return new AtomicReference<>(datastore);
     }

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDaoElementModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDaoElementModule.java
@@ -26,6 +26,7 @@ public class MongoDaoElementModule extends SharedElementModule {
         bind(new TypeLiteral<AtomicReference<Datastore>>(){})
                 .toProvider(MongoAtomicReferenceDataStoreProvider.class)
                 .asEagerSingleton();
+        install(new PreDatastoreMigrationModule());
         install(new MongoDaoModule());
         install(new MongoGridFSLargeObjectBucketModule());
         expose(ElementEntityRegistrar.class);

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDatastoreBootstrapModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDatastoreBootstrapModule.java
@@ -35,6 +35,8 @@ public class MongoDatastoreBootstrapModule extends AbstractModule {
                 .toProvider(MongoAtomicReferenceDataStoreProvider.class)
                 .asEagerSingleton();
 
+        install(new PreDatastoreMigrationModule());
+
         bind(ElementRegistry.class)
                 .annotatedWith(named(ROOT))
                 .to(Key.get(MutableElementRegistry.class, named(ROOT)));

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/PreDatastoreMigrationModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/PreDatastoreMigrationModule.java
@@ -1,0 +1,34 @@
+package dev.getelements.elements.dao.mongo.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigration;
+import dev.getelements.elements.dao.mongo.migration.PreDatastoreMigrationRunner;
+import dev.getelements.elements.dao.mongo.migration.migrations.DropLegacyAuthSchemeIndexesMigration;
+
+/**
+ * Registers every known {@link PreDatastoreMigration} with Guice, mirroring {@link MongoMigrationModule}'s
+ * pattern for {@code Migration} but for migrations that must run before the Morphia {@code Datastore} is
+ * constructed. New migrations are added here as an explicit {@link Multibinder} binding — no classpath
+ * scanning — so ordering and membership stay visible in one place, and call sites that share a
+ * {@code MorphiaConfig} (e.g. {@code MongoAtomicReferenceDataStoreProvider}, {@code MongoElementEntityRegistrar})
+ * never need their own migration-specific code — they just inject {@link PreDatastoreMigrationRunner} and
+ * call {@code run(...)} before {@code Morphia.createDatastore(...)}.
+ *
+ * <p>Installed everywhere {@code MongoAtomicReferenceDataStoreProvider} is bound (see
+ * {@link MongoDaoElementModule}, {@link MongoDatastoreBootstrapModule}, and the test equivalents), since
+ * that provider — and {@code MongoElementEntityRegistrar} — depend on {@link PreDatastoreMigrationRunner}.
+ */
+public class PreDatastoreMigrationModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+        bind(PreDatastoreMigrationRunner.class);
+
+        final var migrations = Multibinder.newSetBinder(binder(), PreDatastoreMigration.class);
+        migrations.addBinding().to(DropLegacyAuthSchemeIndexesMigration.class);
+
+    }
+
+}

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/PreDatastoreMigrationModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/PreDatastoreMigrationModule.java
@@ -27,7 +27,8 @@ public class PreDatastoreMigrationModule extends AbstractModule {
         bind(PreDatastoreMigrationRunner.class);
 
         final var migrations = Multibinder.newSetBinder(binder(), PreDatastoreMigration.class);
-        migrations.addBinding().to(DropLegacyAuthSchemeIndexesMigration.class);
+        //Leaving this here as an example
+//        migrations.addBinding().to(DropLegacyAuthSchemeIndexesMigration.class);
 
     }
 

--- a/mongo-test/src/main/java/dev/getelements/elements/dao/mongo/test/IntegrationTestModule.java
+++ b/mongo-test/src/main/java/dev/getelements/elements/dao/mongo/test/IntegrationTestModule.java
@@ -7,6 +7,7 @@ import dev.getelements.elements.config.DefaultConfigurationSupplier;
 import dev.getelements.elements.dao.mongo.guice.MongoDaoModule;
 import dev.getelements.elements.dao.mongo.guice.MongoGridFSLargeObjectBucketModule;
 import dev.getelements.elements.dao.mongo.guice.MongoMigrationModule;
+import dev.getelements.elements.dao.mongo.guice.PreDatastoreMigrationModule;
 import dev.getelements.elements.dao.mongo.provider.MongoAtomicReferenceDataStoreProvider;
 import dev.getelements.elements.dao.mongo.provider.MongoDozerMapperProvider;
 import dev.getelements.elements.dao.mongo.provider.MorphiaConfigProvider;
@@ -76,6 +77,8 @@ public class IntegrationTestModule extends AbstractModule {
         bind(new TypeLiteral<AtomicReference<Datastore>>(){})
                 .toProvider(MongoAtomicReferenceDataStoreProvider.class)
                 .asEagerSingleton();
+
+        install(new PreDatastoreMigrationModule());
 
         install(new MongoDaoModule(){
             @Override

--- a/service-test/src/test/java/dev/getelements/elements/service/AbstractIntegrationTestModule.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/AbstractIntegrationTestModule.java
@@ -6,6 +6,7 @@ import dev.getelements.elements.config.DefaultConfigurationSupplier;
 import dev.getelements.elements.config.FacebookBuiltinPermissionsSupplier;
 import dev.getelements.elements.dao.mongo.guice.MongoDaoModule;
 import dev.getelements.elements.dao.mongo.guice.MongoGridFSLargeObjectBucketModule;
+import dev.getelements.elements.dao.mongo.guice.PreDatastoreMigrationModule;
 import dev.getelements.elements.dao.mongo.provider.MongoAtomicReferenceDataStoreProvider;
 import dev.getelements.elements.dao.mongo.provider.MorphiaConfigProvider;
 import dev.getelements.elements.sdk.mongo.test.DockerMongoTestInstance;
@@ -89,6 +90,7 @@ public abstract class AbstractIntegrationTestModule extends AbstractModule {
         bind(new TypeLiteral<AtomicReference<Datastore>>(){})
                 .toProvider(MongoAtomicReferenceDataStoreProvider.class)
                 .asEagerSingleton();
+        install(new PreDatastoreMigrationModule());
         install(new MongoDaoModule());
 
         bind(JeroMQSecurity.class).toInstance(JeroMQSecurity.DEFAULT);


### PR DESCRIPTION
## Summary

Fixes #63: commit `3f235f127` (PR #58/#56) added `sparse: true` to the unique indexes on `oauth2_auth_scheme.name` and `oidc_auth_scheme.name`/`issuer`, but kept the auto-generated index names (`name_1`/`issuer_1`). Any environment that ran before that change already has a non-sparse index under the same name, and MongoDB rejects redefining an existing index's options under its current name (`IndexKeySpecsConflict`) — crashing `Morphia.createDatastore(...)` on every startup for already-deployed instances.

Beyond the fix itself, this introduces a small **pre-datastore migration framework**, mirroring the existing `Migration`/`MigrationRunner` pair used for post-datastore data migrations, but for fixes (like this one) that must run *before* the Morphia `Datastore` can even be constructed:

- `PreDatastoreMigration` / `PreDatastoreMigrationRunner` (`mongo-dao/.../migration/`) — operate on a raw `MongoDatabase` (no `Datastore` exists yet), track completion in a plain `pre_datastore_migrations` collection, mirroring `MigrationRunner`'s claim-based approach against the raw driver.
- `PreDatastoreMigrationModule` (`mongo-guice`) — the **one place** future migrations get registered (a single `Multibinder` addition), so call sites never need migration-specific code again.
- The two places that independently call `Morphia.createDatastore(...)` with the same `MorphiaConfig` — `MongoAtomicReferenceDataStoreProvider` (app bootstrap) and `MongoElementEntityRegistrar` (runs on every element load/unload afterward) — now just inject `PreDatastoreMigrationRunner` and call `.run(client, config)` first.
- `DropLegacyAuthSchemeIndexesMigration` is the concrete fix: drops the old `name_1`/`issuer_1` indexes, no-op if already gone. The model classes now declare their sparse indexes under new, explicit names (`name_1_sparse`, `issuer_1_sparse`) so creation never collides going forward.

## Test plan
- [x] All touched modules (`mongo-dao`, `mongo-guice`, `mongo-test`, `service-test`) compile cleanly.
- [x] Manually recreated the stale `name_1`/`issuer_1` indexes on a local dev database (seeded before #58) to reproduce the crash.
- [x] Booted the real app (`jettyws`) against it: migration applied, all three stale indexes dropped, completion recorded, server started cleanly, `GET /version` returned 200.
- [x] Rebooted a second time: migration correctly skipped as already-applied, no errors, clean startup — confirms idempotency across restarts.

Closes #63
