### PR TITLE
Add Mongo-backed Email Templates with admin UI editor

### DIFF
--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/mapper/MongoEmailTemplateMapper.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/mapper/MongoEmailTemplateMapper.java
@@ -1,0 +1,21 @@
+package dev.getelements.elements.dao.mongo.mapper;
+
+import dev.getelements.elements.dao.mongo.model.schema.email.MongoEmailTemplate;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
+import dev.getelements.elements.sdk.model.util.MapperRegistry;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(uses = {PropertyConverters.class})
+public interface MongoEmailTemplateMapper extends MapperRegistry.ReversibleMapper<MongoEmailTemplate, EmailTemplate> {
+
+    @Override
+    @Mapping(target = "id", source = "objectId")
+    EmailTemplate forward(MongoEmailTemplate source);
+
+    @Override
+    @InheritInverseConfiguration
+    MongoEmailTemplate reverse(EmailTemplate source);
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/schema/email/MongoEmailTemplate.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/model/schema/email/MongoEmailTemplate.java
@@ -1,0 +1,100 @@
+package dev.getelements.elements.dao.mongo.model.schema.email;
+
+import dev.morphia.annotations.*;
+import org.bson.types.ObjectId;
+
+import java.util.Date;
+
+@Entity(value = "email_template", useDiscriminator = false)
+public class MongoEmailTemplate {
+
+    @Id
+    private ObjectId objectId;
+
+    @Property
+    @Indexed(options = @IndexOptions(unique = true, sparse = true))
+    private String key;
+
+    @Property
+    private String name;
+
+    @Property
+    private String subject;
+
+    @Property
+    private String body;
+
+    @Property
+    private String description;
+
+    @Property
+    private Date createdAt;
+
+    @Property
+    private Date updatedAt;
+
+    public ObjectId getObjectId() {
+        return objectId;
+    }
+
+    public void setObjectId(ObjectId objectId) {
+        this.objectId = objectId;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+}

--- a/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/schema/email/MongoEmailTemplateDao.java
+++ b/mongo-dao/src/main/java/dev/getelements/elements/dao/mongo/schema/email/MongoEmailTemplateDao.java
@@ -1,0 +1,223 @@
+package dev.getelements.elements.dao.mongo.schema.email;
+
+import dev.getelements.elements.sdk.Event;
+import dev.getelements.elements.sdk.dao.EmailTemplateDao;
+import dev.getelements.elements.dao.mongo.MongoDBUtils;
+import dev.getelements.elements.dao.mongo.UpdateBuilder;
+import dev.getelements.elements.dao.mongo.model.schema.email.MongoEmailTemplate;
+import dev.getelements.elements.sdk.model.exception.schema.EmailTemplateNotFoundException;
+import dev.getelements.elements.sdk.model.Pagination;
+import dev.getelements.elements.sdk.model.ValidationGroups;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
+import dev.getelements.elements.sdk.model.util.ValidationHelper;
+import dev.getelements.elements.sdk.model.util.MapperRegistry;
+import dev.morphia.Datastore;
+import dev.morphia.ModifyOptions;
+import dev.morphia.UpdateOptions;
+
+import jakarta.inject.Inject;
+import java.util.Date;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static com.mongodb.client.model.ReturnDocument.AFTER;
+import static dev.morphia.query.filters.Filters.eq;
+import static dev.morphia.query.filters.Filters.exists;
+import static dev.morphia.query.updates.UpdateOperators.set;
+import static dev.morphia.query.updates.UpdateOperators.unset;
+
+public class MongoEmailTemplateDao implements EmailTemplateDao {
+
+    private MongoDBUtils mongoDBUtils;
+
+    private Datastore datastore;
+
+    private MapperRegistry beanMapperRegistry;
+
+    private ValidationHelper validationHelper;
+
+    private Consumer<Event> eventPublisher;
+
+    @Override
+    public Pagination<EmailTemplate> getEmailTemplates(final int offset, final int count) {
+
+        final var mongoQuery = getDatastore()
+                .find(MongoEmailTemplate.class)
+                .filter(exists("key"));
+
+        return getMongoDBUtils().paginationFromQuery(mongoQuery, offset, count, this::transform);
+
+    }
+
+    @Override
+    public Optional<EmailTemplate> findEmailTemplate(final String id) {
+        return findMongoEmailTemplate(id).map(this::transform);
+    }
+
+    public Optional<MongoEmailTemplate> findMongoEmailTemplate(final String id) {
+        return getMongoDBUtils()
+                .parse(id)
+                .flatMap(objectId -> Optional.ofNullable(getDatastore()
+                        .find(MongoEmailTemplate.class)
+                        .filter(eq("_id", objectId), exists("key"))
+                        .first()));
+    }
+
+    @Override
+    public Optional<EmailTemplate> findEmailTemplateByKey(final String key) {
+        return findMongoEmailTemplateByKey(key).map(this::transform);
+    }
+
+    public Optional<MongoEmailTemplate> findMongoEmailTemplateByKey(final String key) {
+
+        final var template = getDatastore()
+                .find(MongoEmailTemplate.class)
+                .filter(eq("key", key))
+                .first();
+
+        return Optional.ofNullable(template);
+
+    }
+
+    @Override
+    public EmailTemplate createEmailTemplate(final EmailTemplate emailTemplate) {
+
+        getValidationHelper().validateModel(emailTemplate, ValidationGroups.Insert.class);
+
+        final var now = new Date();
+
+        final var toInsert = getBeanMapper().map(emailTemplate, MongoEmailTemplate.class);
+        toInsert.setCreatedAt(now);
+        toInsert.setUpdatedAt(now);
+
+        final var inserted = getMongoDBUtils().perform(ds -> ds.save(toInsert));
+        final var createdTemplate = transform(inserted);
+
+        getEventPublisher().accept(Event.builder()
+                .argument(createdTemplate)
+                .named(EMAIL_TEMPLATE_CREATED)
+                .build());
+
+        return createdTemplate;
+    }
+
+    @Override
+    public EmailTemplate updateEmailTemplate(final EmailTemplate emailTemplate) {
+
+        getValidationHelper().validateModel(emailTemplate, ValidationGroups.Update.class);
+
+        final var objectId = getMongoDBUtils().parseOrThrow(
+                emailTemplate.getId(),
+                EmailTemplateNotFoundException::new
+        );
+
+        final var options = new ModifyOptions()
+                .upsert(false)
+                .returnDocument(AFTER);
+
+        final var updated = getDatastore().find(MongoEmailTemplate.class)
+                .filter(eq("_id", objectId), exists("key"))
+                .modify(options,
+                        set("name", emailTemplate.getName()),
+                        set("subject", emailTemplate.getSubject()),
+                        set("body", emailTemplate.getBody()),
+                        set("description", emailTemplate.getDescription() == null ? "" : emailTemplate.getDescription()),
+                        set("updatedAt", new Date())
+                );
+
+        if (updated == null) {
+            throw new EmailTemplateNotFoundException("Email template with id not found.");
+        }
+
+        final var updatedTemplate = transform(updated);
+
+        getEventPublisher().accept(Event.builder()
+                .argument(updatedTemplate)
+                .named(EMAIL_TEMPLATE_UPDATED)
+                .build());
+
+        return updatedTemplate;
+
+    }
+
+    @Override
+    public void deleteEmailTemplate(final String id) {
+
+        final var objectId = getMongoDBUtils().parseOrThrow(id, EmailTemplateNotFoundException::new);
+
+        final var query = getDatastore()
+                .find(MongoEmailTemplate.class)
+                .filter(
+                        exists("key"),
+                        eq("_id", objectId)
+                );
+
+        final var existing = query.first();
+
+        final var result = new UpdateBuilder()
+                .with(unset("key"))
+                .execute(query, new UpdateOptions().upsert(false));
+
+        if (result.getModifiedCount() == 0) {
+            throw new EmailTemplateNotFoundException();
+        }
+
+        if (existing != null) {
+            getEventPublisher().accept(Event.builder()
+                    .argument(transform(existing))
+                    .named(EMAIL_TEMPLATE_DELETED)
+                    .build());
+        }
+
+    }
+
+    public EmailTemplate transform(final MongoEmailTemplate mongoEmailTemplate) {
+        return getBeanMapper().map(mongoEmailTemplate, EmailTemplate.class);
+    }
+
+    public MongoDBUtils getMongoDBUtils() {
+        return mongoDBUtils;
+    }
+
+    @Inject
+    public void setMongoDBUtils(MongoDBUtils mongoDBUtils) {
+        this.mongoDBUtils = mongoDBUtils;
+    }
+
+    public Datastore getDatastore() {
+        return datastore;
+    }
+
+    @Inject
+    public void setDatastore(Datastore datastore) {
+        this.datastore = datastore;
+    }
+
+    public MapperRegistry getBeanMapper() {
+        return beanMapperRegistry;
+    }
+
+    @Inject
+    public void setBeanMapper(MapperRegistry beanMapperRegistry) {
+        this.beanMapperRegistry = beanMapperRegistry;
+    }
+
+    public ValidationHelper getValidationHelper() {
+        return validationHelper;
+    }
+
+    @Inject
+    public void setValidationHelper(ValidationHelper validationHelper) {
+        this.validationHelper = validationHelper;
+    }
+
+    public Consumer<Event> getEventPublisher() {
+        return eventPublisher;
+    }
+
+    @Inject
+    public void setEventPublisher(Consumer<Event> eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+}

--- a/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDaoModule.java
+++ b/mongo-guice/src/main/java/dev/getelements/elements/dao/mongo/guice/MongoDaoModule.java
@@ -41,6 +41,7 @@ import dev.getelements.elements.dao.mongo.receipt.MongoGooglePlayIapReceiptDao;
 import dev.getelements.elements.dao.mongo.receipt.MongoReceiptDao;
 import dev.getelements.elements.dao.mongo.savedata.MongoSaveDataDocumentDao;
 import dev.getelements.elements.dao.mongo.schema.MongoMetadataSpecDao;
+import dev.getelements.elements.dao.mongo.schema.email.MongoEmailTemplateDao;
 import dev.getelements.elements.dao.mongo.system.MongoElementDeploymentDao;
 import dev.getelements.elements.dao.mongo.ucode.MongoUniqueCodeDao;
 import dev.getelements.elements.dao.mongo.ucode.OffensiveWordFilterProvider;
@@ -115,6 +116,7 @@ public class MongoDaoModule extends PrivateModule {
         bind(DatabaseHealthStatusDao.class).to(MongoDatabaseHealthStatusDao.class);
         bind(MetadataDao.class).to(MongoMetadataDao.class);
         bind(MetadataSpecDao.class).to(MongoMetadataSpecDao.class);
+        bind(EmailTemplateDao.class).to(MongoEmailTemplateDao.class);
         bind(SaveDataDocumentDao.class).to(MongoSaveDataDocumentDao.class);
         bind(AuthSchemeDao.class).to(MongoAuthSchemeDao.class);
         bind(OidcAuthSchemeDao.class).to(MongoOidcAuthSchemeDao.class);
@@ -202,6 +204,7 @@ public class MongoDaoModule extends PrivateModule {
         expose(DatabaseHealthStatusDao.class);
         expose(MetadataDao.class);
         expose(MetadataSpecDao.class);
+        expose(EmailTemplateDao.class);
         expose(SaveDataDocumentDao.class);
         expose(AuthSchemeDao.class);
         expose(OidcAuthSchemeDao.class);

--- a/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MongoEmailTemplateDaoTest.java
+++ b/mongo-test/src/test/java/dev/getelements/elements/dao/mongo/test/MongoEmailTemplateDaoTest.java
@@ -1,0 +1,146 @@
+package dev.getelements.elements.dao.mongo.test;
+
+import dev.getelements.elements.sdk.ElementRegistry;
+import dev.getelements.elements.sdk.dao.EmailTemplateDao;
+import dev.getelements.elements.sdk.model.exception.schema.EmailTemplateNotFoundException;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
+import dev.getelements.elements.sdk.model.util.PaginationWalker;
+import jakarta.inject.Named;
+import org.bson.types.ObjectId;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import jakarta.inject.Inject;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static dev.getelements.elements.sdk.ElementRegistry.ROOT;
+import static dev.getelements.elements.sdk.dao.EmailTemplateDao.*;
+import static org.testng.Assert.*;
+
+@Guice(modules = IntegrationTestModule.class)
+public class MongoEmailTemplateDaoTest {
+
+    private EmailTemplate working;
+
+    private EmailTemplateDao emailTemplateDao;
+
+    @Inject
+    @Named(ROOT)
+    private ElementRegistry elementRegistry;
+
+    private final Set<String> createdEventIds = ConcurrentHashMap.newKeySet();
+
+    private final Set<String> updatedEventIds = ConcurrentHashMap.newKeySet();
+
+    private final Set<String> deletedEventIds = ConcurrentHashMap.newKeySet();
+
+    @BeforeClass
+    public void setupEventHandlers() {
+        elementRegistry.onEvent(ev -> {
+            switch (ev.getEventName()) {
+                case EMAIL_TEMPLATE_CREATED -> createdEventIds.add(ev.getEventArgument(0, EmailTemplate.class).getId());
+                case EMAIL_TEMPLATE_UPDATED -> updatedEventIds.add(ev.getEventArgument(0, EmailTemplate.class).getId());
+                case EMAIL_TEMPLATE_DELETED -> deletedEventIds.add(ev.getEventArgument(0, EmailTemplate.class).getId());
+            }
+        });
+    }
+
+    @Test(groups = "create")
+    public void testCreateEmailTemplate() {
+
+        final var template = new EmailTemplate();
+        template.setKey("com.example.test." + UUID.randomUUID());
+        template.setName("Test Template");
+        template.setSubject("Test Subject");
+        template.setBody("<p>Test Body</p>");
+        template.setDescription("A test template.");
+
+        working = getEmailTemplateDao().createEmailTemplate(template);
+
+        assertNotNull(working.getId());
+        assertEquals(working.getKey(), template.getKey());
+        assertEquals(working.getName(), template.getName());
+        assertEquals(working.getSubject(), template.getSubject());
+        assertEquals(working.getBody(), template.getBody());
+
+        assertTrue(createdEventIds.contains(working.getId()),
+                "Expected EMAIL_TEMPLATE_CREATED event for " + working.getId());
+
+    }
+
+    @Test(groups = "update", dependsOnGroups = "create")
+    public void testUpdateEmailTemplate() {
+
+        working.setName("Updated Name");
+        working.setSubject("Updated Subject");
+        working.setBody("<p>Updated Body</p>");
+
+        final var updated = getEmailTemplateDao().updateEmailTemplate(working);
+        assertEquals(updated.getName(), "Updated Name");
+        assertEquals(updated.getSubject(), "Updated Subject");
+        assertEquals(updated.getBody(), "<p>Updated Body</p>");
+        working = updated;
+
+        assertTrue(updatedEventIds.contains(working.getId()),
+                "Expected EMAIL_TEMPLATE_UPDATED event for " + working.getId());
+
+    }
+
+    @Test(groups = "fetch", dependsOnGroups = "update")
+    public void testGetSingleById() {
+        final var fetched = getEmailTemplateDao().getEmailTemplate(working.getId());
+        assertEquals(fetched.getId(), working.getId());
+    }
+
+    @Test(groups = "fetch", dependsOnGroups = "update")
+    public void testGetSingleByKey() {
+        final var fetched = getEmailTemplateDao().getEmailTemplateByKey(working.getKey());
+        assertEquals(fetched.getId(), working.getId());
+    }
+
+    @Test(groups = "fetch", dependsOnGroups = "update")
+    public void testGetMultiple() {
+        final var templates = new PaginationWalker().toList(getEmailTemplateDao()::getEmailTemplates);
+        assertTrue(templates.stream().anyMatch(t -> t.getId().equals(working.getId())));
+    }
+
+    @Test(groups = "delete", dependsOnGroups = "fetch")
+    public void testDelete() {
+        getEmailTemplateDao().deleteEmailTemplate(working.getId());
+        assertTrue(deletedEventIds.contains(working.getId()),
+                "Expected EMAIL_TEMPLATE_DELETED event for " + working.getId());
+    }
+
+    @Test(groups = "delete",
+            dependsOnMethods = "testDelete",
+            expectedExceptions = EmailTemplateNotFoundException.class)
+    public void testDoubleDelete() {
+        getEmailTemplateDao().deleteEmailTemplate(working.getId());
+    }
+
+    @Test(groups = "delete",
+            dependsOnMethods = "testDelete",
+            expectedExceptions = EmailTemplateNotFoundException.class)
+    public void testTemplateIsDeleted() {
+        getEmailTemplateDao().getEmailTemplate(working.getId());
+    }
+
+    @Test(expectedExceptions = EmailTemplateNotFoundException.class)
+    public void testEmailTemplateNotFoundById() {
+        final var objectId = new ObjectId();
+        getEmailTemplateDao().getEmailTemplate(objectId.toString());
+    }
+
+    public EmailTemplateDao getEmailTemplateDao() {
+        return emailTemplateDao;
+    }
+
+    @Inject
+    public void setEmailTemplateDao(EmailTemplateDao emailTemplateDao) {
+        this.emailTemplateDao = emailTemplateDao;
+    }
+
+}

--- a/rest-api/src/main/java/dev/getelements/elements/rest/schema/email/EmailTemplateResource.java
+++ b/rest-api/src/main/java/dev/getelements/elements/rest/schema/email/EmailTemplateResource.java
@@ -1,0 +1,88 @@
+package dev.getelements.elements.rest.schema.email;
+
+import com.google.common.base.Strings;
+import dev.getelements.elements.sdk.model.exception.NotFoundException;
+import dev.getelements.elements.sdk.model.Pagination;
+import dev.getelements.elements.sdk.model.schema.email.CreateEmailTemplateRequest;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
+import dev.getelements.elements.sdk.model.schema.email.UpdateEmailTemplateRequest;
+import dev.getelements.elements.sdk.service.schema.email.EmailTemplateService;
+import io.swagger.v3.oas.annotations.Operation;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/email_template")
+public class EmailTemplateResource {
+
+    private EmailTemplateService emailTemplateService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Get Email Templates",
+            description = "Gets a pagination of Email Templates for the given query.")
+    public Pagination<EmailTemplate> getEmailTemplates(
+            @QueryParam("offset") @DefaultValue("0") final int offset,
+            @QueryParam("count")  @DefaultValue("20") final int count) {
+        return getEmailTemplateService().getEmailTemplates(offset, count);
+    }
+
+    @GET
+    @Path("{emailTemplateIdOrKey}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Gets a specific Email Template",
+            description = "Gets a specific EmailTemplate by id or key.")
+    public EmailTemplate getEmailTemplate(@PathParam("emailTemplateIdOrKey") String emailTemplateIdOrKey) {
+        return getEmailTemplateService().getEmailTemplate(emailTemplateIdOrKey);
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Creates a new Email Template",
+            description = "Creates a new Email Template.")
+    public EmailTemplate createEmailTemplate(final CreateEmailTemplateRequest createEmailTemplateRequest) {
+        return getEmailTemplateService().createEmailTemplate(createEmailTemplateRequest);
+    }
+
+    @PUT
+    @Path("{emailTemplateId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Updates an Email Template",
+            description = "Updates an EmailTemplate with the specified id.")
+    public EmailTemplate updateEmailTemplate(
+            @PathParam("emailTemplateId") String emailTemplateId,
+            final UpdateEmailTemplateRequest updateEmailTemplateRequest) {
+        return getEmailTemplateService().updateEmailTemplate(emailTemplateId, updateEmailTemplateRequest);
+    }
+
+    @DELETE
+    @Path("{emailTemplateId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Deletes an Email Template",
+            description = "Deletes an EmailTemplate with the specified id.")
+    public void deleteEmailTemplate(@PathParam("emailTemplateId") String emailTemplateId) {
+
+        emailTemplateId = Strings.nullToEmpty(emailTemplateId).trim();
+
+        if (emailTemplateId.isEmpty()) {
+            throw new NotFoundException();
+        }
+
+        getEmailTemplateService().deleteEmailTemplate(emailTemplateId);
+    }
+
+    public EmailTemplateService getEmailTemplateService() {
+        return emailTemplateService;
+    }
+
+    @Inject
+    public void setEmailTemplateService(EmailTemplateService emailTemplateService) {
+        this.emailTemplateService = emailTemplateService;
+    }
+
+}

--- a/sdk-dao/src/main/java/dev/getelements/elements/sdk/dao/EmailTemplateDao.java
+++ b/sdk-dao/src/main/java/dev/getelements/elements/sdk/dao/EmailTemplateDao.java
@@ -1,0 +1,120 @@
+package dev.getelements.elements.sdk.dao;
+
+import dev.getelements.elements.sdk.model.exception.schema.EmailTemplateNotFoundException;
+import dev.getelements.elements.sdk.model.Pagination;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
+import dev.getelements.elements.sdk.annotation.ElementEventProducer;
+import dev.getelements.elements.sdk.annotation.ElementServiceExport;
+
+import java.util.Optional;
+
+@ElementServiceExport
+@ElementEventProducer(
+        value = EmailTemplateDao.EMAIL_TEMPLATE_CREATED,
+        parameters = EmailTemplate.class,
+        description = "Called when an email template was created."
+)
+@ElementEventProducer(
+        value = EmailTemplateDao.EMAIL_TEMPLATE_CREATED,
+        parameters = {EmailTemplate.class, Transaction.class},
+        description = "Called when an email template was created. This variant includes the transaction so that reactions to this event can be performed in the same transaction."
+)
+@ElementEventProducer(
+        value = EmailTemplateDao.EMAIL_TEMPLATE_UPDATED,
+        parameters = EmailTemplate.class,
+        description = "Called when an email template was updated."
+)
+@ElementEventProducer(
+        value = EmailTemplateDao.EMAIL_TEMPLATE_UPDATED,
+        parameters = {EmailTemplate.class, Transaction.class},
+        description = "Called when an email template was updated. This variant includes the transaction so that reactions to this event can be performed in the same transaction."
+)
+@ElementEventProducer(
+        value = EmailTemplateDao.EMAIL_TEMPLATE_DELETED,
+        parameters = EmailTemplate.class,
+        description = "Called when an email template was deleted."
+)
+@ElementEventProducer(
+        value = EmailTemplateDao.EMAIL_TEMPLATE_DELETED,
+        parameters = {EmailTemplate.class, Transaction.class},
+        description = "Called when an email template was deleted. This variant includes the transaction so that reactions to this event can be performed in the same transaction."
+)
+public interface EmailTemplateDao {
+
+    String EMAIL_TEMPLATE_CREATED = "dev.getelements.elements.sdk.model.dao.email.template.created";
+
+    String EMAIL_TEMPLATE_UPDATED = "dev.getelements.elements.sdk.model.dao.email.template.updated";
+
+    String EMAIL_TEMPLATE_DELETED = "dev.getelements.elements.sdk.model.dao.email.template.deleted";
+
+    /**
+     * Lists all {@link EmailTemplate} instances.
+     *
+     * @param offset
+     * @param count
+     * @return a {@link Pagination} of {@link EmailTemplate} instances
+     */
+    Pagination<EmailTemplate> getEmailTemplates(int offset, int count);
+
+    /**
+     * Finds an email template by its id.
+     *
+     * @param id the email template ID
+     * @return an {@link Optional} possibly containing the {@link EmailTemplate}
+     */
+    Optional<EmailTemplate> findEmailTemplate(String id);
+
+    /**
+     * Fetches a specific {@link EmailTemplate} instance based on ID. If not found, an
+     * exception is raised.
+     *
+     * @param id the email template ID
+     * @return the {@link EmailTemplate}, never null
+     */
+    default EmailTemplate getEmailTemplate(String id) {
+        return findEmailTemplate(id).orElseThrow(EmailTemplateNotFoundException::new);
+    }
+
+    /**
+     * Finds an email template by its key.
+     *
+     * @param key the email template key
+     * @return an {@link Optional} possibly containing the {@link EmailTemplate}
+     */
+    Optional<EmailTemplate> findEmailTemplateByKey(String key);
+
+    /**
+     * Fetches a specific {@link EmailTemplate} instance based on key. If not found, an
+     * exception is raised.
+     *
+     * @param key the email template key
+     * @return the {@link EmailTemplate}, never null
+     */
+    default EmailTemplate getEmailTemplateByKey(final String key) {
+        return findEmailTemplateByKey(key).orElseThrow(EmailTemplateNotFoundException::new);
+    }
+
+    /**
+     * Creates a new email template.
+     *
+     * @param emailTemplate
+     * @return
+     */
+    EmailTemplate createEmailTemplate(EmailTemplate emailTemplate);
+
+    /**
+     * Updates an existing email template.
+     *
+     * @param emailTemplate
+     * @return
+     */
+    EmailTemplate updateEmailTemplate(EmailTemplate emailTemplate);
+
+    /**
+     * Deletes the {@link EmailTemplate} with the supplied ID.
+     *
+     * @param id the email template ID.
+     */
+    void deleteEmailTemplate(String id);
+
+}

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/exception/schema/EmailTemplateNotFoundException.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/exception/schema/EmailTemplateNotFoundException.java
@@ -1,0 +1,46 @@
+package dev.getelements.elements.sdk.model.exception.schema;
+
+import dev.getelements.elements.sdk.model.exception.NotFoundException;
+
+/** Thrown when an email template cannot be found. */
+public class EmailTemplateNotFoundException extends NotFoundException {
+
+    /** Creates a new instance. */
+    public EmailTemplateNotFoundException() {}
+
+    /**
+     * Creates a new instance with the given message.
+     * @param message the detail message
+     */
+    public EmailTemplateNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance with the given message and cause.
+     * @param message the detail message
+     * @param cause the cause
+     */
+    public EmailTemplateNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance with the given cause.
+     * @param cause the cause
+     */
+    public EmailTemplateNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param message the detail message
+     * @param cause the cause
+     * @param enableSuppression whether suppression is enabled
+     * @param writableStackTrace whether the stack trace is writable
+     */
+    public EmailTemplateNotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/schema/email/CreateEmailTemplateRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/schema/email/CreateEmailTemplateRequest.java
@@ -1,0 +1,154 @@
+package dev.getelements.elements.sdk.model.schema.email;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Represents a request to create an {@link EmailTemplate}. */
+@Schema(description = "Represents a request to create an EmailTemplate.")
+public class CreateEmailTemplateRequest implements Serializable {
+
+    /** Creates a new instance. */
+    public CreateEmailTemplateRequest() {}
+
+    @NotNull
+    @Schema(description = "The unique key used to reference this email template.")
+    private String key;
+
+    @NotNull
+    @Schema(description = "The display name of the email template.")
+    private String name;
+
+    @NotNull
+    @Schema(description = "The subject line of the email template.")
+    private String subject;
+
+    @NotNull
+    @Schema(description = "The HTML body of the email template.")
+    private String body;
+
+    @Schema(description = "An optional human-readable description of the email template.")
+    private String description;
+
+    /**
+     * Returns the unique key of the email template.
+     *
+     * @return the key
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Sets the unique key of the email template.
+     *
+     * @param key the key
+     */
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Returns the display name of the email template.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the display name of the email template.
+     *
+     * @param name the name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the subject line of the email template.
+     *
+     * @return the subject
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * Sets the subject line of the email template.
+     *
+     * @param subject the subject
+     */
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+     * Returns the HTML body of the email template.
+     *
+     * @return the body
+     */
+    public String getBody() {
+        return body;
+    }
+
+    /**
+     * Sets the HTML body of the email template.
+     *
+     * @param body the body
+     */
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    /**
+     * Returns the description of the email template.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the description of the email template.
+     *
+     * @param description the description
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreateEmailTemplateRequest that = (CreateEmailTemplateRequest) o;
+        return Objects.equals(getKey(), that.getKey()) &&
+                Objects.equals(getName(), that.getName()) &&
+                Objects.equals(getSubject(), that.getSubject()) &&
+                Objects.equals(getBody(), that.getBody()) &&
+                Objects.equals(getDescription(), that.getDescription());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getKey(), getName(), getSubject(), getBody(), getDescription());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("CreateEmailTemplateRequest{");
+        sb.append("key='").append(key).append('\'');
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", subject='").append(subject).append('\'');
+        sb.append(", body='").append(body).append('\'');
+        sb.append(", description='").append(description).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/schema/email/EmailTemplate.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/schema/email/EmailTemplate.java
@@ -1,0 +1,230 @@
+package dev.getelements.elements.sdk.model.schema.email;
+
+import dev.getelements.elements.sdk.model.ValidationGroups;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+
+/** Represents a reusable, admin-managed email template used to compose system emails. */
+@Schema(description = "Represents a reusable email template.")
+public class EmailTemplate implements Serializable {
+
+    /** Creates a new instance. */
+    public EmailTemplate() {}
+
+    @Null(groups = ValidationGroups.Insert.class)
+    @NotNull(groups = ValidationGroups.Update.class)
+    @Schema(description = "The unique ID of the email template.")
+    private String id;
+
+    @NotNull
+    @Schema(description = "The unique key used to reference this email template (e.g. "
+            + "dev.getelements.elements.password_reset.email_template).")
+    private String key;
+
+    @NotNull
+    @Schema(description = "The display name of the email template.")
+    private String name;
+
+    @NotNull
+    @Schema(description = "The subject line of the email template.")
+    private String subject;
+
+    @NotNull
+    @Schema(description = "The HTML body of the email template.")
+    private String body;
+
+    @Schema(description = "An optional human-readable description of the email template.")
+    private String description;
+
+    @Schema(description = "The time the email template was created.")
+    private Date createdAt;
+
+    @Schema(description = "The time the email template was last updated.")
+    private Date updatedAt;
+
+    /**
+     * Returns the unique ID of the email template.
+     *
+     * @return the id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the unique ID of the email template.
+     *
+     * @param id the id
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the unique key of the email template.
+     *
+     * @return the key
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Sets the unique key of the email template.
+     *
+     * @param key the key
+     */
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Returns the display name of the email template.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the display name of the email template.
+     *
+     * @param name the name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the subject line of the email template.
+     *
+     * @return the subject
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * Sets the subject line of the email template.
+     *
+     * @param subject the subject
+     */
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+     * Returns the HTML body of the email template.
+     *
+     * @return the body
+     */
+    public String getBody() {
+        return body;
+    }
+
+    /**
+     * Sets the HTML body of the email template.
+     *
+     * @param body the body
+     */
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    /**
+     * Returns the description of the email template.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the description of the email template.
+     *
+     * @param description the description
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Returns the time the email template was created.
+     *
+     * @return the createdAt
+     */
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * Sets the time the email template was created.
+     *
+     * @param createdAt the createdAt
+     */
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * Returns the time the email template was last updated.
+     *
+     * @return the updatedAt
+     */
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /**
+     * Sets the time the email template was last updated.
+     *
+     * @param updatedAt the updatedAt
+     */
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EmailTemplate that = (EmailTemplate) o;
+        return Objects.equals(getId(), that.getId()) &&
+                Objects.equals(getKey(), that.getKey()) &&
+                Objects.equals(getName(), that.getName()) &&
+                Objects.equals(getSubject(), that.getSubject()) &&
+                Objects.equals(getBody(), that.getBody()) &&
+                Objects.equals(getDescription(), that.getDescription()) &&
+                Objects.equals(getCreatedAt(), that.getCreatedAt()) &&
+                Objects.equals(getUpdatedAt(), that.getUpdatedAt());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getKey(), getName(), getSubject(), getBody(), getDescription(),
+                getCreatedAt(), getUpdatedAt());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("EmailTemplate{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", key='").append(key).append('\'');
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", subject='").append(subject).append('\'');
+        sb.append(", body='").append(body).append('\'');
+        sb.append(", description='").append(description).append('\'');
+        sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/sdk-model/src/main/java/dev/getelements/elements/sdk/model/schema/email/UpdateEmailTemplateRequest.java
+++ b/sdk-model/src/main/java/dev/getelements/elements/sdk/model/schema/email/UpdateEmailTemplateRequest.java
@@ -1,0 +1,130 @@
+package dev.getelements.elements.sdk.model.schema.email;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Represents a request to update an {@link EmailTemplate}'s name, subject, body, and description. */
+@Schema(description = "Represents a request to update an EmailTemplate.")
+public class UpdateEmailTemplateRequest implements Serializable {
+
+    /** Creates a new instance. */
+    public UpdateEmailTemplateRequest() {}
+
+    @NotNull
+    @Schema(description = "The display name of the email template.")
+    private String name;
+
+    @NotNull
+    @Schema(description = "The subject line of the email template.")
+    private String subject;
+
+    @NotNull
+    @Schema(description = "The HTML body of the email template.")
+    private String body;
+
+    @Schema(description = "An optional human-readable description of the email template.")
+    private String description;
+
+    /**
+     * Returns the display name of the email template.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the display name of the email template.
+     *
+     * @param name the name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the subject line of the email template.
+     *
+     * @return the subject
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * Sets the subject line of the email template.
+     *
+     * @param subject the subject
+     */
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+     * Returns the HTML body of the email template.
+     *
+     * @return the body
+     */
+    public String getBody() {
+        return body;
+    }
+
+    /**
+     * Sets the HTML body of the email template.
+     *
+     * @param body the body
+     */
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    /**
+     * Returns the description of the email template.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the description of the email template.
+     *
+     * @param description the description
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UpdateEmailTemplateRequest that = (UpdateEmailTemplateRequest) o;
+        return Objects.equals(getName(), that.getName()) &&
+                Objects.equals(getSubject(), that.getSubject()) &&
+                Objects.equals(getBody(), that.getBody()) &&
+                Objects.equals(getDescription(), that.getDescription());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getSubject(), getBody(), getDescription());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("UpdateEmailTemplateRequest{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", subject='").append(subject).append('\'');
+        sb.append(", body='").append(body).append('\'');
+        sb.append(", description='").append(description).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/sdk-service/src/main/java/dev/getelements/elements/sdk/service/schema/email/EmailTemplateService.java
+++ b/sdk-service/src/main/java/dev/getelements/elements/sdk/service/schema/email/EmailTemplateService.java
@@ -1,0 +1,86 @@
+package dev.getelements.elements.sdk.service.schema.email;
+
+import dev.getelements.elements.sdk.model.Pagination;
+import dev.getelements.elements.sdk.model.schema.email.CreateEmailTemplateRequest;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
+import dev.getelements.elements.sdk.model.schema.email.UpdateEmailTemplateRequest;
+import dev.getelements.elements.sdk.annotation.ElementPublic;
+import dev.getelements.elements.sdk.annotation.ElementServiceExport;
+
+import static dev.getelements.elements.sdk.service.Constants.UNSCOPED;
+
+/**
+ * Manages instances of {@link EmailTemplate}.
+ *
+ * <p>Kept as a standalone type (not extending any other service interface) so that the
+ * Guice-HK2 bridge can resolve it without type-hierarchy ambiguity.
+ */
+@ElementPublic
+@ElementServiceExport
+@ElementServiceExport(name = UNSCOPED)
+public interface EmailTemplateService {
+
+    /**
+     * Lists all {@link EmailTemplate} instances.
+     *
+     * @param offset
+     * @param count
+     * @return a {@link Pagination} of {@link EmailTemplate} instances
+     */
+    Pagination<EmailTemplate> getEmailTemplates(int offset, int count);
+
+    /**
+     * Fetches a specific {@link EmailTemplate} instance based on ID or key. If not found, an
+     * exception is raised.
+     *
+     * @param idOrKey the email template ID or key
+     * @return the {@link EmailTemplate}, never null
+     */
+    EmailTemplate getEmailTemplate(String idOrKey);
+
+    /**
+     * Creates a new {@link EmailTemplate}.
+     *
+     * <p>Rejects requests whose key begins with the reserved {@code dev.getelements.elements.} prefix,
+     * which is reserved for core system templates.
+     *
+     * @param request the {@link CreateEmailTemplateRequest} with the information to create
+     * @return the {@link EmailTemplate} as it was created by the service.
+     */
+    EmailTemplate createEmailTemplate(CreateEmailTemplateRequest request);
+
+    /**
+     * Updates the {@link EmailTemplate} with the supplied id.
+     *
+     * @param id      the id of the email template to update
+     * @param request the information to update
+     * @return the {@link EmailTemplate} as it was changed by the service.
+     */
+    EmailTemplate updateEmailTemplate(String id, UpdateEmailTemplateRequest request);
+
+    /**
+     * Deletes the {@link EmailTemplate} with the supplied id.
+     *
+     * <p>Rejects requests to delete a template whose key begins with the reserved
+     * {@code dev.getelements.elements.} prefix.
+     *
+     * @param id the email template id.
+     */
+    void deleteEmailTemplate(String id);
+
+    /**
+     * Idempotent upsert — finds an {@link EmailTemplate} by its key, creating it with the supplied
+     * defaults if it does not already exist. Core services and custom Elements alike should call this
+     * at startup (or lazily, before sending an email) to self-register and fetch their own templates.
+     * This method is not subject to the reserved-key restriction that governs
+     * {@link #createEmailTemplate(CreateEmailTemplateRequest)} and {@link #deleteEmailTemplate(String)}.
+     *
+     * @param key            the unique key identifying the template
+     * @param defaultName    the display name to use if the template does not already exist
+     * @param defaultSubject the subject to use if the template does not already exist
+     * @param defaultBody    the HTML body to use if the template does not already exist
+     * @return the existing or newly-created {@link EmailTemplate}
+     */
+    EmailTemplate getOrCreateEmailTemplate(String key, String defaultName, String defaultSubject, String defaultBody);
+
+}

--- a/sdk-service/src/main/java/dev/getelements/elements/sdk/service/user/EmailVerificationService.java
+++ b/sdk-service/src/main/java/dev/getelements/elements/sdk/service/user/EmailVerificationService.java
@@ -63,25 +63,16 @@ public interface EmailVerificationService {
     String VERIFICATION_BASE_URL = "dev.getelements.elements.verification.base_url";
 
     /**
-     * Element attribute: subject line for the verification email.
-     * Defaults to {@code "Verify your email"}.
+     * Key identifying the {@code EmailTemplate} whose subject line is used for the verification email.
+     * This is no longer an element attribute; the template content is managed via {@code EmailTemplateService}.
      */
-    @ElementDefaultAttribute(
-            value = "Verify your email",
-            description = "Subject line for verification emails.")
     String VERIFICATION_EMAIL_SUBJECT = "dev.getelements.elements.verification.email_subject";
 
     /**
-     * Element attribute: HTML body template for the verification email.
+     * Key identifying the {@code EmailTemplate} whose HTML body is used for the verification email.
      * Must contain the literal token {@code {link}}, which is replaced with the full verification URL.
-     *
-     * <p>Defaults to a plain inline link. Override this in your Element to provide a branded template.
+     * This is no longer an element attribute; the template content is managed via {@code EmailTemplateService}.
      */
-    @ElementDefaultAttribute(
-            value = "<p>Please verify your email address by clicking the link below:</p>"
-                  + "<p><a href=\"{link}\">Verify Email</a></p>",
-            description = "HTML email body template for verification emails. "
-                        + "Use {link} as a placeholder for the verification URL.")
     String VERIFICATION_EMAIL_TEMPLATE = "dev.getelements.elements.verification.email_template";
 
     /**

--- a/sdk-service/src/main/java/dev/getelements/elements/sdk/service/user/PasswordResetService.java
+++ b/sdk-service/src/main/java/dev/getelements/elements/sdk/service/user/PasswordResetService.java
@@ -48,23 +48,16 @@ public interface PasswordResetService {
     String RESET_BASE_URL = "dev.getelements.elements.password_reset.base_url";
 
     /**
-     * Element attribute: subject line for the password reset email.
+     * Key identifying the {@code EmailTemplate} whose subject line is used for the password reset email.
+     * This is no longer an element attribute; the template content is managed via {@code EmailTemplateService}.
      */
-    @ElementDefaultAttribute(
-            value = "Reset your password",
-            description = "Subject line for password reset emails.")
     String RESET_EMAIL_SUBJECT = "dev.getelements.elements.password_reset.email_subject";
 
     /**
-     * Element attribute: HTML body template for the password reset email.
+     * Key identifying the {@code EmailTemplate} whose HTML body is used for the password reset email.
      * Must contain the literal token {@code {link}}, which is replaced with the full reset URL.
+     * This is no longer an element attribute; the template content is managed via {@code EmailTemplateService}.
      */
-    @ElementDefaultAttribute(
-            value = "<p>Click the link below to reset your password. "
-                  + "This link expires in 1 hour.</p>"
-                  + "<p><a href=\"{link}\">Reset Password</a></p>",
-            description = "HTML email body template for password reset emails. "
-                        + "Use {link} as a placeholder for the reset URL.")
     String RESET_EMAIL_TEMPLATE = "dev.getelements.elements.password_reset.email_template";
 
     /**

--- a/service-guice/src/main/java/dev/getelements/elements/service/guice/ScopedServicesModule.java
+++ b/service-guice/src/main/java/dev/getelements/elements/service/guice/ScopedServicesModule.java
@@ -48,6 +48,7 @@ import dev.getelements.elements.sdk.service.receipt.ReceiptService;
 import dev.getelements.elements.sdk.service.rewardissuance.RewardIssuanceService;
 import dev.getelements.elements.sdk.service.savedata.SaveDataDocumentService;
 import dev.getelements.elements.sdk.service.schema.MetadataSpecService;
+import dev.getelements.elements.sdk.service.schema.email.EmailTemplateService;
 import dev.getelements.elements.sdk.service.system.ElementInspectorService;
 import dev.getelements.elements.sdk.service.system.ElementStatusService;
 import dev.getelements.elements.sdk.service.system.ElementDeploymentService;
@@ -134,6 +135,8 @@ import dev.getelements.elements.service.savedata.SuperUserSaveDataDocumentServic
 import dev.getelements.elements.service.savedata.UserSaveDataDocumentService;
 import dev.getelements.elements.service.schema.MetadataSpecServiceProvider;
 import dev.getelements.elements.service.schema.SuperUserMetadataSpecService;
+import dev.getelements.elements.service.schema.email.EmailTemplateServiceProvider;
+import dev.getelements.elements.service.schema.email.SuperUserEmailTemplateService;
 import dev.getelements.elements.service.system.ElementDeploymentServiceProvider;
 import dev.getelements.elements.service.system.ElementInspectorServiceProvider;
 import dev.getelements.elements.service.system.SuperUserElementDeploymentService;
@@ -365,6 +368,10 @@ public class ScopedServicesModule extends AbstractModule {
 
         bind(MetadataSpecService.class)
                 .toProvider(MetadataSpecServiceProvider.class)
+                .in(scope);
+
+        bind(EmailTemplateService.class)
+                .toProvider(EmailTemplateServiceProvider.class)
                 .in(scope);
 
         bind(HealthStatusService.class)

--- a/service-guice/src/main/java/dev/getelements/elements/service/guice/UnscopedServicesModule.java
+++ b/service-guice/src/main/java/dev/getelements/elements/service/guice/UnscopedServicesModule.java
@@ -54,6 +54,7 @@ import dev.getelements.elements.sdk.service.profile.ProfileService;
 import dev.getelements.elements.sdk.service.progress.ProgressService;
 import dev.getelements.elements.sdk.service.savedata.SaveDataDocumentService;
 import dev.getelements.elements.sdk.service.schema.MetadataSpecService;
+import dev.getelements.elements.sdk.service.schema.email.EmailTemplateService;
 import dev.getelements.elements.sdk.service.version.VersionService;
 import dev.getelements.elements.service.application.*;
 import dev.getelements.elements.service.auth.*;
@@ -88,6 +89,7 @@ import dev.getelements.elements.service.progress.SuperUserProgressService;
 import dev.getelements.elements.service.receipt.SuperuserReceiptService;
 import dev.getelements.elements.service.savedata.SuperUserSaveDataDocumentService;
 import dev.getelements.elements.service.schema.SuperUserMetadataSpecService;
+import dev.getelements.elements.service.schema.email.SuperUserEmailTemplateService;
 import dev.getelements.elements.service.system.SuperUserElementDeploymentService;
 import dev.getelements.elements.service.system.SuperUserElementInspectorService;
 import dev.getelements.elements.service.user.AnonPasswordResetService;
@@ -247,6 +249,10 @@ public class UnscopedServicesModule extends AbstractModule {
         bind(MetadataSpecService.class)
                 .annotatedWith(named(UNSCOPED))
                 .to(SuperUserMetadataSpecService.class);
+
+        bind(EmailTemplateService.class)
+                .annotatedWith(named(UNSCOPED))
+                .to(SuperUserEmailTemplateService.class);
 
         bind(AuthSchemeService.class)
                 .annotatedWith(named(UNSCOPED))

--- a/service-test/src/test/java/dev/getelements/elements/service/schema/email/SuperUserEmailTemplateServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/schema/email/SuperUserEmailTemplateServiceTest.java
@@ -1,0 +1,135 @@
+package dev.getelements.elements.service.schema.email;
+
+import com.google.inject.AbstractModule;
+import dev.getelements.elements.sdk.dao.EmailTemplateDao;
+import dev.getelements.elements.sdk.model.exception.InvalidDataException;
+import dev.getelements.elements.sdk.model.schema.email.CreateEmailTemplateRequest;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
+import jakarta.inject.Inject;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.google.inject.Guice.createInjector;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+public class SuperUserEmailTemplateServiceTest {
+
+    @Inject
+    private SuperUserEmailTemplateService service;
+
+    @Inject
+    private EmailTemplateDao emailTemplateDao;
+
+    @BeforeMethod
+    public void setup() {
+        createInjector(new TestModule()).injectMembers(this);
+    }
+
+    @Test(expectedExceptions = InvalidDataException.class)
+    public void testCreateRejectsReservedKeyPrefix() {
+        final var request = new CreateEmailTemplateRequest();
+        request.setKey("dev.getelements.elements.some_core_template");
+        request.setName("Reserved");
+        request.setSubject("Subject");
+        request.setBody("Body");
+        service.createEmailTemplate(request);
+    }
+
+    @Test
+    public void testCreateAllowsNonReservedKeyPrefix() {
+
+        when(emailTemplateDao.createEmailTemplate(any())).thenAnswer(i -> i.getArgument(0));
+
+        final var request = new CreateEmailTemplateRequest();
+        request.setKey("com.example.my_template");
+        request.setName("My Template");
+        request.setSubject("Subject");
+        request.setBody("Body");
+
+        final var created = service.createEmailTemplate(request);
+
+        assertEquals(created.getKey(), "com.example.my_template");
+        verify(emailTemplateDao).createEmailTemplate(any());
+    }
+
+    @Test(expectedExceptions = InvalidDataException.class)
+    public void testDeleteRejectsReservedKeyPrefix() {
+
+        final var existing = new EmailTemplate();
+        existing.setId("template-1");
+        existing.setKey("dev.getelements.elements.password_reset.email_template");
+        when(emailTemplateDao.getEmailTemplate("template-1")).thenReturn(existing);
+
+        service.deleteEmailTemplate("template-1");
+    }
+
+    @Test
+    public void testDeleteAllowsNonReservedKeyPrefix() {
+
+        final var existing = new EmailTemplate();
+        existing.setId("template-1");
+        existing.setKey("com.example.my_template");
+        when(emailTemplateDao.getEmailTemplate("template-1")).thenReturn(existing);
+
+        service.deleteEmailTemplate("template-1");
+
+        verify(emailTemplateDao).deleteEmailTemplate("template-1");
+    }
+
+    @Test
+    public void testGetOrCreateEmailTemplateReturnsExistingWithoutCreating() {
+
+        final var existing = new EmailTemplate();
+        existing.setId("template-1");
+        existing.setKey("dev.getelements.elements.password_reset.email_template");
+        existing.setName("Existing");
+        existing.setSubject("Existing Subject");
+        existing.setBody("Existing Body");
+
+        when(emailTemplateDao.findEmailTemplateByKey("dev.getelements.elements.password_reset.email_template"))
+                .thenReturn(Optional.of(existing));
+
+        final var result = service.getOrCreateEmailTemplate(
+                "dev.getelements.elements.password_reset.email_template",
+                "Default Name", "Default Subject", "Default Body");
+
+        assertEquals(result, existing);
+        verify(emailTemplateDao, never()).createEmailTemplate(any());
+    }
+
+    @Test
+    public void testGetOrCreateEmailTemplateCreatesWithDefaultsWhenAbsent() {
+
+        when(emailTemplateDao.findEmailTemplateByKey("dev.getelements.elements.verification.email_template"))
+                .thenReturn(Optional.empty());
+        when(emailTemplateDao.createEmailTemplate(any())).thenAnswer(i -> i.getArgument(0));
+
+        final var result = service.getOrCreateEmailTemplate(
+                "dev.getelements.elements.verification.email_template",
+                "Email Verification Email", "Verify your email", "<p>Body</p>");
+
+        final var captor = ArgumentCaptor.forClass(EmailTemplate.class);
+        verify(emailTemplateDao).createEmailTemplate(captor.capture());
+
+        assertEquals(captor.getValue().getKey(), "dev.getelements.elements.verification.email_template");
+        assertEquals(captor.getValue().getName(), "Email Verification Email");
+        assertEquals(captor.getValue().getSubject(), "Verify your email");
+        assertEquals(captor.getValue().getBody(), "<p>Body</p>");
+        assertEquals(result.getKey(), "dev.getelements.elements.verification.email_template");
+    }
+
+    private static class TestModule extends AbstractModule {
+
+        @Override
+        protected void configure() {
+            bind(EmailTemplateDao.class).toInstance(mock(EmailTemplateDao.class));
+        }
+
+    }
+
+}

--- a/service-test/src/test/java/dev/getelements/elements/service/user/EmailVerificationServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/user/EmailVerificationServiceTest.java
@@ -7,11 +7,13 @@ import dev.getelements.elements.sdk.dao.UidVerificationTokenDao;
 import dev.getelements.elements.sdk.dao.UserUidDao;
 import dev.getelements.elements.sdk.model.exception.ForbiddenException;
 import dev.getelements.elements.sdk.model.exception.NotFoundException;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
 import dev.getelements.elements.sdk.model.user.UidVerificationToken;
 import dev.getelements.elements.sdk.model.user.User;
 import dev.getelements.elements.sdk.model.user.UserUid;
 import dev.getelements.elements.sdk.model.user.VerificationStatus;
 import dev.getelements.elements.sdk.service.email.EmailService;
+import dev.getelements.elements.sdk.service.schema.email.EmailTemplateService;
 import jakarta.inject.Inject;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
@@ -23,6 +25,7 @@ import java.util.Optional;
 import static com.google.inject.Guice.createInjector;
 import static com.google.inject.name.Names.named;
 import static dev.getelements.elements.sdk.dao.UserUidDao.SCHEME_EMAIL;
+import static dev.getelements.elements.sdk.service.Constants.UNSCOPED;
 import static dev.getelements.elements.sdk.service.user.EmailVerificationService.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -298,6 +301,14 @@ public class EmailVerificationServiceTest {
             bind(UidVerificationTokenDao.class).toInstance(mock(UidVerificationTokenDao.class));
             bind(EmailService.class).toInstance(mock(EmailService.class));
             bind(ElementRegistry.class).toInstance(mock(ElementRegistry.class));
+
+            final var template = new EmailTemplate();
+            template.setSubject(SUBJECT);
+            template.setBody(TEMPLATE);
+
+            final var emailTemplateService = mock(EmailTemplateService.class);
+            when(emailTemplateService.getOrCreateEmailTemplate(any(), any(), any(), any())).thenReturn(template);
+            bind(EmailTemplateService.class).annotatedWith(named(UNSCOPED)).toInstance(emailTemplateService);
 
             bindConstant().annotatedWith(named(VERIFICATION_EMAIL_SUBJECT)).to(SUBJECT);
             bindConstant().annotatedWith(named(VERIFICATION_EMAIL_TEMPLATE)).to(TEMPLATE);

--- a/service-test/src/test/java/dev/getelements/elements/service/user/PasswordResetServiceTest.java
+++ b/service-test/src/test/java/dev/getelements/elements/service/user/PasswordResetServiceTest.java
@@ -7,10 +7,12 @@ import dev.getelements.elements.sdk.dao.PasswordResetTokenDao;
 import dev.getelements.elements.sdk.dao.UserDao;
 import dev.getelements.elements.sdk.dao.UserUidDao;
 import dev.getelements.elements.sdk.model.exception.InvalidParameterException;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
 import dev.getelements.elements.sdk.model.user.PasswordResetToken;
 import dev.getelements.elements.sdk.model.user.User;
 import dev.getelements.elements.sdk.model.user.UserUid;
 import dev.getelements.elements.sdk.service.email.EmailService;
+import dev.getelements.elements.sdk.service.schema.email.EmailTemplateService;
 import jakarta.inject.Inject;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -23,6 +25,7 @@ import java.util.Optional;
 import static com.google.inject.Guice.createInjector;
 import static com.google.inject.name.Names.named;
 import static dev.getelements.elements.sdk.dao.UserUidDao.SCHEME_EMAIL;
+import static dev.getelements.elements.sdk.service.Constants.UNSCOPED;
 import static dev.getelements.elements.sdk.service.user.PasswordResetService.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -239,6 +242,14 @@ public class PasswordResetServiceTest {
             bind(PasswordResetTokenDao.class).toInstance(mock(PasswordResetTokenDao.class));
             bind(EmailService.class).toInstance(mock(EmailService.class));
             bind(ElementRegistry.class).toInstance(mock(ElementRegistry.class));
+
+            final var template = new EmailTemplate();
+            template.setSubject(SUBJECT);
+            template.setBody(TEMPLATE);
+
+            final var emailTemplateService = mock(EmailTemplateService.class);
+            when(emailTemplateService.getOrCreateEmailTemplate(any(), any(), any(), any())).thenReturn(template);
+            bind(EmailTemplateService.class).annotatedWith(named(UNSCOPED)).toInstance(emailTemplateService);
 
             bindConstant().annotatedWith(named(RESET_EMAIL_SUBJECT)).to(SUBJECT);
             bindConstant().annotatedWith(named(RESET_EMAIL_TEMPLATE)).to(TEMPLATE);

--- a/service/src/main/java/dev/getelements/elements/service/schema/email/EmailTemplateServiceProvider.java
+++ b/service/src/main/java/dev/getelements/elements/service/schema/email/EmailTemplateServiceProvider.java
@@ -1,0 +1,43 @@
+package dev.getelements.elements.service.schema.email;
+
+import dev.getelements.elements.sdk.model.user.User;
+import dev.getelements.elements.sdk.service.schema.email.EmailTemplateService;
+import dev.getelements.elements.sdk.service.Services;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+
+public class EmailTemplateServiceProvider implements Provider<EmailTemplateService> {
+
+    private User user;
+
+    private Provider<SuperUserEmailTemplateService> superUserEmailTemplateService;
+
+    @Override
+    public EmailTemplateService get() {
+        switch (getUser().getLevel()) {
+            case SUPERUSER:
+                return getSuperUserEmailTemplateService().get();
+            default:
+                return Services.forbidden(EmailTemplateService.class);
+        }
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Inject
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Provider<SuperUserEmailTemplateService> getSuperUserEmailTemplateService() {
+        return superUserEmailTemplateService;
+    }
+
+    @Inject
+    public void setSuperUserEmailTemplateService(Provider<SuperUserEmailTemplateService> superUserEmailTemplateService) {
+        this.superUserEmailTemplateService = superUserEmailTemplateService;
+    }
+}

--- a/service/src/main/java/dev/getelements/elements/service/schema/email/SuperUserEmailTemplateService.java
+++ b/service/src/main/java/dev/getelements/elements/service/schema/email/SuperUserEmailTemplateService.java
@@ -1,0 +1,129 @@
+package dev.getelements.elements.service.schema.email;
+
+import dev.getelements.elements.sdk.dao.EmailTemplateDao;
+import dev.getelements.elements.sdk.model.Pagination;
+import dev.getelements.elements.sdk.model.exception.InvalidDataException;
+import dev.getelements.elements.sdk.model.exception.schema.EmailTemplateNotFoundException;
+import dev.getelements.elements.sdk.model.schema.email.CreateEmailTemplateRequest;
+import dev.getelements.elements.sdk.model.schema.email.EmailTemplate;
+import dev.getelements.elements.sdk.model.schema.email.UpdateEmailTemplateRequest;
+import dev.getelements.elements.sdk.service.schema.email.EmailTemplateService;
+import dev.getelements.elements.sdk.service.user.EmailVerificationService;
+import dev.getelements.elements.sdk.service.user.PasswordResetService;
+import jakarta.inject.Inject;
+
+public class SuperUserEmailTemplateService implements EmailTemplateService {
+
+    /** Reserved key prefix for core, built-in email templates. Not creatable or deletable via the API. */
+    private static final String RESERVED_PREFIX = "dev.getelements.elements.";
+
+    private static final String RESET_EMAIL_TEMPLATE_NAME = "Password Reset Email";
+
+    private static final String RESET_EMAIL_SUBJECT_DEFAULT = "Reset your password";
+
+    private static final String RESET_EMAIL_BODY_DEFAULT =
+            "<p>Click the link below to reset your password. This link expires in 1 hour.</p>"
+          + "<p><a href=\"{link}\">Reset Password</a></p>";
+
+    private static final String VERIFICATION_EMAIL_TEMPLATE_NAME = "Email Verification Email";
+
+    private static final String VERIFICATION_EMAIL_SUBJECT_DEFAULT = "Verify your email";
+
+    private static final String VERIFICATION_EMAIL_BODY_DEFAULT =
+            "<p>Please verify your email address by clicking the link below:</p>"
+          + "<p><a href=\"{link}\">Verify Email</a></p>";
+
+    private EmailTemplateDao emailTemplateDao;
+
+    @Override
+    public Pagination<EmailTemplate> getEmailTemplates(final int offset, final int count) {
+
+        // Ensure the core, built-in templates always exist so they show up in the admin list even
+        // before any email of that kind has ever been sent.
+        getOrCreateEmailTemplate(
+                PasswordResetService.RESET_EMAIL_TEMPLATE,
+                RESET_EMAIL_TEMPLATE_NAME,
+                RESET_EMAIL_SUBJECT_DEFAULT,
+                RESET_EMAIL_BODY_DEFAULT);
+
+        getOrCreateEmailTemplate(
+                EmailVerificationService.VERIFICATION_EMAIL_TEMPLATE,
+                VERIFICATION_EMAIL_TEMPLATE_NAME,
+                VERIFICATION_EMAIL_SUBJECT_DEFAULT,
+                VERIFICATION_EMAIL_BODY_DEFAULT);
+
+        return getEmailTemplateDao().getEmailTemplates(offset, count);
+    }
+
+    @Override
+    public EmailTemplate getEmailTemplate(final String idOrKey) {
+        return getEmailTemplateDao()
+                .findEmailTemplate(idOrKey)
+                .or(() -> getEmailTemplateDao().findEmailTemplateByKey(idOrKey))
+                .orElseThrow(EmailTemplateNotFoundException::new);
+    }
+
+    @Override
+    public EmailTemplate createEmailTemplate(final CreateEmailTemplateRequest request) {
+
+        if (request.getKey() != null && request.getKey().startsWith(RESERVED_PREFIX)) {
+            throw new InvalidDataException("Email template key may not use the reserved prefix: " + RESERVED_PREFIX);
+        }
+
+        final var template = new EmailTemplate();
+        template.setKey(request.getKey());
+        template.setName(request.getName());
+        template.setSubject(request.getSubject());
+        template.setBody(request.getBody());
+        template.setDescription(request.getDescription());
+
+        return getEmailTemplateDao().createEmailTemplate(template);
+    }
+
+    @Override
+    public EmailTemplate updateEmailTemplate(final String id, final UpdateEmailTemplateRequest request) {
+        final var template = getEmailTemplateDao().getEmailTemplate(id);
+        template.setName(request.getName());
+        template.setSubject(request.getSubject());
+        template.setBody(request.getBody());
+        template.setDescription(request.getDescription());
+        return getEmailTemplateDao().updateEmailTemplate(template);
+    }
+
+    @Override
+    public void deleteEmailTemplate(final String id) {
+
+        final var template = getEmailTemplateDao().getEmailTemplate(id);
+
+        if (template.getKey() != null && template.getKey().startsWith(RESERVED_PREFIX)) {
+            throw new InvalidDataException("Core email templates may not be deleted: " + template.getKey());
+        }
+
+        getEmailTemplateDao().deleteEmailTemplate(id);
+    }
+
+    @Override
+    public EmailTemplate getOrCreateEmailTemplate(final String key,
+                                                   final String defaultName,
+                                                   final String defaultSubject,
+                                                   final String defaultBody) {
+        return getEmailTemplateDao().findEmailTemplateByKey(key).orElseGet(() -> {
+            final var template = new EmailTemplate();
+            template.setKey(key);
+            template.setName(defaultName);
+            template.setSubject(defaultSubject);
+            template.setBody(defaultBody);
+            return getEmailTemplateDao().createEmailTemplate(template);
+        });
+    }
+
+    public EmailTemplateDao getEmailTemplateDao() {
+        return emailTemplateDao;
+    }
+
+    @Inject
+    public void setEmailTemplateDao(EmailTemplateDao emailTemplateDao) {
+        this.emailTemplateDao = emailTemplateDao;
+    }
+
+}

--- a/service/src/main/java/dev/getelements/elements/service/user/AbstractEmailVerificationService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/AbstractEmailVerificationService.java
@@ -9,6 +9,7 @@ import dev.getelements.elements.sdk.model.user.User;
 import dev.getelements.elements.sdk.model.user.UserUid;
 import dev.getelements.elements.sdk.model.user.VerificationStatus;
 import dev.getelements.elements.sdk.service.email.EmailService;
+import dev.getelements.elements.sdk.service.schema.email.EmailTemplateService;
 import dev.getelements.elements.sdk.service.user.EmailVerificationService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -17,6 +18,7 @@ import java.sql.Timestamp;
 import java.util.concurrent.TimeUnit;
 
 import static dev.getelements.elements.sdk.dao.UserUidDao.SCHEME_EMAIL;
+import static dev.getelements.elements.sdk.service.Constants.UNSCOPED;
 import static dev.getelements.elements.sdk.service.user.EmailVerificationService.*;
 
 /**
@@ -30,6 +32,12 @@ abstract class AbstractEmailVerificationService implements EmailVerificationServ
 
     static final long TOKEN_VALIDITY_MS = TimeUnit.HOURS.toMillis(24);
 
+    private static final String DEFAULT_SUBJECT = "Verify your email";
+
+    private static final String DEFAULT_BODY =
+            "<p>Please verify your email address by clicking the link below:</p>"
+          + "<p><a href=\"{link}\">Verify Email</a></p>";
+
     private UserUidDao userUidDao;
 
     private UidVerificationTokenDao tokenDao;
@@ -38,9 +46,7 @@ abstract class AbstractEmailVerificationService implements EmailVerificationServ
 
     private ElementRegistry elementRegistry;
 
-    private String emailSubject;
-
-    private String emailTemplate;
+    private EmailTemplateService emailTemplateService;
 
     // -------------------------------------------------------------------------
     // Shared core operations
@@ -61,10 +67,13 @@ abstract class AbstractEmailVerificationService implements EmailVerificationServ
         final var expiry = new Timestamp(System.currentTimeMillis() + TOKEN_VALIDITY_MS);
         final var token = getTokenDao().createToken(ownerUser, SCHEME_EMAIL, email, expiry);
 
-        final var link = verificationBaseUrl + "?token=" + token;
-        final var body = getEmailTemplate().replace("{link}", link);
+        final var template = getEmailTemplateService().getOrCreateEmailTemplate(
+                VERIFICATION_EMAIL_TEMPLATE, "Email Verification Email", DEFAULT_SUBJECT, DEFAULT_BODY);
 
-        getEmailService().send(null, email, getEmailSubject(), body, true);
+        final var link = verificationBaseUrl + "?token=" + token;
+        final var body = template.getBody().replace("{link}", link);
+
+        getEmailService().send(null, email, template.getSubject(), body, true);
 
         final var updated = getUserUidDao().updateVerificationStatus(email, SCHEME_EMAIL, VerificationStatus.PENDING);
 
@@ -141,39 +150,18 @@ abstract class AbstractEmailVerificationService implements EmailVerificationServ
     }
 
     /**
-     * Returns the subject line for the verification email.
-     *
-     * <p>Override this in a subclass to supply a custom subject without reimplementing
-     * the full verification flow. The default returns the value injected via
-     * {@link EmailVerificationService#VERIFICATION_EMAIL_SUBJECT}.
+     * Returns the {@link EmailTemplateService} used to resolve the subject and body of the
+     * verification email. The template is looked up (and lazily created with defaults if absent)
+     * via {@link EmailTemplateService#getOrCreateEmailTemplate} keyed on
+     * {@link EmailVerificationService#VERIFICATION_EMAIL_TEMPLATE}.
      */
-    protected String getEmailSubject() {
-        return emailSubject;
+    public EmailTemplateService getEmailTemplateService() {
+        return emailTemplateService;
     }
 
     @Inject
-    public void setEmailSubject(@Named(VERIFICATION_EMAIL_SUBJECT) String emailSubject) {
-        this.emailSubject = emailSubject;
-    }
-
-    /**
-     * Returns the HTML body template for the verification email.
-     *
-     * <p>Override this in a subclass to supply a custom template without reimplementing
-     * the full verification flow. The template must contain the literal token {@code {link}},
-     * which is replaced at send-time with the full verification URL. The default returns
-     * the value injected via {@link EmailVerificationService#VERIFICATION_EMAIL_TEMPLATE}.
-     *
-     * <p>To back this with a database (for a live UI editor), inject a DAO here and
-     * read from it, falling back to {@code super.getEmailTemplate()} when no override is stored.
-     */
-    protected String getEmailTemplate() {
-        return emailTemplate;
-    }
-
-    @Inject
-    public void setEmailTemplate(@Named(VERIFICATION_EMAIL_TEMPLATE) String emailTemplate) {
-        this.emailTemplate = emailTemplate;
+    public void setEmailTemplateService(@Named(UNSCOPED) EmailTemplateService emailTemplateService) {
+        this.emailTemplateService = emailTemplateService;
     }
 
 }

--- a/service/src/main/java/dev/getelements/elements/service/user/AbstractPasswordResetService.java
+++ b/service/src/main/java/dev/getelements/elements/service/user/AbstractPasswordResetService.java
@@ -7,9 +7,12 @@ import dev.getelements.elements.sdk.dao.UserDao;
 import dev.getelements.elements.sdk.dao.UserUidDao;
 import dev.getelements.elements.sdk.model.exception.InvalidParameterException;
 import dev.getelements.elements.sdk.service.email.EmailService;
+import dev.getelements.elements.sdk.service.schema.email.EmailTemplateService;
 import dev.getelements.elements.sdk.service.user.PasswordResetService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+
+import static dev.getelements.elements.sdk.service.Constants.UNSCOPED;
 
 import java.sql.Timestamp;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,6 +36,13 @@ abstract class AbstractPasswordResetService implements PasswordResetService {
 
     private static final long EMAIL_COOLDOWN_MS = TimeUnit.SECONDS.toMillis(60);
 
+    private static final String DEFAULT_SUBJECT = "Reset your password";
+
+    private static final String DEFAULT_BODY =
+            "<p>Click the link below to reset your password. "
+          + "This link expires in 1 hour.</p>"
+          + "<p><a href=\"{link}\">Reset Password</a></p>";
+
     private UserUidDao userUidDao;
 
     private PasswordResetTokenDao tokenDao;
@@ -43,9 +53,7 @@ abstract class AbstractPasswordResetService implements PasswordResetService {
 
     private ElementRegistry elementRegistry;
 
-    private String emailSubject;
-
-    private String emailTemplate;
+    private EmailTemplateService emailTemplateService;
 
     private String expiryHours;
 
@@ -83,10 +91,13 @@ abstract class AbstractPasswordResetService implements PasswordResetService {
         final var expiry = new Timestamp(now + getTokenValidityMs());
         final var token = getTokenDao().createToken(user, expiry);
 
-        final var link = resetBaseUrl + "?token=" + token;
-        final var body = getEmailTemplate().replace("{link}", link);
+        final var template = getEmailTemplateService().getOrCreateEmailTemplate(
+                RESET_EMAIL_TEMPLATE, "Password Reset Email", DEFAULT_SUBJECT, DEFAULT_BODY);
 
-        getEmailService().send(null, normalised, getEmailSubject(), body, true);
+        final var link = resetBaseUrl + "?token=" + token;
+        final var body = template.getBody().replace("{link}", link);
+
+        getEmailService().send(null, normalised, template.getSubject(), body, true);
 
         getElementRegistry().publish(Event.builder()
                 .named(PASSWORD_RESET_REQUESTED_EVENT)
@@ -160,22 +171,13 @@ abstract class AbstractPasswordResetService implements PasswordResetService {
         this.elementRegistry = elementRegistry;
     }
 
-    public String getEmailSubject() {
-        return emailSubject;
+    public EmailTemplateService getEmailTemplateService() {
+        return emailTemplateService;
     }
 
     @Inject
-    public void setEmailSubject(@Named(RESET_EMAIL_SUBJECT) String emailSubject) {
-        this.emailSubject = emailSubject;
-    }
-
-    public String getEmailTemplate() {
-        return emailTemplate;
-    }
-
-    @Inject
-    public void setEmailTemplate(@Named(RESET_EMAIL_TEMPLATE) String emailTemplate) {
-        this.emailTemplate = emailTemplate;
+    public void setEmailTemplateService(@Named(UNSCOPED) EmailTemplateService emailTemplateService) {
+        this.emailTemplateService = emailTemplateService;
     }
 
     public String getExpiryHours() {

--- a/web-ui-react-jetty/elements-web-ui/client/src/App.tsx
+++ b/web-ui-react-jetty/elements-web-ui/client/src/App.tsx
@@ -14,6 +14,7 @@ import DashboardLayout from "@/components/DashboardLayout";
 import Dashboard from "@/pages/Dashboard";
 import ResourceManager from "@/pages/ResourceManager";
 import LargeObjects from "@/pages/LargeObjects";
+import EmailTemplates from "@/pages/EmailTemplates";
 import MultiMatch from "@/pages/MultiMatch";
 import Vaults from "@/pages/Vaults";
 import ProductBundles from "@/pages/ProductBundles";
@@ -139,6 +140,9 @@ function Routes() {
         </Route>
         <Route path="/resource/large-objects">
           <LargeObjects />
+        </Route>
+        <Route path="/resource/email-templates">
+          <EmailTemplates />
         </Route>
         <Route path="/resource/matchmaking">
           <MultiMatch />

--- a/web-ui-react-jetty/elements-web-ui/client/src/components/AppSidebar.tsx
+++ b/web-ui-react-jetty/elements-web-ui/client/src/components/AppSidebar.tsx
@@ -44,6 +44,7 @@ const iconMap: Record<string, any> = {
   FileJson: Icons.FileJson,
   Key: Icons.Key,
   HardDrive: Icons.HardDrive,
+  Mail: Icons.Mail,
   ScrollText: Icons.ScrollText,
   Plug: Icons.Plug,
   Puzzle: Icons.Puzzle,

--- a/web-ui-react-jetty/elements-web-ui/client/src/lib/resource-discovery.ts
+++ b/web-ui-react-jetty/elements-web-ui/client/src/lib/resource-discovery.ts
@@ -40,6 +40,7 @@ const POTENTIAL_RESOURCES = [
   
   // Other
   { name: 'Large Objects', endpoint: '/api/rest/large_object', icon: 'HardDrive', category: 'Other' },
+  { name: 'Email Templates', endpoint: '/api/rest/email_template', icon: 'Mail', category: 'Other' },
 ];
 
 export async function discoverResources(): Promise<ResourceDefinition[]> {

--- a/web-ui-react-jetty/elements-web-ui/client/src/pages/EmailTemplates.tsx
+++ b/web-ui-react-jetty/elements-web-ui/client/src/pages/EmailTemplates.tsx
@@ -1,0 +1,690 @@
+import { useState, useEffect, useRef } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Mail, Plus, Pencil, Trash2, Eye, ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { apiRequest, queryClient } from '@/lib/queryClient';
+
+const RESERVED_KEY_PREFIX = 'dev.getelements.elements.';
+
+interface TemplateVariable {
+  token: string;
+  description: string;
+  sampleValue: string;
+}
+
+// Documented variables for the core, built-in templates. Custom Elements' own templates don't have
+// a documented set here since the platform has no way to know what placeholders they use.
+const CORE_TEMPLATE_VARIABLES: Record<string, TemplateVariable[]> = {
+  'dev.getelements.elements.password_reset.email_template': [
+    { token: '{link}', description: 'Full password-reset URL the recipient should click', sampleValue: 'https://example.com/reset-password?token=sample-token-1234' },
+  ],
+  'dev.getelements.elements.verification.email_template': [
+    { token: '{link}', description: 'Full email-verification URL the recipient should click', sampleValue: 'https://example.com/verify-email?token=sample-token-1234' },
+  ],
+};
+
+const renderPreviewHtml = (key: string, body: string) => {
+  const variables = CORE_TEMPLATE_VARIABLES[key];
+  if (variables) {
+    return variables.reduce((html, v) => html.split(v.token).join(v.sampleValue), body);
+  }
+  // Fall back to a generic {link} substitution so previewing custom templates that happen to use
+  // the same convention still renders something sensible.
+  return body.split('{link}').join('https://example.com/sample-link');
+};
+
+interface EmailTemplate {
+  id: string;
+  key: string;
+  name: string;
+  subject: string;
+  body: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface EmailTemplateResponse {
+  objects: EmailTemplate[];
+  offset: number;
+  count: number;
+  total: number;
+}
+
+interface EmailTemplateFormData {
+  key: string;
+  name: string;
+  subject: string;
+  description: string;
+  body: string;
+}
+
+const EMPTY_FORM: EmailTemplateFormData = {
+  key: '',
+  name: '',
+  subject: '',
+  description: '',
+  body: '',
+};
+
+const isReserved = (key: string) => key.startsWith(RESERVED_KEY_PREFIX);
+
+export default function EmailTemplates() {
+  const { toast } = useToast();
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [createForm, setCreateForm] = useState<EmailTemplateFormData>(EMPTY_FORM);
+  const [editDialog, setEditDialog] = useState<{ open: boolean; template: EmailTemplate | null }>({
+    open: false,
+    template: null,
+  });
+  const [editForm, setEditForm] = useState<EmailTemplateFormData>(EMPTY_FORM);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [previewDialog, setPreviewDialog] = useState<{ open: boolean; key: string; subject: string; body: string }>({
+    open: false,
+    key: '',
+    subject: '',
+    body: '',
+  });
+
+  const openPreview = (key: string, subject: string, body: string) => {
+    setPreviewDialog({ open: true, key, subject, body });
+  };
+
+  // Read pagination limit from settings
+  const getPageSize = () => {
+    const saved = localStorage.getItem('admin-results-per-page');
+    return saved ? parseInt(saved, 10) : 20;
+  };
+
+  // Check localStorage on every query to ensure we use the latest setting
+  const pageSize = getPageSize();
+
+  // Reset to page 0 when page size changes to avoid empty pages
+  const prevPageSizeRef = useRef(pageSize);
+  useEffect(() => {
+    if (prevPageSizeRef.current !== pageSize) {
+      setCurrentPage(0);
+      prevPageSizeRef.current = pageSize;
+    }
+  }, [pageSize]);
+
+  const { data: response, isLoading, isFetching, error } = useQuery<EmailTemplateResponse>({
+    queryKey: ['/api/rest/email_template', currentPage, pageSize],
+    queryFn: async () => {
+      const path = `/api/rest/email_template?offset=${currentPage * pageSize}&count=${pageSize}`;
+      const response = await apiRequest('GET', path);
+      return response.json();
+    },
+    retry: false,
+  });
+
+  const templates = response?.objects || [];
+  const totalPages = response ? Math.ceil(response.total / pageSize) : 0;
+
+  const createMutation = useMutation({
+    mutationFn: async (data: { key: string; name: string; subject: string; body: string; description?: string }) => {
+      const response = await apiRequest('POST', '/api/rest/email_template', data);
+      return response.json();
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['/api/rest/email_template'] });
+      toast({
+        title: 'Success',
+        description: `Email template "${data.name || data.key}" created`,
+      });
+      setIsCreateDialogOpen(false);
+      setCreateForm(EMPTY_FORM);
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Error',
+        description: error.message || 'Failed to create email template',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async (vars: { id: string; data: { name: string; subject: string; body: string; description?: string } }) => {
+      const response = await apiRequest('PUT', `/api/rest/email_template/${vars.id}`, vars.data);
+      return response.json();
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['/api/rest/email_template'] });
+      toast({
+        title: 'Success',
+        description: `Email template "${data.name || data.key}" updated`,
+      });
+      setEditDialog({ open: false, template: null });
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Error',
+        description: error.message || 'Failed to update email template',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await apiRequest('DELETE', `/api/rest/email_template/${id}`);
+      return id;
+    },
+    onSuccess: (deletedId) => {
+      // If we're deleting the last item on this page and it's not the first page, go back one page
+      const queryKey = ['/api/rest/email_template', currentPage, pageSize];
+      const currentData = queryClient.getQueryData(queryKey) as EmailTemplateResponse | undefined;
+
+      if (currentData && currentData.objects.length === 1 && currentPage > 0) {
+        setCurrentPage(Math.max(0, currentPage - 1));
+      }
+
+      // Update all cached pages for this resource
+      queryClient.setQueriesData(
+        { queryKey: ['/api/rest/email_template'] },
+        (oldData: any) => {
+          if (!oldData || typeof oldData.total !== 'number') {
+            return oldData; // Skip non-paginated responses
+          }
+
+          if (Array.isArray(oldData.objects)) {
+            const filteredObjects = oldData.objects.filter((obj: any) => obj.id !== deletedId);
+
+            if (filteredObjects.length < oldData.objects.length) {
+              return {
+                ...oldData,
+                objects: filteredObjects,
+                total: Math.max(0, oldData.total - 1),
+              };
+            }
+          }
+
+          return {
+            ...oldData,
+            total: Math.max(0, oldData.total - 1),
+          };
+        }
+      );
+
+      toast({ title: 'Success', description: 'Email template deleted successfully' });
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Error',
+        description: error.message || 'Failed to delete email template',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const handleCreate = () => {
+    if (!createForm.key.trim() || !createForm.name.trim() || !createForm.subject.trim() || !createForm.body.trim()) {
+      toast({
+        title: 'Error',
+        description: 'Key, Name, Subject, and Body are required',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    createMutation.mutate({
+      key: createForm.key.trim(),
+      name: createForm.name.trim(),
+      subject: createForm.subject.trim(),
+      body: createForm.body,
+      description: createForm.description.trim() || undefined,
+    });
+  };
+
+  const openEditDialog = (template: EmailTemplate) => {
+    setEditForm({
+      key: template.key,
+      name: template.name,
+      subject: template.subject,
+      description: template.description || '',
+      body: template.body,
+    });
+    setEditDialog({ open: true, template });
+  };
+
+  const handleUpdate = () => {
+    if (!editDialog.template) return;
+
+    if (!editForm.name.trim() || !editForm.subject.trim() || !editForm.body.trim()) {
+      toast({
+        title: 'Error',
+        description: 'Name, Subject, and Body are required',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    updateMutation.mutate({
+      id: editDialog.template.id,
+      data: {
+        name: editForm.name.trim(),
+        subject: editForm.subject.trim(),
+        body: editForm.body,
+        description: editForm.description.trim() || undefined,
+      },
+    });
+  };
+
+  const handleDelete = (template: EmailTemplate) => {
+    if (isReserved(template.key)) return;
+    if (confirm(`Are you sure you want to delete email template "${template.name}"?`)) {
+      deleteMutation.mutate(template.id);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Email Templates</h1>
+          <p className="text-muted-foreground mt-1">Manage transactional and system email templates</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={async () => {
+              await queryClient.invalidateQueries({ queryKey: ['/api/rest/email_template'] });
+            }}
+            variant="outline"
+            size="sm"
+            disabled={isFetching}
+            data-testid="button-refresh-email-templates"
+          >
+            <RefreshCw className={`w-4 h-4 mr-2 ${isFetching ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+          <Dialog
+            open={isCreateDialogOpen}
+            onOpenChange={(open) => {
+              setIsCreateDialogOpen(open);
+              if (!open) setCreateForm(EMPTY_FORM);
+            }}
+          >
+            <DialogTrigger asChild>
+              <Button data-testid="button-create-email-template">
+                <Plus className="w-4 h-4 mr-2" />
+                Create Template
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>Create Email Template</DialogTitle>
+                <DialogDescription>
+                  Define a new email template. The key cannot be changed after creation.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="create-key">Key</Label>
+                  <Input
+                    id="create-key"
+                    value={createForm.key}
+                    onChange={(e) => setCreateForm((f) => ({ ...f, key: e.target.value }))}
+                    placeholder="com.mystudio.mygame.welcome_email"
+                    className="font-mono"
+                    data-testid="input-create-key"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Reverse-DNS style, e.g. com.mystudio.mygame.welcome_email. Cannot be changed after creation.
+                  </p>
+                  {createForm.key.trim().startsWith(RESERVED_KEY_PREFIX) && (
+                    <p className="text-xs text-destructive">
+                      Keys starting with "{RESERVED_KEY_PREFIX}" are reserved for core templates and will be rejected by the server.
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="create-name">Name</Label>
+                  <Input
+                    id="create-name"
+                    value={createForm.name}
+                    onChange={(e) => setCreateForm((f) => ({ ...f, name: e.target.value }))}
+                    placeholder="Welcome Email"
+                    data-testid="input-create-name"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="create-subject">Subject</Label>
+                  <Input
+                    id="create-subject"
+                    value={createForm.subject}
+                    onChange={(e) => setCreateForm((f) => ({ ...f, subject: e.target.value }))}
+                    placeholder="Welcome to the game!"
+                    data-testid="input-create-subject"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="create-description">Description (optional)</Label>
+                  <Input
+                    id="create-description"
+                    value={createForm.description}
+                    onChange={(e) => setCreateForm((f) => ({ ...f, description: e.target.value }))}
+                    placeholder="Sent when a new user registers"
+                    data-testid="input-create-description"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="create-body">Body (HTML)</Label>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => openPreview(createForm.key, createForm.subject, createForm.body)}
+                      data-testid="button-preview-create-email-template"
+                    >
+                      <Eye className="w-4 h-4 mr-1" />
+                      Preview
+                    </Button>
+                  </div>
+                  <Textarea
+                    id="create-body"
+                    value={createForm.body}
+                    onChange={(e) => setCreateForm((f) => ({ ...f, body: e.target.value }))}
+                    placeholder="<html>...</html>"
+                    className="font-mono text-xs"
+                    rows={16}
+                    data-testid="textarea-create-body"
+                  />
+                </div>
+                <Button
+                  onClick={handleCreate}
+                  disabled={createMutation.isPending}
+                  className="w-full"
+                  data-testid="button-submit-create-email-template"
+                >
+                  {createMutation.isPending ? 'Creating...' : 'Create Template'}
+                </Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Mail className="w-5 h-5" />
+            Templates
+          </CardTitle>
+          <CardDescription>
+            {response ? `${response.total} template${response.total !== 1 ? 's' : ''}` : 'All email templates'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="text-center py-8 text-muted-foreground">Loading templates...</div>
+          ) : error ? (
+            <div className="text-center py-8 text-muted-foreground">
+              Failed to load email templates. Please try again.
+            </div>
+          ) : !templates || templates.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">No email templates found</div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-auto">Key</TableHead>
+                  <TableHead className="w-[160px]">Name</TableHead>
+                  <TableHead className="w-[200px]">Subject</TableHead>
+                  <TableHead className="w-[110px]">Updated At</TableHead>
+                  <TableHead className="w-[150px] text-center sticky right-0 bg-background border-l z-10">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {templates.map((template) => {
+                  const reserved = isReserved(template.key);
+                  return (
+                    <TableRow key={template.id}>
+                      <TableCell data-testid={`cell-key-${template.id}`}>
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-xs break-all">
+                            {template.key}
+                          </span>
+                          {reserved && (
+                            <Badge variant="outline" className="shrink-0" data-testid={`badge-core-${template.id}`}>
+                              Core
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell data-testid={`cell-name-${template.id}`}>{template.name}</TableCell>
+                      <TableCell data-testid={`cell-subject-${template.id}`} className="max-w-xs truncate">
+                        {template.subject}
+                      </TableCell>
+                      <TableCell data-testid={`cell-updated-${template.id}`}>
+                        {template.updatedAt
+                          ? new Date(template.updatedAt).toLocaleDateString()
+                          : <span className="text-muted-foreground">—</span>}
+                      </TableCell>
+                      <TableCell className="w-[150px] sticky right-0 bg-background border-l z-10">
+                        <div className="flex items-center justify-center gap-1">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => openPreview(template.key, template.subject, template.body)}
+                            data-testid={`button-preview-${template.id}`}
+                          >
+                            <Eye className="w-4 h-4" />
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => openEditDialog(template)}
+                            data-testid={`button-edit-${template.id}`}
+                          >
+                            <Pencil className="w-4 h-4" />
+                          </Button>
+                          {!reserved && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleDelete(template)}
+                              data-testid={`button-delete-${template.id}`}
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </Button>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+
+          {response && response.total > pageSize && (
+            <div className="flex items-center justify-between pt-4 border-t">
+              <div className="text-sm text-muted-foreground">
+                Showing {currentPage * pageSize + 1}-{Math.min((currentPage + 1) * pageSize, response.total)} of {response.total}
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
+                  disabled={currentPage === 0}
+                  data-testid="button-prev-page"
+                >
+                  <ChevronLeft className="w-4 h-4 mr-1" />
+                  Previous
+                </Button>
+                <div className="text-sm text-muted-foreground">
+                  Page {currentPage + 1} of {totalPages}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
+                  disabled={currentPage >= totalPages - 1}
+                  data-testid="button-next-page"
+                >
+                  Next
+                  <ChevronRight className="w-4 h-4 ml-1" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Edit Dialog */}
+      <Dialog
+        open={editDialog.open}
+        onOpenChange={(open) => {
+          if (!open) setEditDialog({ open: false, template: null });
+        }}
+      >
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Edit Email Template</DialogTitle>
+            <DialogDescription>
+              {editDialog.template && isReserved(editDialog.template.key)
+                ? 'This is a core template. Its key cannot be changed and it cannot be deleted.'
+                : 'Update the template fields below.'}
+            </DialogDescription>
+          </DialogHeader>
+          {editDialog.template && (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="edit-key">Key</Label>
+                  {isReserved(editDialog.template.key) && (
+                    <Badge variant="outline">Core</Badge>
+                  )}
+                </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Input
+                      id="edit-key"
+                      value={editForm.key}
+                      disabled
+                      className="font-mono"
+                      data-testid="input-edit-key"
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Key cannot be changed after creation
+                  </TooltipContent>
+                </Tooltip>
+                <p className="text-xs text-muted-foreground">Key cannot be changed after creation.</p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-name">Name</Label>
+                <Input
+                  id="edit-name"
+                  value={editForm.name}
+                  onChange={(e) => setEditForm((f) => ({ ...f, name: e.target.value }))}
+                  data-testid="input-edit-name"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-subject">Subject</Label>
+                <Input
+                  id="edit-subject"
+                  value={editForm.subject}
+                  onChange={(e) => setEditForm((f) => ({ ...f, subject: e.target.value }))}
+                  data-testid="input-edit-subject"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-description">Description (optional)</Label>
+                <Input
+                  id="edit-description"
+                  value={editForm.description}
+                  onChange={(e) => setEditForm((f) => ({ ...f, description: e.target.value }))}
+                  data-testid="input-edit-description"
+                />
+              </div>
+              {CORE_TEMPLATE_VARIABLES[editForm.key] && (
+                <div className="rounded-md border bg-muted/50 p-3 space-y-1.5" data-testid="box-edit-variables">
+                  <p className="text-xs font-medium">Available variables</p>
+                  {CORE_TEMPLATE_VARIABLES[editForm.key].map((v) => (
+                    <p key={v.token} className="text-xs text-muted-foreground">
+                      <code className="font-mono text-foreground">{v.token}</code> — {v.description}
+                    </p>
+                  ))}
+                </div>
+              )}
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="edit-body">Body (HTML)</Label>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => openPreview(editForm.key, editForm.subject, editForm.body)}
+                    data-testid="button-preview-edit-email-template"
+                  >
+                    <Eye className="w-4 h-4 mr-1" />
+                    Preview
+                  </Button>
+                </div>
+                <Textarea
+                  id="edit-body"
+                  value={editForm.body}
+                  onChange={(e) => setEditForm((f) => ({ ...f, body: e.target.value }))}
+                  className="font-mono text-xs"
+                  rows={16}
+                  data-testid="textarea-edit-body"
+                />
+              </div>
+              <Button
+                onClick={handleUpdate}
+                disabled={updateMutation.isPending}
+                className="w-full"
+                data-testid="button-submit-edit-email-template"
+              >
+                {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+              </Button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Preview Dialog */}
+      <Dialog
+        open={previewDialog.open}
+        onOpenChange={(open) => setPreviewDialog((d) => ({ ...d, open }))}
+      >
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Preview Email</DialogTitle>
+            <DialogDescription>
+              Rendered with sample values in place of any known variables. This is an approximation —
+              actual rendering may vary by email client.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="rounded-md border px-3 py-2 bg-muted/50">
+              <p className="text-xs text-muted-foreground">Subject</p>
+              <p className="text-sm font-medium">{previewDialog.subject || <span className="text-muted-foreground">(no subject)</span>}</p>
+            </div>
+            <iframe
+              title="email-preview"
+              className="w-full h-[500px] rounded-md border bg-white"
+              sandbox=""
+              srcDoc={renderPreviewHtml(previewDialog.key, previewDialog.body)}
+              data-testid="iframe-email-preview"
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Decouple email templates from the element-attribute resolution chain, which had no way for a custom Element to override a core service's template since Tier-2 attribute defaults are scoped per-Element.
- `EmailTemplateService` stores subject/body as persistent, key-addressed records: core templates (password reset, email verification) use reserved `dev.getelements.elements.*` keys and auto-seed on first list/fetch, while custom Elements can mint their own keys via the idempotent `getOrCreateEmailTemplate` and manage them through the same admin UI.
- `sdk-model`/`sdk-dao`/`mongo-dao`/`mongo-guice`: `EmailTemplate` entity, DAO, and Mongo implementation with a unique index on `key`.
- `sdk-service`/`service`/`service-guice`: `EmailTemplateService` (standalone interface, Superuser + Unscoped access), reserved-key validation on create/delete.
- `rest-api`: `/email_template` CRUD resource.
- Migrate `AbstractPasswordResetService`/`AbstractEmailVerificationService` off `@ElementDefaultAttribute` onto `EmailTemplateService`.
- New "Email Templates" page under **Other** in the admin dashboard, with preview and a variables reference for the core templates.

Closes #79. Companion docs PR: `NamazuStudios/elements-manual#7`.

## Test plan

- [x] `SuperUserEmailTemplateServiceTest` (reserved-key rejection, `getOrCreateEmailTemplate` idempotency) — 6/6 passing
- [x] `MongoEmailTemplateDaoTest` (CRUD, custom-key create/fetch by id and key, soft-delete) — compiles; requires live Mongo to run
- [x] `mvn -pl sdk-model,sdk-dao,mongo-dao,mongo-guice,sdk-service,service,service-guice,rest-api,rest-guice,deployment-jetty,jetty-ws -am compile` passes
- [x] Client `npm run check` and production build pass, no new type errors
- [ ] Manual end-to-end verification against a running local Mongo + `jetty-ws`
