### PR TITLE
#48 Make Maven/Aether local-repository cache dir configurable via env var

### DIFF
--- a/sdk-spi-shrinkwrap/src/main/java/dev/getelements/elements/sdk/spi/shrinkwrap/CachingShrinkwrapElementArtifactLoader.java
+++ b/sdk-spi-shrinkwrap/src/main/java/dev/getelements/elements/sdk/spi/shrinkwrap/CachingShrinkwrapElementArtifactLoader.java
@@ -36,9 +36,30 @@ public class CachingShrinkwrapElementArtifactLoader implements ElementArtifactLo
         java.util.logging.Logger
                 .getLogger("org.jboss.shrinkwrap.resolver.impl.maven.logging.LogTransferListener")
                 .setLevel(java.util.logging.Level.SEVERE);
+        applyLocalRepositoryOverride();
     }
 
     public static final String DEFAULT_LAYOUT = "default";
+
+    /**
+     * System property checked (before {@link #LOCAL_REPOSITORY_ENV_VAR}) to redirect the Maven/Aether
+     * local-repository cache -- e.g. to an NFS-mounted, cluster-shared directory so multiple server
+     * instances avoid redundant artifact resolution/downloads.
+     */
+    public static final String LOCAL_REPOSITORY_PROPERTY = "dev.getelements.elements.maven.repo.local";
+
+    /**
+     * Environment variable checked if {@link #LOCAL_REPOSITORY_PROPERTY} isn't set.
+     */
+    public static final String LOCAL_REPOSITORY_ENV_VAR = "ELEMENTS_MAVEN_REPO_LOCAL";
+
+    /**
+     * The system property ShrinkWrap's own resolver reads for the local-repository path
+     * ({@code MavenSettingsBuilder.ALT_LOCAL_REPOSITORY_LOCATION}). Not configurable via an environment
+     * variable in ShrinkWrap itself -- {@link #applyLocalRepositoryOverride()} bridges
+     * {@link #LOCAL_REPOSITORY_PROPERTY}/{@link #LOCAL_REPOSITORY_ENV_VAR} into it.
+     */
+    private static final String SHRINKWRAP_LOCAL_REPOSITORY_PROPERTY = "maven.repo.local";
 
     private static final Set<String> NOT_FOUND_EXCEPTIONS = Set.of(
         "org.eclipse.aether.transfer.ArtifactNotFoundException",
@@ -154,6 +175,32 @@ public class CachingShrinkwrapElementArtifactLoader implements ElementArtifactLo
 
         final var artifact = toArtifact(resolvedArtifact);
         return Optional.of(artifact);
+
+    }
+
+    /**
+     * Promotes {@value #LOCAL_REPOSITORY_PROPERTY} / {@value #LOCAL_REPOSITORY_ENV_VAR} into ShrinkWrap's
+     * own {@value #SHRINKWRAP_LOCAL_REPOSITORY_PROPERTY} system property, so operators can redirect the
+     * Maven/Aether local-repository cache via this platform's normal env-var/property convention instead
+     * of an undocumented raw JVM flag. Never overrides an already-explicit
+     * {@value #SHRINKWRAP_LOCAL_REPOSITORY_PROPERTY} system property -- an operator who set that directly
+     * is respected as-is.
+     *
+     * <p>Public (not {@code private}) so it can be invoked directly from tests, since the {@code static}
+     * initializer that calls it in normal operation only runs once per JVM.</p>
+     */
+    public static void applyLocalRepositoryOverride() {
+
+        if (System.getProperty(SHRINKWRAP_LOCAL_REPOSITORY_PROPERTY) != null) {
+            return;
+        }
+
+        final var override = System.getProperty(LOCAL_REPOSITORY_PROPERTY, System.getenv(LOCAL_REPOSITORY_ENV_VAR));
+
+        if (override != null && !override.isBlank()) {
+            System.setProperty(SHRINKWRAP_LOCAL_REPOSITORY_PROPERTY, override.trim());
+            logger.info("Using configured Maven local repository: {}", override.trim());
+        }
 
     }
 

