### PR TITLE
Fix null displayName validation failure on OAuth2 auto-create-profile

### DIFF
--- a/service-test/src/test/java/dev/getelements/elements/service/OAuth2AuthServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/OAuth2AuthServiceTest.java
@@ -65,6 +65,9 @@ public class OAuth2AuthServiceTest {
     @Inject
     private ProfileDao profileDao;
 
+    @Inject
+    private NameService nameService;
+
     @BeforeMethod
     public void setup() {
 
@@ -175,6 +178,7 @@ public class OAuth2AuthServiceTest {
 
         when(applicationDao.findApplication("app-1")).thenReturn(java.util.Optional.of(application));
         when(profileDao.findPrimaryProfile("user-1", "app-1")).thenReturn(java.util.Optional.empty());
+        when(nameService.generateQualifiedName()).thenReturn("brave-otter");
 
         final var createdProfile = new Profile();
         createdProfile.setId("profile-1");
@@ -186,6 +190,7 @@ public class OAuth2AuthServiceTest {
         verify(profileDao).createSlottedProfile(profileCaptor.capture(), anyMap());
         assertEquals(profileCaptor.getValue().getUser(), user);
         assertEquals(profileCaptor.getValue().getApplication(), application);
+        assertEquals(profileCaptor.getValue().getDisplayName(), "brave-otter");
 
         final var sessionCaptor = ArgumentCaptor.forClass(Session.class);
         verify(sessionDao).create(sessionCaptor.capture());

--- a/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
+++ b/service/src/main/java/dev/getelements/elements/service/auth/oauth2/OAuth2AuthServiceOperations.java
@@ -17,6 +17,7 @@ import dev.getelements.elements.sdk.model.session.OAuth2SessionRequest;
 import dev.getelements.elements.sdk.model.session.Session;
 import dev.getelements.elements.sdk.model.session.SessionCreation;
 import dev.getelements.elements.sdk.model.user.User;
+import dev.getelements.elements.sdk.service.name.NameService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.ws.rs.client.Client;
@@ -35,6 +36,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class OAuth2AuthServiceOperations {
 
     private static final Logger logger = LoggerFactory.getLogger(OAuth2AuthServiceOperations.class);
+
+    private NameService nameService;
 
     private ProfileDao profileDao;
 
@@ -116,6 +119,7 @@ public class OAuth2AuthServiceOperations {
 
         final var profile = new Profile();
         profile.setUser(user);
+        profile.setDisplayName(getNameService().generateQualifiedName());
         profile.setApplication(application);
 
         return getProfileDao().createSlottedProfile(profile, Map.of());
@@ -259,6 +263,15 @@ public class OAuth2AuthServiceOperations {
         }
 
         return node;
+    }
+
+    public NameService getNameService() {
+        return nameService;
+    }
+
+    @Inject
+    public void setNameService(NameService nameService) {
+        this.nameService = nameService;
     }
 
     public ProfileDao getProfileDao() {


### PR DESCRIPTION
## Summary
- `autoCreatePrimaryProfileIfConfigured()` built a `Profile` with only `user` and `application` set, so `createSlottedProfile` always failed Bean Validation on the `@NotNull` `displayName` field.
- Mirrors the OIDC sibling (`OidcAuthServiceOperations.map()`) by falling back to `NameService.generateQualifiedName()`.

Fixes #80

Cherry-picked from #82, which was mistakenly branched off `release/3.9` (already at `3.9.0-rc-9`, a real published version) instead of `main`. That caused CI's Central "no-op" snapshot deploy to fail because Central won't accept a re-upload of an already-published RC version — unrelated to this code change. Retargeting to `main` builds against `3.9.0-SNAPSHOT`, which Central genuinely no-ops on. #82 will be closed in favor of this PR; once merged to `main`, this fix will be merged into `release/3.9` to cut a new RC.

## Test plan
- [x] `OAuth2AuthServiceTest` updated to assert `displayName` is populated via `NameService.generateQualifiedName()`
- [ ] CI passes on `main` (3.9.0-SNAPSHOT, no Central collision)