### PR TITLE
Permit java.sql for Elements and clarify classloader denial errors

### DIFF
--- a/sdk-spi/src/main/java/dev/getelements/elements/sdk/spi/ElementImplementationClassLoader.java
+++ b/sdk-spi/src/main/java/dev/getelements/elements/sdk/spi/ElementImplementationClassLoader.java
@@ -3,8 +3,10 @@ package dev.getelements.elements.sdk.spi;
 import dev.getelements.elements.sdk.PermittedPackages;
 import dev.getelements.elements.sdk.PermittedTypes;
 import dev.getelements.elements.sdk.annotation.ElementLocal;
+import dev.getelements.elements.sdk.annotation.ElementPackageRequest;
 import dev.getelements.elements.sdk.annotation.ElementPrivate;
 import dev.getelements.elements.sdk.annotation.ElementPublic;
+import dev.getelements.elements.sdk.annotation.ElementTypeRequest;
 import dev.getelements.elements.sdk.exception.SdkException;
 import dev.getelements.elements.sdk.record.ElementRecord;
 import dev.getelements.elements.sdk.record.ElementServiceRecord;
@@ -276,7 +278,24 @@ public class ElementImplementationClassLoader extends ClassLoader {
                 }
 
                 // Step 9: Default Deny
-                throw new ClassNotFoundException(name);
+                final var message = (
+                        "%s was denied by %s: it is not a registered service export, and no %s or %s in this " +
+                        "Element's package-info.java permits type or package %s. To permit this type, add " +
+                        "@%s(\"%s\") or @%s to the Element's package-info.java, or export it as a service."
+                ).formatted(
+                        name,
+                        ElementImplementationClassLoader.class.getSimpleName(),
+                        ElementTypeRequest.class.getSimpleName(),
+                        ElementPackageRequest.class.getSimpleName(),
+                        packageName,
+                        ElementPackageRequest.class.getSimpleName(),
+                        packageName,
+                        ElementTypeRequest.class.getSimpleName()
+                );
+
+                logger.trace(message);
+
+                throw new ClassNotFoundException(message);
 
             }
 

--- a/sdk/src/main/java/dev/getelements/elements/sdk/JavaSqlPermittedPackages.java
+++ b/sdk/src/main/java/dev/getelements/elements/sdk/JavaSqlPermittedPackages.java
@@ -1,0 +1,18 @@
+package dev.getelements.elements.sdk;
+
+public class JavaSqlPermittedPackages implements PermittedPackages {
+
+    @Override
+    public boolean test(final Package aPackage) {
+        final var name = aPackage.getName();
+        return name.equals("java.sql") || name.startsWith("java.sql.");
+    }
+
+    @Override
+    public String getDescription() {
+        return "Permits the usage of java.sql types (e.g. java.sql.Timestamp, java.sql.Date). Unlike java.base, " +
+                "the java.sql platform module is not loaded by the bootstrap class loader, so its types are not " +
+                "otherwise visible to Elements without this rule.";
+    }
+
+}

--- a/sdk/src/main/java/dev/getelements/elements/sdk/PermittedTypesClassLoader.java
+++ b/sdk/src/main/java/dev/getelements/elements/sdk/PermittedTypesClassLoader.java
@@ -1,6 +1,5 @@
 package dev.getelements.elements.sdk;
 
-import dev.getelements.elements.sdk.annotation.ElementDefinition;
 import dev.getelements.elements.sdk.annotation.ElementPrivate;
 import dev.getelements.elements.sdk.annotation.ElementPublic;
 import org.slf4j.Logger;
@@ -203,26 +202,38 @@ public class PermittedTypesClassLoader extends ClassLoader {
             return aClass;
         }
 