--- a/sdk-spi-shrinkwrap/src/test/java/dev/getelements/elements/spi/shrinkwrap/CachingShrinkwrapElementArtifactLoaderTest.java
+++ b/sdk-spi-shrinkwrap/src/test/java/dev/getelements/elements/spi/shrinkwrap/CachingShrinkwrapElementArtifactLoaderTest.java
@@ -3,13 +3,18 @@ package dev.getelements.elements.spi.shrinkwrap;
 import dev.getelements.elements.sdk.ElementArtifactLoader;
 import dev.getelements.elements.sdk.record.ArtifactRepository;
 import dev.getelements.elements.sdk.spi.shrinkwrap.CachingShrinkwrapElementArtifactLoader;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Set;
 
+import static dev.getelements.elements.sdk.spi.shrinkwrap.CachingShrinkwrapElementArtifactLoader.LOCAL_REPOSITORY_PROPERTY;
+import static dev.getelements.elements.sdk.spi.shrinkwrap.CachingShrinkwrapElementArtifactLoader.applyLocalRepositoryOverride;
 import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class CachingShrinkwrapElementArtifactLoaderTest {
@@ -34,7 +39,15 @@ public class CachingShrinkwrapElementArtifactLoaderTest {
             "com.example:does-not-exist:0.0.1"
     );
 
+    private static final String MAVEN_LOCAL_REPO_PROPERTY = "maven.repo.local";
+
     private final ElementArtifactLoader loader = new CachingShrinkwrapElementArtifactLoader();
+
+    @AfterMethod
+    public void clearProperties() {
+        System.clearProperty(LOCAL_REPOSITORY_PROPERTY);
+        System.clearProperty(MAVEN_LOCAL_REPO_PROPERTY);
+    }
 
     @DataProvider
     public Object[][] getTestArtifacts() {
@@ -74,6 +87,27 @@ public class CachingShrinkwrapElementArtifactLoaderTest {
         final var result = loader.findClassLoader(null, ArtifactRepository.DEFAULTS, all);
         assertTrue(result.isPresent());
 
+    }
+
+    @Test
+    public void testLocalRepositoryOverridePromotesConfiguredProperty() {
+        System.setProperty(LOCAL_REPOSITORY_PROPERTY, "/tmp/custom-m2-repo");
+        applyLocalRepositoryOverride();
+        assertEquals(System.getProperty(MAVEN_LOCAL_REPO_PROPERTY), "/tmp/custom-m2-repo");
+    }
+
+    @Test
+    public void testLocalRepositoryOverrideNoOpWhenNeitherSet() {
+        applyLocalRepositoryOverride();
+        assertNull(System.getProperty(MAVEN_LOCAL_REPO_PROPERTY));
+    }
+
+    @Test
+    public void testLocalRepositoryOverrideDoesNotClobberExplicitShrinkwrapProperty() {
+        System.setProperty(MAVEN_LOCAL_REPO_PROPERTY, "/tmp/operator-set-repo");
+        System.setProperty(LOCAL_REPOSITORY_PROPERTY, "/tmp/custom-m2-repo");
+        applyLocalRepositoryOverride();
+        assertEquals(System.getProperty(MAVEN_LOCAL_REPO_PROPERTY), "/tmp/operator-set-repo");
     }
 
 }


### PR DESCRIPTION
## Summary
- Confirmed `CachingShrinkwrapElementArtifactLoader` already honors Maven/Aether's on-disk local-repository cache (via ShrinkWrap resolver's own `MavenSettingsBuilder`): `~/.m2/repository` by default, overridable by `settings.xml`, overridable again by the `-Dmaven.repo.local` JVM system property. No environment-variable equivalent exists in ShrinkWrap itself.
- Fixes #48
- Adds `applyLocalRepositoryOverride()`, called once from the existing static initializer, which promotes our own `dev.getelements.elements.maven.repo.local` system property (or `ELEMENTS_MAVEN_REPO_LOCAL` env var) into ShrinkWrap's `maven.repo.local` property, so operators can redirect the cache — e.g. to an NFS-mounted, cluster-shared directory — via this platform's normal env-var/property convention instead of an undocumented raw JVM flag. Never overrides an already-explicit `maven.repo.local` system property.

## Test plan
- [x] `mvn -pl sdk-spi-shrinkwrap -am install -DskipTests` — compiles cleanly
- [x] `mvn -pl sdk-spi-shrinkwrap test` — all 12 tests pass (9 existing artifact-resolution tests + 3 new override-logic tests)
- [x] Manual end-to-end verification: ran with `-Ddev.getelements.elements.maven.repo.local=/tmp/custom-m2-repo` pointed at a fresh empty directory and confirmed real resolved artifact jars landed there instead of `~/.m2/repository`
