### PR TITLE
Fix null displayName validation failure on OAuth2 auto-create-profile

### DIFF
--- a/service-test/src/test/java/dev/getelements/elements/service/OAuth2AuthServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OAuth2AuthServiceTest.java
@@ -65,6 +65,9 @@ public class OAuth2AuthServiceTest {
     @Inject
     private ProfileDao profileDao;
 
+    @Inject
+    private NameService nameService;
+
     @BeforeMethod
     public void setup() {
 
@@ -175,6 +178,7 @@ public class OAuth2AuthServiceTest {
 
         when(applicationDao.findApplication("app-1")).thenReturn(java.util.Optional.of(application));
         when(profileDao.findPrimaryProfile("user-1", "app-1")).thenReturn(java.util.Optional.empty());
+        when(nameService.generateQualifiedName()).thenReturn("brave-otter");
 
         final var createdProfile = new Profile();
         createdProfile.setId("profile-1");
@@ -186,6 +190,7 @@ public class OAuth2AuthServiceTest {
         verify(profileDao).createSlottedProfile(profileCaptor.capture(), anyMap());
         assertEquals(profileCaptor.getValue().getUser(), user);
         assertEquals(profileCaptor.getValue().getApplication(), application);
+        assertEquals(profileCaptor.getValue().getDisplayName(), "brave-otter");
 
         final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
         verify(sessionDao).create(sessionCaptor.capture());

--- a/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
@@ -17,6 +17,7 @@ import dev.getelements.elements.sdk.model.session.OAuth2SessionRequest;
 import dev.getelements.elements.sdk.model.session.Session;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
 import dev.getelements.elements.sdk.model.user.User;
+import dev.getelements.elements.sdk.service.name.NameService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.client.Client;
@@ -35,6 +36,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class OAuth2AuthServiceOperations {
 
     private static final Logger logger = LoggerFactory.getLogger(OAuth2AuthServiceOperations.class);
+
+    private NameService nameService;
 
     private ProfileDao profileDao;
 
@@ -116,6 +119,7 @@ public class OAuth2AuthServiceOperations {
 
         final var profile = new Profile();
         profile.setUser(user);
+        profile.setDisplayName(getNameService().generateQualifiedName());
         profile.setApplication(application);
 
         return getProfileDao().createSlottedProfile(profile, Map.of());
@@ -259,6 +263,15 @@ public class OAuth2AuthServiceOperations {
         }
 
         return node;
+    }
+
+    public NameService getNameService() {
+        return nameService;
+    }
+
+    @Inject
+    public void setNameService(NameService nameService) {
+        this.nameService = nameService;
     }
 
     public ProfileDao getProfileDao() {


### PR DESCRIPTION
## Summary
- Fixes #80 — logging in via a generic OAuth2 scheme (e.g. Meta/Oculus) with `autoCreateProfile` enabled threw `ValidationFailureException` on `displayName` because `OAuth2AuthServiceOperations.autoCreatePrimaryProfileIfConfigured()` built a `Profile` with only `user`/`application` set.
- Mirrors the existing OIDC sibling (`OidcAuthServiceOperations.map()`), which already falls back to `NameService.generateQualifiedName()` for the display name — that's why Google/Apple (OIDC-configured) logins never hit this, while Meta (generic-OAuth2-configured) did.
- Injects `NameService` into `OAuth2AuthServiceOperations` and sets `profile.setDisplayName(getNameService().generateQualifiedName())` before calling `createSlottedProfile`.

## Test plan
- [x] `mvn -pl service-test -Dtest=OAuth2AuthServiceTest test` — all 10 cases pass
- [x] Updated `testAutoCreatesPrimaryProfileWhenConfigured` to stub `NameService.generateQualifiedName()` and assert the created profile's `displayName`, so the real Bean Validation gap can't silently regress again
- [x] `mvn -pl service,service-test -am install -DskipTests` builds clean

cc @andrew-menard (original reporter) — findings are also posted on the issue.