-        logger.trace(
-                "{} or {}'s package ({}) must have @{} annotation, be exposed via @{}, or one of [{}] or [{}]",
-                aClass.getSimpleName(),
-                aClass.getSimpleName(),
+        final var message = (
+                "%s was denied by %s: its package (%s) is not permitted by any registered %s or %s, and " +
+                "neither the type nor its package is annotated with @%s. Registered %s: [%s]. Registered %s: [%s]. " +
+                "To permit this type, register a %s/%s service (see META-INF/services), or annotate the type or " +
+                "its package with @%s."
+        ).formatted(
+                aClass.getName(),
+                PermittedTypesClassLoader.class.getSimpleName(),
                 aClass.getPackage(),
+                PermittedTypes.class.getSimpleName(),
+                PermittedPackages.class.getSimpleName(),
                 ElementPublic.class.getSimpleName(),
-                ElementDefinition.class.getSimpleName(),
+                PermittedTypes.class.getSimpleName(),
                 permittedTypes
                         .stream()
                         .map(Object::getClass)
                         .map(Objects::toString)
                         .collect(Collectors.joining(",")),
+                PermittedPackages.class.getSimpleName(),
                 permittedPackages
                         .stream()
                         .map(Object::getClass)
                         .map(Objects::toString)
-                        .collect(Collectors.joining(","))
+                        .collect(Collectors.joining(",")),
+                PermittedTypes.class.getSimpleName(),
+                PermittedPackages.class.getSimpleName(),
+                ElementPublic.class.getSimpleName()
         );
 
-        throw new ClassNotFoundException(aClass.getName());
+        logger.trace(message);
+
+        throw new ClassNotFoundException(message);
 
     }
 

--- a/sdk/src/main/resources/META-INF/services/dev.getelements.elements.sdk.PermittedPackages
+++ b/sdk/src/main/resources/META-INF/services/dev.getelements.elements.sdk.PermittedPackages
@@ -1,2 +1,3 @@
 dev.getelements.elements.sdk.LoggingPermittedPackages
 dev.getelements.elements.sdk.JakartaInjectPermittedPackages
+dev.getelements.elements.sdk.JavaSqlPermittedPackages


### PR DESCRIPTION
## Summary

Fixes #75 — customer Elements referencing `java.sql.Timestamp` (or any other `java.sql` type) were denied at load time with a bare `NoClassDefFoundError`/`ClassNotFoundException`, because only `java.base` is implicitly visible to Elements today (an accident of `PermittedTypesClassLoader` being constructed with `parent == null`, which the JDK treats as "delegate to the bootstrap loader" — see #75 for the full root-cause writeup).

This PR ships the two pieces we agreed were independently valuable without touching the deeper `PermittedTypesClassLoader.loadClass` bypass logic (tracked separately as follow-up item #2 in #75, since that's a bigger, security-sensitive refactor and not needed to unblock this specific gap):

- **`JavaSqlPermittedPackages`** (new, in `sdk`, registered via `META-INF/services/dev.getelements.elements.sdk.PermittedPackages`, following the exact pattern of `JakartaInjectPermittedPackages`/`MongoPermittedPackages`): permits the `java.sql` package and its subpackages for all Elements, so `java.sql.Timestamp` and friends work without every customer needing to discover `@ElementPackageRequest` on their own.
- **Better denial errors** in both places a class can be denied:
  - `PermittedTypesClassLoader.processVisibilityAnnotations` — the exception thrown now names the class, the classloader, which SPI/annotation mechanisms exist, and what's currently registered, instead of just the bare class name.
  - `ElementImplementationClassLoader`'s Step 9 default-deny — same treatment, naming `@ElementTypeRequest`/`@ElementPackageRequest` as the Element-side mechanisms to permit the type.

Neither loader previously surfaced *why* a class was denied in the thrown exception (only via a `trace`-level log line), so a customer hitting this saw a plain `NoClassDefFoundError` with no indication it was a deliberate Elements visibility gate rather than a real missing dependency.

## Test plan

- [x] `mvn -pl sdk,sdk-spi -am compile` — compiles clean
- [x] `mvn -pl sdk,sdk-spi install -DskipTests && mvn -pl sdk-test test -Dtest=ElementDefaultAttributeScopeTest,ElementLoaderTest,ApiElementLoaderTest,FlatElementPathLoaderTest,ElmDependencyOrderTest` — all pass, no regressions from the message/visibility changes
- [ ] Manual verification against the original customer repro (Element referencing `java.sql.Timestamp` in a Guice module) — recommend before merge, since that's the actual customer-blocking scenario