### PR TITLE
#49 Fix RootElementRegistry.unregister() self-comparison and iterator.remove() bugs

### DIFF
--- a/sdk-spi/pom.xml
+++ b/sdk-spi/pom.xml
@@ -36,6 +36,28 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.testng</groupId>
+                        <artifactId>testng</artifactId>
+                        <version>${testng.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/sdk-spi/src/main/java/dev/getelements/elements/sdk/spi/RootElementRegistry.java
+++ b/sdk-spi/src/main/java/dev/getelements/elements/sdk/spi/RootElementRegistry.java
@@ -80,12 +80,12 @@ public class RootElementRegistry implements MutableElementRegistry {
 
             check();
 
-            final var iterator = loaded.iterator();
-
-            while (iterator.hasNext()) {
-                final var loadedElement = iterator.next().element();
-                if (element.equals(element)) {
-                    iterator.remove();
+            // CopyOnWriteArrayList's iterator is a point-in-time snapshot and does not support
+            // Iterator#remove (throws UnsupportedOperationException); remove by value instead.
+            for (final var loadedElement : loaded) {
+                if (loadedElement.element().equals(element)) {
+                    loadedElement.subscriptions().unsubscribe();
+                    loaded.remove(loadedElement);
                     return true;
                 }
             }

--- a/sdk-spi/src/test/java/dev/getelements/elements/sdk/spi/RootElementRegistryTest.java
+++ b/sdk-spi/src/test/java/dev/getelements/elements/sdk/spi/RootElementRegistryTest.java
@@ -1,0 +1,85 @@
+package dev.getelements.elements.sdk.spi;
+
+import dev.getelements.elements.sdk.Element;
+import dev.getelements.elements.sdk.Event;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class RootElementRegistryTest {
+
+    @Test
+    public void unregisterRemovesTheRequestedElementNotJustTheFirst() {
+
+        final var registry = new RootElementRegistry();
+        final var first = mock(Element.class);
+        final var second = mock(Element.class);
+        final var third = mock(Element.class);
+
+        registry.register(first);
+        registry.register(second);
+        registry.register(third);
+
+        final var removed = registry.unregister(second);
+
+        assertTrue(removed);
+        assertEquals(registry.stream().toList(), java.util.List.of(first, third));
+
+    }
+
+    @Test
+    public void unregisterReturnsFalseForAnElementThatWasNeverRegistered() {
+
+        final var registry = new RootElementRegistry();
+        final var registered = mock(Element.class);
+        final var neverRegistered = mock(Element.class);
+
+        registry.register(registered);
+
+        final var removed = registry.unregister(neverRegistered);
+
+        assertFalse(removed);
+        assertEquals(registry.stream().toList(), java.util.List.of(registered));
+
+    }
+
+    @Test
+    public void unregisterDetachesTheElementFromFurtherEventsAndRegistryClose() {
+
+        final var registry = new RootElementRegistry();
+        final var element = mock(Element.class);
+
+        registry.register(element);
+        registry.unregister(element);
+
+        final var event = Event.builder().named("some.event").build();
+        registry.publish(event);
+
+        verify(element, never()).publish(event);
+
+        registry.close();
+
+        verify(element, never()).close();
+
+    }
+
+    @Test
+    public void registeredElementIsStillClosedWhenRegistryCloses() throws Exception {
+
+        final var registry = new RootElementRegistry();
+        final var element = mock(Element.class);
+
+        registry.register(element);
+        registry.close();
+
+        verify(element, times(1)).close();
+
+    }
+
+}


### PR DESCRIPTION
## Summary
- Audited the Element close cycle (`StandardElementRuntimeService.ActiveDeployment.close()`, `DirectoryElementPathLoader`'s reference-counted classloader closing, `GuiceSdkElement.close()`) — all correct on review, no changes needed there. Whether `Loader` implementations (`JakartaRsLoader`/`JakartaWebsocketLoader`) independently register handlers/resources is deferred to #50, which already covers that investigation.
- Fixes #49
- Found and fixed two independent bugs in `RootElementRegistry.unregister()`, currently inert since it has zero production callers:
  1. Its loop compared `element.equals(element)` — a self-comparison, always `true` — so it always removed the first entry in the list regardless of which element was actually requested.
  2. It called `iterator.remove()` on `loaded`, a `CopyOnWriteArrayList`, whose iterator is a point-in-time snapshot that does not support removal (throws `UnsupportedOperationException`). This would have crashed the first time `unregister()` was ever exercised for real, independent of bug #1.
- Fixed both, and `unregister()` now also unsubscribes the element's onEvent/onClose subscription so an unregistered element stops receiving published events and isn't double-closed when the registry itself later closes.

## Test plan
- [x] Added `sdk-spi` test infrastructure (none existed) plus `RootElementRegistryTest` covering: unregistering a middle element leaves the others correctly ordered, unregistering something never registered returns `false`, and an unregistered element is detached from further events/close
- [x] `mvn -pl sdk-spi -am install -DskipTests` — compiles cleanly
- [x] `mvn -pl sdk-spi test` — all 4 tests pass
- [x] `mvn -pl sdk-test-element,sdk-test-element-a,sdk-test-element-b,sdk-test -am install -DskipTests && mvn -pl sdk-test test` — full 27-test suite still passes, no regression
