### PR TITLE
Self-heal stale index-option conflicts in the migrate tool

### DIFF
--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/IndexConflictResolver.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/IndexConflictResolver.java
@@ -1,0 +1,23 @@
+package dev.getelements.elements.dao.mongo.provider;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.MongoCollection;
+
+/**
+ * Resolves an index-definition conflict (MongoDB error code 85 {@code IndexOptionsConflict} or
+ * 86 {@code IndexKeySpecsConflict}) raised while creating an index on {@code collection}, by dropping the
+ * stale, conflicting index so that it can be recreated with its newly-declared options.
+ */
+public interface IndexConflictResolver {
+
+    /**
+     * Attempts to resolve the given index conflict on {@code collection}.
+     *
+     * @param collection the collection on which the conflicting index create was attempted
+     * @param cause      the exception raised by the attempted index creation
+     * @return true if a conflicting index was identified and dropped; false if {@code cause} is not a
+     *         recognized index-conflict error, or the conflicting index name could not be determined
+     */
+    boolean resolve(MongoCollection<?> collection, MongoCommandException cause);
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MigrateMorphiaConfigProvider.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MigrateMorphiaConfigProvider.java
@@ -1,0 +1,34 @@
+package dev.getelements.elements.dao.mongo.provider;
+
+import dev.getelements.elements.sdk.mongo.MongoConfigurationService;
+import dev.morphia.config.MorphiaConfig;
+import dev.morphia.mapping.DiscriminatorFunction;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
+
+import java.util.List;
+
+/**
+ * Provides the {@link MorphiaConfig} used by the migration tool. Index application is disabled here
+ * ({@code applyIndexes(false)}) so that {@link SelfHealingAtomicReferenceDataStoreProvider} can apply
+ * indexes itself, healing any conflict between a newly-declared index's options and a stale on-disk index
+ * instead of aborting datastore construction.
+ */
+public class MigrateMorphiaConfigProvider implements Provider<MorphiaConfig> {
+
+    @Inject
+    @Named(MongoConfigurationService.DATABASE_NAME)
+    private Provider<String> databaseNameProvider;
+
+    @Override
+    public MorphiaConfig get() {
+        return MorphiaConfig.load()
+                .applyIndexes(false)
+                .enablePolymorphicQueries(true)
+                .discriminator(DiscriminatorFunction.className())
+                .packages(List.of("dev.getelements.elements.dao.mongo.*"))
+                .database(databaseNameProvider.get());
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MongoIndexConflictResolver.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MongoIndexConflictResolver.java
@@ -1,0 +1,67 @@
+package dev.getelements.elements.dao.mongo.provider;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.MongoCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MongoIndexConflictResolver implements IndexConflictResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(MongoIndexConflictResolver.class);
+
+    private static final int INDEX_OPTIONS_CONFLICT = 85;
+
+    private static final int INDEX_KEY_SPECS_CONFLICT = 86;
+
+    private static final int INDEX_NOT_FOUND = 27;
+
+    private static final Pattern EXISTING_INDEX_NAME = Pattern.compile("name:\\s*\"([^\"]+)\"");
+
+    @Override
+    public boolean resolve(final MongoCollection<?> collection, final MongoCommandException cause) {
+
+        final var code = cause.getErrorCode();
+
+        if (code != INDEX_OPTIONS_CONFLICT && code != INDEX_KEY_SPECS_CONFLICT) {
+            return false;
+        }
+
+        final var matcher = EXISTING_INDEX_NAME.matcher(cause.getErrorMessage());
+        String indexName = null;
+
+        while (matcher.find()) {
+            indexName = matcher.group(1);
+        }
+
+        if (indexName == null) {
+            logger.error(
+                    "Index conflict on {} could not be resolved; unable to determine conflicting index name from: {}",
+                    collection.getNamespace(),
+                    cause.getResponse().toJson()
+            );
+            return false;
+        }
+
+        try {
+            collection.dropIndex(indexName);
+            logger.warn(
+                    "Dropped conflicting index {} on {} to resolve {}: {}",
+                    indexName,
+                    collection.getNamespace(),
+                    cause.getErrorCodeName(),
+                    cause.getErrorMessage()
+            );
+        } catch (MongoCommandException dropFailure) {
+            if (dropFailure.getErrorCode() != INDEX_NOT_FOUND) {
+                throw dropFailure;
+            }
+        }
+
+        return true;
+
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MorphiaSelfHealingIndexApplier.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/MorphiaSelfHealingIndexApplier.java
@@ -1,0 +1,56 @@
+package dev.getelements.elements.dao.mongo.provider;
+
+import com.mongodb.MongoCommandException;
+import dev.morphia.Datastore;
+import dev.morphia.annotations.internal.IndexHelper;
+import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MorphiaSelfHealingIndexApplier implements SelfHealingIndexApplier {
+
+    private static final Logger logger = LoggerFactory.getLogger(MorphiaSelfHealingIndexApplier.class);
+
+    private static final int MAX_ATTEMPTS = 8;
+
+    @Inject
+    private IndexConflictResolver indexConflictResolver;
+
+    @Override
+    public void applyIndexes(final Datastore datastore) {
+
+        final var mapper = datastore.getMapper();
+        final var indexHelper = new IndexHelper(mapper);
+
+        for (final var model : mapper.getMappedEntities()) {
+
+            if (model.getIdProperty() == null) {
+                continue;
+            }
+
+            final var collection = datastore.getCollection(model.getType());
+
+            for (int attempt = 1; ; attempt++) {
+                try {
+                    indexHelper.createIndex(collection, model);
+                    break;
+                } catch (MongoCommandException e) {
+
+                    if (attempt >= MAX_ATTEMPTS || !indexConflictResolver.resolve(collection, e)) {
+                        logger.error(
+                                "Unable to self-heal index conflict for {} on {} after {} attempt(s)",
+                                model.getType().getName(),
+                                collection.getNamespace(),
+                                attempt
+                        );
+                        throw e;
+                    }
+
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/SelfHealingAtomicReferenceDataStoreProvider.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/SelfHealingAtomicReferenceDataStoreProvider.java
@@ -1,0 +1,38 @@
+package dev.getelements.elements.dao.mongo.provider;
+
+import com.mongodb.client.MongoClient;
+import dev.morphia.Datastore;
+import dev.morphia.config.MorphiaConfig;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static dev.morphia.Morphia.createDatastore;
+
+/**
+ * Builds the {@link Datastore} used by the migration tool, applying indexes itself via
+ * {@link SelfHealingIndexApplier} rather than relying on {@code MorphiaConfig.applyIndexes(true)}, so a
+ * stale on-disk index left over from a prior index-option change doesn't abort datastore construction.
+ */
+public class SelfHealingAtomicReferenceDataStoreProvider implements Provider<AtomicReference<Datastore>> {
+
+    @Inject
+    private Provider<MongoClient> mongoClientProvider;
+
+    @Inject
+    private Provider<MorphiaConfig> morphiaConfigProvider;
+
+    @Inject
+    private SelfHealingIndexApplier selfHealingIndexApplier;
+
+    @Override
+    public AtomicReference<Datastore> get() {
+        final var client = mongoClientProvider.get();
+        final var config = morphiaConfigProvider.get();
+        final var datastore = createDatastore(client, config);
+        selfHealingIndexApplier.applyIndexes(datastore);
+        return new AtomicReference<>(datastore);
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/SelfHealingIndexApplier.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/provider/SelfHealingIndexApplier.java
@@ -1,0 +1,21 @@
+package dev.getelements.elements.dao.mongo.provider;
+
+import dev.morphia.Datastore;
+
+/**
+ * Applies every mapped entity's declared indexes against a {@link Datastore}, healing (via
+ * {@link IndexConflictResolver}) any single collection whose on-disk index conflicts with its newly-declared
+ * options, instead of letting one conflicting index abort index application for every other entity, which is
+ * how {@link Datastore}'s own automatic index application behaves. Callers must configure the datastore's
+ * {@code MorphiaConfig.applyIndexes()} to {@code false} so this is the only path that creates indexes.
+ */
+public interface SelfHealingIndexApplier {
+
+    /**
+     * Applies indexes for every entity mapped by {@code datastore}, healing conflicts as they're encountered.
+     *
+     * @param datastore the datastore whose mapped entities' indexes should be applied
+     */
+    void applyIndexes(Datastore datastore);
+
+}

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDatastoreBootstrapModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDatastoreBootstrapModule.java
@@ -3,8 +3,12 @@ package dev.getelements.elements.dao.mongo.guice;
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
-import dev.getelements.elements.dao.mongo.provider.MongoAtomicReferenceDataStoreProvider;
-import dev.getelements.elements.dao.mongo.provider.MorphiaConfigProvider;
+import dev.getelements.elements.dao.mongo.provider.IndexConflictResolver;
+import dev.getelements.elements.dao.mongo.provider.MigrateMorphiaConfigProvider;
+import dev.getelements.elements.dao.mongo.provider.MongoIndexConflictResolver;
+import dev.getelements.elements.dao.mongo.provider.MorphiaSelfHealingIndexApplier;
+import dev.getelements.elements.dao.mongo.provider.SelfHealingAtomicReferenceDataStoreProvider;
+import dev.getelements.elements.dao.mongo.provider.SelfHealingIndexApplier;
 import dev.getelements.elements.sdk.ElementRegistry;
 import dev.getelements.elements.sdk.MutableElementRegistry;
 import dev.morphia.Datastore;
@@ -29,11 +33,15 @@ public class MongoDatastoreBootstrapModule extends AbstractModule {
     protected void configure() {
 
         bind(MorphiaConfig.class)
-                .toProvider(MorphiaConfigProvider.class);
+                .toProvider(MigrateMorphiaConfigProvider.class);
 
         bind(new TypeLiteral<AtomicReference<Datastore>>(){})
-                .toProvider(MongoAtomicReferenceDataStoreProvider.class)
+                .toProvider(SelfHealingAtomicReferenceDataStoreProvider.class)
                 .asEagerSingleton();
+
+        bind(IndexConflictResolver.class).to(MongoIndexConflictResolver.class);
+
+        bind(SelfHealingIndexApplier.class).to(MorphiaSelfHealingIndexApplier.class);
 
         bind(ElementRegistry.class)
                 .annotatedWith(named(ROOT))


### PR DESCRIPTION
## Summary

- The `migrate` tool crashed at Guice injector construction with `IndexKeySpecsConflict` (Mongo error 86) whenever an on-disk index's options no longer matched its current Morphia annotation (e.g. `name_1` on `oauth2_auth_scheme`/`oidc_auth_scheme` after `sparse=true` was added in `3f235f1273` without a corresponding index migration).
- Because `AtomicReference<Datastore>` is bound `.asEagerSingleton()`, this happened before `MigrationRunner` was ever obtained, so no migration could fix it — the injector itself failed to construct.
- Scopes the `migrate` tool's own Guice wiring (`MongoDatastoreBootstrapModule`) to build the `Datastore` with `applyIndexes(false)` and drive index application itself via a new `SelfHealingIndexApplier`, which drops and recreates any single conflicting index (per Mongo's own documented remedy for this error) instead of letting one conflict abort every other collection's indexing.
- `jetty-ws`'s wiring (`MongoDaoElementModule`) and `MongoElementEntityRegistrar` are intentionally untouched, so the main server's boot behavior doesn't change — a deliberate scope decision, called out in the issue.

Closes #67

## Test plan

- [x] `mvn -pl mongo-dao,mongo-guice,migrate -am install -DskipTests` — compiles
- [x] `mvn -pl mongo-dao -am test` — all tests pass, no regressions
- [x] Reproduced against local dev DB with the actual stale `name_1`/`issuer_1` indexes; ran `migrate --status` — self-healed all three conflicts (logged at `WARN`), completed successfully instead of crashing
- [x] Confirmed via `db.<collection>.getIndexes()` that `name_1`/`issuer_1` now show `sparse: true`
- [x] Re-ran `migrate --status` a second time — idempotent, no further drops logged