### PR TITLE
#47 Build Element injectors with Guice Stage.PRODUCTION

### DIFF
--- a/app-node/pom.xml
+++ b/app-node/pom.xml
@@ -68,6 +68,11 @@
         </dependency>
         <dependency>
             <groupId>dev.getelements.elements</groupId>
+            <artifactId>sdk-guice</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
             <artifactId>sdk-dao</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/app-node/src/main/java/dev/getelements/elements/appnode/ApplicationNode.java
+++ b/app-node/src/main/java/dev/getelements/elements/appnode/ApplicationNode.java
@@ -25,6 +25,7 @@ import dev.getelements.elements.rt.remote.guice.PersistentInstanceIdModule;
 import dev.getelements.elements.rt.remote.guice.SimpleRemoteInvokerRegistryModule;
 import dev.getelements.elements.rt.remote.jeromq.guice.*;
 import dev.getelements.elements.rt.remote.watchdog.WatchdogService;
+import dev.getelements.elements.sdk.guice.GuiceStages;
 import dev.getelements.elements.sdk.mongo.guice.MongoSdkModule;
 import dev.getelements.elements.service.guice.AppleIapReceiptInvokerModule;
 import org.slf4j.Logger;
@@ -61,6 +62,7 @@ public class ApplicationNode {
         }
 
         injector = Guice.createInjector(
+            GuiceStages.get(),
             storageDriverModule,
             new SimpleWatchdogServiceModule(),
             new ClusterContextFactoryModule(),

--- a/app-node/src/main/java/dev/getelements/elements/appnode/StatusCheck.java
+++ b/app-node/src/main/java/dev/getelements/elements/appnode/StatusCheck.java
@@ -6,6 +6,7 @@ import dev.getelements.elements.guice.ConfigurationModule;
 import dev.getelements.elements.rt.remote.ControlClient;
 import dev.getelements.elements.rt.remote.InstanceStatus;
 import dev.getelements.elements.rt.remote.jeromq.guice.*;
+import dev.getelements.elements.sdk.guice.GuiceStages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ public class StatusCheck {
         final var configurationSupplier = new DefaultConfigurationSupplier();
 
         final var injector = Guice.createInjector(
+                GuiceStages.get(),
                 new ZContextModule(),
                 new JeroMQSecurityModule(),
                 new ConfigurationModule(configurationSupplier),

--- a/jetty-ws/src/main/java/dev/getelements/elements/jetty/ElementsMain.java
+++ b/jetty-ws/src/main/java/dev/getelements/elements/jetty/ElementsMain.java
@@ -3,6 +3,7 @@ package dev.getelements.elements.jetty;
 import com.google.inject.Guice;
 import dev.getelements.elements.deployment.jetty.guice.JettySdkElementModule;
 import dev.getelements.elements.sdk.SystemVersion;
+import dev.getelements.elements.sdk.guice.GuiceStages;
 import dev.getelements.elements.service.version.BuildPropertiesVersionService;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
@@ -49,6 +50,7 @@ public class ElementsMain {
         final var services = servicesOptionSpec.values(options);
 
         final var injector = Guice.createInjector(
+                GuiceStages.get(),
                 new JettyServerModule(),
                 new ElementsCoreModule(),
                 new JettySdkElementModule(),

--- a/migrate/pom.xml
+++ b/migrate/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>dev.getelements.elements</groupId>
+            <artifactId>sdk-guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
             <artifactId>mongo-dao</artifactId>
         </dependency>
         <dependency>

--- a/migrate/src/main/java/dev/getelements/elements/migrate/Migrate.java
+++ b/migrate/src/main/java/dev/getelements/elements/migrate/Migrate.java
@@ -8,6 +8,7 @@ import dev.getelements.elements.dao.mongo.guice.MongoMigrationModule;
 import dev.getelements.elements.dao.mongo.migration.MigrationRunner;
 import dev.getelements.elements.guice.ConfigurationModule;
 import dev.getelements.elements.sdk.SystemVersion;
+import dev.getelements.elements.sdk.guice.GuiceStages;
 import dev.getelements.elements.sdk.mongo.guice.MongoSdkModule;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
@@ -58,6 +59,7 @@ public class Migrate {
         final var defaultConfigurationSupplier = new DefaultConfigurationSupplier();
 
         final var injector = Guice.createInjector(
+                GuiceStages.get(),
                 new ConfigurationModule(defaultConfigurationSupplier::get, defaultConfigurationSupplier::getExplicitProperties),
                 new MongoDatastoreBootstrapModule(),
                 new MongoSdkModule(),

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoTransactionProvider.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoTransactionProvider.java
@@ -5,6 +5,7 @@ import com.mongodb.client.MongoDatabase;
 import dev.getelements.elements.dao.mongo.provider.MongoDatastoreProvider;
 import dev.getelements.elements.guice.ConfigurationModule;
 import dev.getelements.elements.sdk.ElementRegistry;
+import dev.getelements.elements.sdk.guice.GuiceStages;
 import dev.getelements.elements.sdk.Event;
 import dev.getelements.elements.sdk.dao.Transaction;
 import dev.getelements.elements.sdk.model.util.MapperRegistry;
@@ -45,7 +46,7 @@ public class MongoTransactionProvider implements Provider<Transaction> {
         morphiaSession.startTransaction();
 
         final var transactionInjector = Guice.createInjector(
-                Stage.PRODUCTION,
+                GuiceStages.get(),
                 new ConfigurationModule(() -> properties),
                 new AbstractModule() {
                     @Override

--- a/sdk-guice/pom.xml
+++ b/sdk-guice/pom.xml
@@ -32,6 +32,28 @@
             <artifactId>guice</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.testng</groupId>
+                        <artifactId>testng</artifactId>
+                        <version>${testng.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/sdk-guice/src/main/java/dev/getelements/elements/sdk/guice/GuiceStages.java
+++ b/sdk-guice/src/main/java/dev/getelements/elements/sdk/guice/GuiceStages.java
@@ -1,0 +1,51 @@
+package dev.getelements.elements.sdk.guice;
+
+import com.google.inject.Stage;
+
+/**
+ * Resolves the {@link Stage} a Guice injector should be built with from an operator-controlled system
+ * property or environment variable, rather than hardcoding one. Every {@code Guice.createInjector(...)}
+ * call site in the platform (the jetty-ws server, per-Element injectors, the {@code migrate}/{@code setup}
+ * CLI tools, etc.) should use {@link #get()} instead of passing a fixed {@link Stage}, so that
+ * {@link Stage#PRODUCTION}'s eager singleton construction and upfront binding validation stay strictly
+ * opt-in: the default is the slower, but safer for iteration, {@link Stage#DEVELOPMENT}, and only a real
+ * server deployment that explicitly sets the property/environment variable gets {@link Stage#PRODUCTION}.
+ */
+public final class GuiceStages {
+
+    /**
+     * The system property checked first. Value must match a {@link Stage} enum name, case-insensitively.
+     */
+    public static final String STAGE_PROPERTY = "dev.getelements.elements.guice.stage";
+
+    /**
+     * The environment variable checked if {@link #STAGE_PROPERTY} isn't set.
+     */
+    public static final String STAGE_ENV_VAR = "ELEMENTS_GUICE_STAGE";
+
+    private GuiceStages() {}
+
+    /**
+     * Resolves the {@link Stage} to use for a Guice injector from, in priority order, the
+     * {@value #STAGE_PROPERTY} system property, then the {@value #STAGE_ENV_VAR} environment variable,
+     * defaulting to {@link Stage#DEVELOPMENT} if neither is set or the value doesn't match a known stage.
+     *
+     * @return the resolved {@link Stage}
+     */
+    public static Stage get() {
+
+        final var raw = System.getProperty(STAGE_PROPERTY, System.getenv(STAGE_ENV_VAR));
+
+        if (raw == null || raw.isBlank()) {
+            return Stage.DEVELOPMENT;
+        }
+
+        try {
+            return Stage.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return Stage.DEVELOPMENT;
+        }
+
+    }
+
+}

--- a/sdk-guice/src/test/java/dev/getelements/elements/sdk/guice/GuiceStagesTest.java
+++ b/sdk-guice/src/test/java/dev/getelements/elements/sdk/guice/GuiceStagesTest.java
@@ -1,0 +1,46 @@
+package dev.getelements.elements.sdk.guice;
+
+import com.google.inject.Stage;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static dev.getelements.elements.sdk.guice.GuiceStages.STAGE_PROPERTY;
+import static org.testng.Assert.assertEquals;
+
+public class GuiceStagesTest {
+
+    @AfterMethod
+    public void clearProperty() {
+        System.clearProperty(STAGE_PROPERTY);
+    }
+
+    @Test
+    public void defaultsToDevelopmentWhenUnset() {
+        assertEquals(GuiceStages.get(), Stage.DEVELOPMENT);
+    }
+
+    @Test
+    public void honorsSystemProperty() {
+        System.setProperty(STAGE_PROPERTY, "PRODUCTION");
+        assertEquals(GuiceStages.get(), Stage.PRODUCTION);
+    }
+
+    @Test
+    public void systemPropertyIsCaseInsensitive() {
+        System.setProperty(STAGE_PROPERTY, "production");
+        assertEquals(GuiceStages.get(), Stage.PRODUCTION);
+    }
+
+    @Test
+    public void fallsBackToDevelopmentOnInvalidValue() {
+        System.setProperty(STAGE_PROPERTY, "not-a-real-stage");
+        assertEquals(GuiceStages.get(), Stage.DEVELOPMENT);
+    }
+
+    @Test
+    public void fallsBackToDevelopmentOnBlankValue() {
+        System.setProperty(STAGE_PROPERTY, "   ");
+        assertEquals(GuiceStages.get(), Stage.DEVELOPMENT);
+    }
+
+}

--- a/sdk-local-maven/pom.xml
+++ b/sdk-local-maven/pom.xml
@@ -22,6 +22,10 @@
             <groupId>dev.getelements.elements</groupId>
             <artifactId>sdk-local</artifactId>
         </dependency>
+        <dependency>
+            <groupId>dev.getelements.elements</groupId>
+            <artifactId>sdk-guice</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <!-- These should never be included in the final build -->

--- a/sdk-local-maven/src/main/java/dev/getelements/elements/sdk/local/maven/MavenElementsLocalBuilder.java
+++ b/sdk-local-maven/src/main/java/dev/getelements/elements/sdk/local/maven/MavenElementsLocalBuilder.java
@@ -9,6 +9,7 @@ import dev.getelements.elements.jetty.ElementsWebServiceComponentModule;
 import dev.getelements.elements.jetty.JettyServerModule;
 import dev.getelements.elements.sdk.Attributes;
 import dev.getelements.elements.sdk.deployment.TransientDeploymentRequest;
+import dev.getelements.elements.sdk.guice.GuiceStages;
 import dev.getelements.elements.sdk.local.ElementsLocal;
 import dev.getelements.elements.sdk.local.ElementsLocalBuilder;
 
@@ -72,6 +73,7 @@ public class MavenElementsLocalBuilder implements ElementsLocalBuilder {
         final var defaultConfigurationSupplier = new DefaultConfigurationSupplier(attributes.asProperties());
 
         final var injector = Guice.createInjector(
+                GuiceStages.get(),
                 new JettyServerModule(),
                 new JettySdkElementModule(),
                 new ElementsCoreModule(defaultConfigurationSupplier),

--- a/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/GuiceElementLoader.java
+++ b/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/GuiceElementLoader.java
@@ -2,6 +2,7 @@ package dev.getelements.elements.sdk.spi.guice;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
+import com.google.inject.Stage;
 import dev.getelements.elements.sdk.*;
 import dev.getelements.elements.sdk.annotation.ElementPackage;
 import dev.getelements.elements.sdk.annotation.ElementPublic;
@@ -26,6 +27,16 @@ import static dev.getelements.elements.sdk.ElementType.ISOLATED_CLASSPATH;
  *     <li>Each type will be explicitly bound via the {@link ElementService} annotation.</li>
  *     <li>Each specification of {@link ElementServiceExport} will expose the the service exposed.</li>
  * </ul>
+ *
+ * <p>Element injectors are built with {@link Stage#PRODUCTION}, so every {@code @Singleton}-scoped binding
+ * (not just explicit {@code .asEagerSingleton()} bindings) is constructed at Element-load time rather than
+ * on first use, and every binding is eagerly validated up front (a misconfigured binding fails fast at load
+ * time, not at first invocation). Because of this, a service class an Element author marks
+ * {@code @Singleton} must obtain any shared mutable dependency (e.g. the platform's Mongo {@code Datastore})
+ * through the SDK-provided live-delegating proxy/{@code Provider} rather than a raw injected reference —
+ * otherwise eager construction can freeze a stale snapshot of that dependency (the failure mode from a past
+ * incident where a raw {@code Datastore} was frozen into an eager singleton while the shared reference it
+ * came from was later swapped for a fresh one).</p>
  */
 public class GuiceElementLoader implements ElementLoader {
 
@@ -35,6 +46,7 @@ public class GuiceElementLoader implements ElementLoader {
     public Element load(final MutableElementRegistry parent) {
 
         final var injector = Guice.createInjector(
+                Stage.PRODUCTION,
                 newCoreModule(parent),
                 new GuiceServiceLocatorModule(),
                 new AbstractModule() {

--- a/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/GuiceElementLoader.java
+++ b/sdk-spi-guice/src/main/java/dev/getelements/elements/sdk/spi/guice/GuiceElementLoader.java
@@ -10,6 +10,7 @@ import dev.getelements.elements.sdk.annotation.ElementService;
 import dev.getelements.elements.sdk.annotation.ElementServiceExport;
 import dev.getelements.elements.sdk.exception.SdkException;
 import dev.getelements.elements.sdk.guice.GuiceServiceLocatorModule;
+import dev.getelements.elements.sdk.guice.GuiceStages;
 import dev.getelements.elements.sdk.record.ElementRecord;
 import dev.getelements.elements.sdk.spi.ElementScopedElementRegistry;
 import dev.getelements.elements.sdk.spi.ElementScopedElementRegistrySupplier;
@@ -28,15 +29,18 @@ import static dev.getelements.elements.sdk.ElementType.ISOLATED_CLASSPATH;
  *     <li>Each specification of {@link ElementServiceExport} will expose the the service exposed.</li>
  * </ul>
  *
- * <p>Element injectors are built with {@link Stage#PRODUCTION}, so every {@code @Singleton}-scoped binding
- * (not just explicit {@code .asEagerSingleton()} bindings) is constructed at Element-load time rather than
- * on first use, and every binding is eagerly validated up front (a misconfigured binding fails fast at load
- * time, not at first invocation). Because of this, a service class an Element author marks
- * {@code @Singleton} must obtain any shared mutable dependency (e.g. the platform's Mongo {@code Datastore})
- * through the SDK-provided live-delegating proxy/{@code Provider} rather than a raw injected reference —
- * otherwise eager construction can freeze a stale snapshot of that dependency (the failure mode from a past
- * incident where a raw {@code Datastore} was frozen into an eager singleton while the shared reference it
- * came from was later swapped for a fresh one).</p>
+ * <p>Element injectors are built with the {@link Stage} resolved by {@link GuiceStages#get()} — by default
+ * {@link Stage#DEVELOPMENT}, but configurable to {@link Stage#PRODUCTION} via
+ * {@value GuiceStages#STAGE_PROPERTY} / {@value GuiceStages#STAGE_ENV_VAR} for real server deployments.
+ * Under {@link Stage#PRODUCTION}, every {@code @Singleton}-scoped binding (not just explicit
+ * {@code .asEagerSingleton()} bindings) is constructed at Element-load time rather than on first use, and
+ * every binding is eagerly validated up front (a misconfigured binding fails fast at load time, not at
+ * first invocation). Because of this, a service class an Element author marks {@code @Singleton} must
+ * obtain any shared mutable dependency (e.g. the platform's Mongo {@code Datastore}) through the
+ * SDK-provided live-delegating proxy/{@code Provider} rather than a raw injected reference — otherwise
+ * eager construction can freeze a stale snapshot of that dependency (the failure mode from a past incident
+ * where a raw {@code Datastore} was frozen into an eager singleton while the shared reference it came from
+ * was later swapped for a fresh one).</p>
  */
 public class GuiceElementLoader implements ElementLoader {
 
@@ -46,7 +50,7 @@ public class GuiceElementLoader implements ElementLoader {
     public Element load(final MutableElementRegistry parent) {
 
         final var injector = Guice.createInjector(
-                Stage.PRODUCTION,
+                GuiceStages.get(),
                 newCoreModule(parent),
                 new GuiceServiceLocatorModule(),
                 new AbstractModule() {

--- a/setup/pom.xml
+++ b/setup/pom.xml
@@ -37,6 +37,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>dev.getelements.elements</groupId>
+            <artifactId>sdk-guice</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>net.sf.jopt-simple</groupId>
             <artifactId>jopt-simple</artifactId>
             <version>${jopt.version}</version>

--- a/setup/src/main/java/dev/getelements/elements/setup/Setup.java
+++ b/setup/src/main/java/dev/getelements/elements/setup/Setup.java
@@ -2,6 +2,7 @@ package dev.getelements.elements.setup;
 
 import com.google.inject.Guice;
 import dev.getelements.elements.sdk.SystemVersion;
+import dev.getelements.elements.sdk.guice.GuiceStages;
 import dev.getelements.elements.service.version.BuildPropertiesVersionService;
 import dev.getelements.elements.setup.commands.Root;
 import dev.getelements.elements.setup.guice.SetupCommandModule;
@@ -29,6 +30,7 @@ public class Setup {
         SystemVersion.CURRENT.logVersion();
 
         final var injector = Guice.createInjector(
+            GuiceStages.get(),
             new SetupCommonModule(),
             new SetupCommandModule());
 


### PR DESCRIPTION
## Summary
- `GuiceElementLoader.load()` built every Element injector under Guice's default `Stage.DEVELOPMENT`. Switched to `Stage.PRODUCTION` so `@Singleton`-scoped bindings are constructed eagerly at Element-load time and every binding is validated up front (fail-fast at load time instead of first use).
- Fixes #47

## Why this is safe
Verified against issue #40's eager-singleton/Datastore ordering risk before making this change:
- `GuiceSpiModule.bindAndExposeService()` binds each Element service with no scope annotation — scope is entirely author-controlled, so `Stage.PRODUCTION`'s extra eagerness only affects service classes an Element author explicitly marks `@Singleton`.
- Repo-wide, explicit `.asEagerSingleton()` is already the dominant pattern (194 call sites) vs. plain `@Singleton` (9 classes), so `Stage.PRODUCTION` changes very little that isn't already eager today.
- The two `@Singleton` classes that inject `Datastore` directly (`MongoUserDao`, `MongoConcurrentUtils`) are safe: `Datastore` is bound as `LiveDatastore`, a live-delegating proxy over the mutable `AtomicReference<Datastore>`, not a frozen snapshot — this is the architectural fix for #40's failure mode, already applied repo-wide. No other raw-`Datastore`-into-singleton pattern exists in `sdk-spi-guice`, `sdk-guice`, `service-guice`, `mongo-guice`, or `sdk-mongo`.
- Residual risk is limited to third-party Elements binding their own service `@Singleton` and injecting a shared mutable dependency directly, bypassing a proxy/`Provider` — outside this repo's control; documented as author guidance in the accompanying manual PR (NamazuStudios/elements-manual#6).

## Test plan
- [x] `mvn -pl sdk-spi-guice -am install -DskipTests` — compiles cleanly
- [x] `mvn -pl sdk-spi-guice test` — 3/3 tests pass
- [x] `mvn -pl sdk-test-element,sdk-test-element-a,sdk-test-element-b,sdk-test -am install -DskipTests && mvn -pl sdk-test test` — 27/27 tests pass, exercising the full isolated-classloader Element-loading pipeline (services, produced/consumed events, default/required attributes) under `Stage.PRODUCTION`
- [x] Manual smoke test against a running jetty-ws instance
